### PR TITLE
fix(cors)!: doesn't return `access-control-allow-origin` header when origin is disallowed

### DIFF
--- a/docs/2.utils/98.advanced.md
+++ b/docs/2.utils/98.advanced.md
@@ -191,7 +191,7 @@ router.use("/", async (event) => {
 
 ### `isCorsOriginAllowed(origin, options)`
 
-Check if the incoming request is a CORS request.
+Check if the origin is allowed.
 
 ### `isPreflightRequest(event)`
 

--- a/src/utils/cors.ts
+++ b/src/utils/cors.ts
@@ -13,12 +13,64 @@ import {
 export { isCorsOriginAllowed } from "./internal/cors.ts";
 
 export interface CorsOptions {
+  /**
+   * This determines the value of the "access-control-allow-origin" response header.
+   * If "*", it can be used to allow all origins.
+   * If an array of strings or regular expressions, it can be used with origin matching.
+   * If a custom function, it's used to validate the origin. It takes the origin as an argument and returns `true` if allowed.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
+   * @default "*"
+   */
   origin?: "*" | "null" | (string | RegExp)[] | ((origin: string) => boolean);
+
+  /**
+   * This determines the value of the "access-control-allow-methods" response header of a preflight request.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods
+   * @default "*"
+   * @example ["GET", "HEAD", "PUT", "POST"]
+   */
   methods?: "*" | string[];
+
+  /**
+   * This determines the value of the "access-control-allow-headers" response header of a preflight request.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
+   * @default "*"
+   */
   allowHeaders?: "*" | string[];
+
+  /**
+   * This determines the value of the "access-control-expose-headers" response header.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
+   * @default "*"
+   */
   exposeHeaders?: "*" | string[];
+
+  /**
+   * This determines the value of the "access-control-allow-credentials" response header.
+   * When request with credentials, the options that `origin`, `methods`, `exposeHeaders` and `allowHeaders` should not be set "*".
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials
+   * @see https://fetch.spec.whatwg.org/#cors-protocol-and-credentials
+   * @default false
+   */
   credentials?: boolean;
+
+  /**
+   * This determines the value of the "access-control-max-age" response header of a preflight request.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
+   * @default false
+   */
   maxAge?: string | false;
+
+  /**
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
+   */
   preflight?: {
     statusCode?: number;
   };

--- a/src/utils/internal/cors.ts
+++ b/src/utils/internal/cors.ts
@@ -42,21 +42,24 @@ export function resolveCorsOptions(
 }
 
 /**
- * Check if the incoming request is a CORS request.
+ * Check if the origin is allowed.
  */
 export function isCorsOriginAllowed(
-  origin: string | undefined,
+  origin: string | null | undefined,
   options: CorsOptions,
 ): boolean {
   const { origin: originOption } = options;
 
-  if (
-    !origin ||
-    !originOption ||
-    originOption === "*" ||
-    originOption === "null"
-  ) {
+  if (!origin) {
+    return false;
+  }
+
+  if (!originOption || originOption === "*") {
     return true;
+  }
+
+  if (typeof originOption === "function") {
+    return originOption(origin);
   }
 
   if (Array.isArray(originOption)) {
@@ -69,7 +72,7 @@ export function isCorsOriginAllowed(
     });
   }
 
-  return originOption(origin);
+  return originOption === origin;
 }
 
 /**
@@ -82,17 +85,19 @@ export function createOriginHeaders(
   const { origin: originOption } = options;
   const origin = event.req.headers.get("origin");
 
-  if (!origin || !originOption || originOption === "*") {
+  if (!originOption || originOption === "*") {
     return { "access-control-allow-origin": "*" };
   }
 
-  if (typeof originOption === "string") {
-    return { "access-control-allow-origin": originOption, vary: "origin" };
+  if (originOption === "null") {
+    return { "access-control-allow-origin": "null", vary: "origin" };
   }
 
-  return isCorsOriginAllowed(origin, options)
-    ? { "access-control-allow-origin": origin, vary: "origin" }
-    : {};
+  if (isCorsOriginAllowed(origin, options)) {
+    return { "access-control-allow-origin": origin!, vary: "origin" };
+  }
+
+  return {};
 }
 
 /**


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

resolves #355
