### PR TITLE
fix(serveStatic): omit decoded id from `statusMessage`

### DIFF
--- a/src/utils/static.ts
+++ b/src/utils/static.ts
@@ -110,10 +110,7 @@ export async function serveStatic(
 
   if (!meta) {
     if (!options.fallthrough) {
-      throw createError({
-        statusMessage: "Cannot find static asset " + id,
-        statusCode: 404,
-      });
+      throw createError({ statusCode: 404 });
     }
     return false;
   }


### PR DESCRIPTION
Although it is not a security issue itself, if `statusMessage` used in HTML body unescaped, it can lead to security issues.

Alternatively we could use encoded id in message however it seems extra unnecessary information.