### PR TITLE
fix: make session clearing resilient

### DIFF
--- a/docs/4.examples/handle-session.md
+++ b/docs/4.examples/handle-session.md
@@ -37,7 +37,7 @@ This will initialize a session and return an header `Set-Cookie` with a cookie n
 If the request contains a cookie named `h3` or a header named `x-h3-session`, the session will be initialized with the content of the cookie or the header.
 
 > [!NOTE]
-> The header take precedence over the cookie.
+> The header takes precedence over the cookie.
 
 ## Get Data from a Session
 
@@ -86,6 +86,8 @@ We try to get a session from the request. If there is no session, a new one will
 
 Try to visit the page multiple times and you will see the number of times you visited the page.
 
+If a `maxAge` is configured, the expiration date of the session will not be updated with a call to `update` on the session object, nor with a call using the `updateSession` utility. For details on how to update teh expiration date, see the [rotate session section](#rotate-a-session).
+
 > [!NOTE]
 > If you use a CLI tool like `curl` to test this example, you will not see the number of times you visited the page because the CLI tool does not save cookies. You must get the cookie from the response and send it back to the server.
 
@@ -108,6 +110,30 @@ app.use("/clear", async (event) => {
 ```
 
 h3 will send a header `Set-Cookie` with an empty cookie named `h3` to clear the session.
+
+## Rotate a Session
+
+The session identifier and expiration date are immutable. If a `maxAge` is configured for the session, the expiration date is set when the session is created and there is no way to extend the session beyond the initially determined expiration date.
+
+If the session context needs to be extended, the session must be rotated. This means the current session must first be cleared and a new session must be created. A new session identifier will be created and the expiration date will be set to the current time plus the `maxAge` value.
+
+```js
+import { useSession } from "h3";
+
+app.use("/rotate", async (event) => {
+  const session = await useSession(event, {
+    password: "80d42cfb-1cd2-462c-8f17-e3237d9027e9",
+    maxAge: 60 * 60 * 24 * 7, // 7 days
+  });
+
+  const data = session.date;  // Retrieve the current session data
+  await session.clear();      // Clear the current session
+  await session.update(data); // Create a new session with the original data
+
+  return "Session rotated";
+});
+
+```
 
 ## Options
 

--- a/docs/4.examples/handle-session.md
+++ b/docs/4.examples/handle-session.md
@@ -86,7 +86,7 @@ We try to get a session from the request. If there is no session, a new one will
 
 Try to visit the page multiple times and you will see the number of times you visited the page.
 
-If a `maxAge` is configured, the expiration date of the session will not be updated with a call to `update` on the session object, nor with a call using the `updateSession` utility. For details on how to extend the session's expiration date, see the [Rotating a Session section](#rotating-a-session).
+If a `maxAge` is configured, the expiration date of the session will not be updated with a call to `update` on the session object, nor with a call using the `updateSession` utility.
 
 > [!NOTE]
 > If you use a CLI tool like `curl` to test this example, you will not see the number of times you visited the page because the CLI tool does not save cookies. You must get the cookie from the response and send it back to the server.
@@ -110,29 +110,6 @@ app.use("/clear", async (event) => {
 ```
 
 h3 will send a header `Set-Cookie` with an empty cookie named `h3` to clear the session.
-
-## Rotating a Session
-
-The session identifier and expiration date are immutable. If a `maxAge` is configured for the session, the expiration date is set when the session is created and there is no way to extend the session beyond the initially determined expiration date.
-
-If the session context needs to be extended, the session must be rotated. This means the current session must first be cleared and a new session must be created. A new session identifier will be created and the expiration date will be set to the current time plus the `maxAge` value.
-
-```js
-import { useSession } from "h3";
-
-app.use("/rotate", async (event) => {
-  const session = await useSession(event, {
-    password: "80d42cfb-1cd2-462c-8f17-e3237d9027e9",
-    maxAge: 60 * 60 * 24 * 7, // 7 days
-  });
-
-  const data = session.date; // Retrieve the current session data
-  await session.clear(); // Clear the current session
-  await session.update(data); // Create a new session with the original data
-
-  return "Session rotated";
-});
-```
 
 ## Options
 

--- a/docs/4.examples/handle-session.md
+++ b/docs/4.examples/handle-session.md
@@ -126,13 +126,12 @@ app.use("/rotate", async (event) => {
     maxAge: 60 * 60 * 24 * 7, // 7 days
   });
 
-  const data = session.date;  // Retrieve the current session data
-  await session.clear();      // Clear the current session
+  const data = session.date; // Retrieve the current session data
+  await session.clear(); // Clear the current session
   await session.update(data); // Create a new session with the original data
 
   return "Session rotated";
 });
-
 ```
 
 ## Options

--- a/docs/4.examples/handle-session.md
+++ b/docs/4.examples/handle-session.md
@@ -86,7 +86,7 @@ We try to get a session from the request. If there is no session, a new one will
 
 Try to visit the page multiple times and you will see the number of times you visited the page.
 
-If a `maxAge` is configured, the expiration date of the session will not be updated with a call to `update` on the session object, nor with a call using the `updateSession` utility. For details on how to update teh expiration date, see the [rotate session section](#rotate-a-session).
+If a `maxAge` is configured, the expiration date of the session will not be updated with a call to `update` on the session object, nor with a call using the `updateSession` utility. For details on how to extend the session's expiration date, see the [Rotating a Session section](#rotating-a-session).
 
 > [!NOTE]
 > If you use a CLI tool like `curl` to test this example, you will not see the number of times you visited the page because the CLI tool does not save cookies. You must get the cookie from the response and send it back to the server.
@@ -111,7 +111,7 @@ app.use("/clear", async (event) => {
 
 h3 will send a header `Set-Cookie` with an empty cookie named `h3` to clear the session.
 
-## Rotate a Session
+## Rotating a Session
 
 The session identifier and expiration date are immutable. If a `maxAge` is configured for the session, the expiration date is set when the session is created and there is no way to extend the session beyond the initially determined expiration date.
 

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -220,17 +220,12 @@ export function clearSession(
   event: H3Event,
   config: SessionConfig,
 ): Promise<void> {
+  const sessionName = getSessionName(config);
   if (!event.context.sessions) {
     event.context.sessions = new EmptyObject();
   }
 
-  // Delete the current session
-  const sessionName = getSessionName(config);
-  if (event.context.sessions?.[sessionName]) {
-    delete event.context.sessions![sessionName];
-  }
-
-  // Initialize a new empty session object
+  // Clobber the original session with a new session
   event.context.sessions![sessionName] = {
     id: generateId(config),
     createdAt: Date.now(),

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -215,7 +215,7 @@ export async function sealSession<T extends SessionData = SessionData>(
   // Access current session
   const session: Session<T> =
     (event.context.sessions?.[sessionName] as Session<T>) ||
-    (await getSession<T>(event, config));
+    (await initializeSession<T>(event, config));
 
   const sealed = await seal(session, config.password, {
     ...sealDefaults,

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -18,7 +18,7 @@ function getSessionName(config: SessionConfig) {
 /**
  * Generate the session id from the config.
  */
-function generateId (config: SessionConfig) {
+function generateId(config: SessionConfig) {
   return config.generateId?.() ?? (config.crypto || crypto).randomUUID();
 }
 
@@ -128,10 +128,10 @@ export async function getSession<T extends SessionData = SessionData>(
 
 /**
  * Initialize a new empty session for the current request.
- * 
+ *
  * This will create a new session object on the request context,
  * but will not store it in the cookie. It is intended to be used
- * when either clearing or updating the session, both of which 
+ * when either clearing or updating the session, both of which
  * will mutate the session cookie object.
  */
 async function initializeSession<T extends SessionData = SessionData>(


### PR DESCRIPTION
This PR addresses an issue in the session manager utility which results in an already cleared session returning when `useSession`, `session.update`, `getSession`, `updateSession`, or `sealSession` are used after calling `session.clear` or `clearSession`.

This ensures that after clearing the session, a new blank session is initialized on the event context so that subsequent session mutation calls cause updates on the newly initialized session, rather than restoring the original session from the event context.

There are still edge-cases where the session can be restored, but they require subverting the use of the provided methods and session manager. This fix largely relies on the understanding that the `event.context.sessions` object is the source of truth for expected session state, but in the absence of a valid session in the context, the original session will still be reconstructed.

The documentation for the session management has also been updated to add a section on session rotation, which should lend in resolving issues with the downstream `nuxt-auth-utils` issues.

Closes #1004