### PR TITLE
fix(node): pass through piped stream

### DIFF
--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -86,7 +86,7 @@ function callNodeHandler(
   return new Promise((resolve, reject) => {
     res.once("close", () => resolve(kHandled));
     res.once("finish", () => resolve(kHandled));
-    res.once("pipe", () => resolve(kHandled));
+    res.once("pipe", (stream) => resolve(stream));
     res.once("error", (error) => reject(error));
     try {
       if (isMiddleware) {


### PR DESCRIPTION
Fixes #1039 

By resolving the stream piped to the response in the `callNodeHandler` fn, the issue described in the mentioned issue will be fixed.