### PR TITLE
fix: ensure `callNodeListener` resolves after `res.end()` is called

### DIFF
--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -110,12 +110,13 @@ export function callNodeListener(
       }
       return err ? reject(createError(err)) : resolve(undefined);
     };
+    if (isMiddleware) {
+      res.once("close", next);
+      res.once("error", next);
+    }
     try {
       const returned = handler(req, res, next);
-      if (isMiddleware && returned === undefined) {
-        res.once("close", next);
-        res.once("error", next);
-      } else {
+      if (!isMiddleware || returned !== undefined) {
         resolve(returned);
       }
     } catch (error) {


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

resolves #779

This is a minimal quick fix for `h3@v1`. (I'm not sure if it still needs fixing, though 🤔)

The `res.once` binding was happening too late. Sometimes, `res.end()` would be called and the events would have already fired, preventing the callbacks from firing. This would cause the response to hang indefinitely.

The WIP `h3@2` doesn't need this fix because it binds earlier: https://github.com/h3js/h3/blob/ac609aae8fa93947b564de55e2d1a6bec5ad18ad/src/adapters.ts#L75-L80
