### PR TITLE
fix(readRawBody): handle raw `FormData` with direct fetch (nitro)

### DIFF
--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -95,7 +95,7 @@ export function readRawBody<E extends Encoding = "utf8">(
       if (_resolved instanceof URLSearchParams) {
         return Buffer.from(_resolved.toString());
       }
-      if(_resolved instanceof FormData) {
+      if (_resolved instanceof FormData) {
         return new Response(_resolved).bytes();
       }
       return Buffer.from(_resolved);

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -92,8 +92,11 @@ export function readRawBody<E extends Encoding = "utf8">(
       }
       // TODO: Handle other BodyInit types
       // https://developer.mozilla.org/en-US/docs/Web/API/Response/Response#body
-      if (_resolved instanceof URLSearchParams || _resolved instanceof FormData) {
+      if (_resolved instanceof URLSearchParams) {
         return Buffer.from(_resolved.toString());
+      }
+      if(_resolved instanceof FormData) {
+        return new Response(_resolved).bytes();
       }
       return Buffer.from(_resolved);
     });

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -96,7 +96,9 @@ export function readRawBody<E extends Encoding = "utf8">(
         return Buffer.from(_resolved.toString());
       }
       if (_resolved instanceof FormData) {
-        return new Response(_resolved).bytes();
+        return new Response(_resolved)
+          .bytes()
+          .then((buffer) => Buffer.from(buffer));
       }
       return Buffer.from(_resolved);
     });

--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -92,7 +92,7 @@ export function readRawBody<E extends Encoding = "utf8">(
       }
       // TODO: Handle other BodyInit types
       // https://developer.mozilla.org/en-US/docs/Web/API/Response/Response#body
-      if (_resolved instanceof URLSearchParams) {
+      if (_resolved instanceof URLSearchParams || _resolved instanceof FormData) {
         return Buffer.from(_resolved.toString());
       }
       return Buffer.from(_resolved);


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

resolves https://github.com/nitrojs/nitro/issues/2883

This is a quick fix for the `FormData` body for `h3@1`, addressing the issue reported in https://github.com/nitrojs/nitro/issues/2883.

Since v2 is WIP, merging this is optional ❤️
