### PR TITLE
build: add `type: "module"` to the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Minimal H(TTP) framework built for high performance and portability.",
   "repository": "unjs/h3",
   "license": "MIT",
+  "type": "module",
   "sideEffects": false,
   "exports": {
     "./package.json": "./package.json",


### PR DESCRIPTION
Module syntax detection is enabled by default in [Node.js v20.19.0](https://nodejs.org/en/blog/release/v20.19.0) and [Node.js v22.7.0](https://nodejs.org/en/blog/release/v22.7.0). But Node.js recommends to use `"type"`: `"module"` when it comes for ESM. Node.js doc says, Syntax detection should have no performance impact on CommonJS modules, but it incurs a slight performance penalty for ES modules; add "type": "module" to the nearest parent package.json file to eliminate the performance cost. (https://nodejs.org/en/blog/release/v20.19.0#module-syntax-detection-is-now-enabled-by-default) That's why I think we may add it in `package.json`. 