### PR TITLE
fix(setCookie): unique by `name`, `domain` and `path` only

### DIFF
--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -95,6 +95,7 @@ export function deleteCookie(
     maxAge: 0,
   });
 }
+
 /**
  * Cookies are unique by "cookie-name, domain-value, and path-value".
  *

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -95,14 +95,11 @@ export function deleteCookie(
     maxAge: 0,
   });
 }
-
+/**
+ * Cookies are unique by "cookie-name, domain-value, and path-value".
+ *
+ * @see https://httpwg.org/specs/rfc6265.html#rfc.section.4.1.2
+ */
 function _getDistinctCookieKey(name: string, options: Partial<SetCookie>) {
-  return [
-    name,
-    options.domain || "",
-    options.path || "/",
-    Boolean(options.secure),
-    Boolean(options.httpOnly),
-    Boolean(options.sameSite),
-  ].join(";");
+  return [name, options.domain || "", options.path || "/"].join(";");
 }

--- a/test/cookies.test.ts
+++ b/test/cookies.test.ts
@@ -82,22 +82,27 @@ describeMatrix("cookies", (t, { it, expect, describe }) => {
     });
   });
 
-  it("can merge and deduplicate unique cookies", async () => {
+  it("can merge unique cookies", async () => {
     t.app.get("/", (event) => {
-      setCookie(event, "session", "abc", {
-        path: "/docs",
-      });
+      setCookie(event, "session", "abc", { path: "/a" });
+      setCookie(event, "session", "cba", { path: "/b" });
+
       setCookie(event, "session", "123", { httpOnly: false });
-      setCookie(event, "session", "456", {
-        httpOnly: true,
-        maxAge: 60 * 60 * 24 * 30,
-      });
+      setCookie(event, "session", "321", { httpOnly: true });
+
+      setCookie(event, "session", "456", { secure: false });
+      setCookie(event, "session", "654", { secure: true });
+
+      setCookie(event, "session", "789", { sameSite: false });
+      setCookie(event, "session", "987", { sameSite: true });
+
       return "200";
     });
     const result = await t.fetch("/");
     expect(result.headers.getSetCookie()).toEqual([
-      "session=abc; Path=/docs",
-      "session=456; Max-Age=2592000; Path=/; HttpOnly",
+      "session=abc; Path=/a",
+      "session=cba; Path=/b",
+      "session=987; Path=/; SameSite=Strict",
     ]);
     expect(await result.text()).toBe("200");
   });

--- a/test/cookies.test.ts
+++ b/test/cookies.test.ts
@@ -82,10 +82,13 @@ describeMatrix("cookies", (t, { it, expect, describe }) => {
     });
   });
 
-  it("can merge unique cookies", async () => {
+  it("can merge and deduplicate unique cookies", async () => {
     t.app.get("/", (event) => {
-      setCookie(event, "session", "123", { httpOnly: true });
-      setCookie(event, "session", "123", {
+      setCookie(event, "session", "abc", {
+        path: "/docs",
+      });
+      setCookie(event, "session", "123", { httpOnly: false });
+      setCookie(event, "session", "456", {
         httpOnly: true,
         maxAge: 60 * 60 * 24 * 30,
       });
@@ -93,7 +96,8 @@ describeMatrix("cookies", (t, { it, expect, describe }) => {
     });
     const result = await t.fetch("/");
     expect(result.headers.getSetCookie()).toEqual([
-      "session=123; Max-Age=2592000; Path=/; HttpOnly",
+      "session=abc; Path=/docs",
+      "session=456; Max-Age=2592000; Path=/; HttpOnly",
     ]);
     expect(await result.text()).toBe("200");
   });


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

resolves #1037

This PR uniquely identifies cookies by only three segments: "cookie-name, domain-value, and path-value" according to this spec: https://httpwg.org/specs/rfc6265.html#rfc.section.4.1.2

> If the user agent receives a new cookie with the same cookie-name, domain-value, and path-value as a cookie that it has already stored, the existing cookie is evicted and replaced with the new cookie. Notice that servers can delete cookies by sending the user agent a new cookie with an Expires attribute with a value in the past.