### PR TITLE
feat(proxy): support `forwardHeaders` and `filterHeaders`

### DIFF
--- a/docs/2.utils/98.advanced.md
+++ b/docs/2.utils/98.advanced.md
@@ -135,7 +135,7 @@ Check request caching headers (`If-Modified-Since`) and add caching headers (Las
 
 Make a fetch request with the event's context and headers.
 
-### `getProxyRequestHeaders(event, opts?: { host? })`
+### `getProxyRequestHeaders(event, opts?: { host?, preserveHeaders?[] })`
 
 Get the request headers object without headers known to cause issues when proxying.
 

--- a/docs/2.utils/98.advanced.md
+++ b/docs/2.utils/98.advanced.md
@@ -135,7 +135,7 @@ Check request caching headers (`If-Modified-Since`) and add caching headers (Las
 
 Make a fetch request with the event's context and headers.
 
-### `getProxyRequestHeaders(event, opts?: { host?, forwardHeaders?[], filterHeaders?[] })`
+### `getProxyRequestHeaders(event)`
 
 Get the request headers object without headers known to cause issues when proxying.
 

--- a/docs/2.utils/98.advanced.md
+++ b/docs/2.utils/98.advanced.md
@@ -135,7 +135,7 @@ Check request caching headers (`If-Modified-Since`) and add caching headers (Las
 
 Make a fetch request with the event's context and headers.
 
-### `getProxyRequestHeaders(event, opts?: { host?, forwardHeaders?[] })`
+### `getProxyRequestHeaders(event, opts?: { host?, forwardHeaders?[], filterHeaders?[] })`
 
 Get the request headers object without headers known to cause issues when proxying.
 

--- a/docs/2.utils/98.advanced.md
+++ b/docs/2.utils/98.advanced.md
@@ -135,7 +135,7 @@ Check request caching headers (`If-Modified-Since`) and add caching headers (Las
 
 Make a fetch request with the event's context and headers.
 
-### `getProxyRequestHeaders(event, opts?: { host?, trustedHeaders?[] })`
+### `getProxyRequestHeaders(event, opts?: { host?, forwardHeaders?[] })`
 
 Get the request headers object without headers known to cause issues when proxying.
 

--- a/docs/2.utils/98.advanced.md
+++ b/docs/2.utils/98.advanced.md
@@ -135,7 +135,7 @@ Check request caching headers (`If-Modified-Since`) and add caching headers (Las
 
 Make a fetch request with the event's context and headers.
 
-### `getProxyRequestHeaders(event, opts?: { host?, preserveHeaders?[] })`
+### `getProxyRequestHeaders(event, opts?: { host?, trustedHeaders?[] })`
 
 Get the request headers object without headers known to cause issues when proxying.
 

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -13,7 +13,7 @@ import { EmptyObject } from "./internal/obj.ts";
 
 export interface ProxyOptions {
   headers?: HeadersInit;
-  trustedHeaders?: string[];
+  forwardHeaders?: string[];
   fetchOptions?: RequestInit & { duplex?: "half" | "full" } & {
     ignoreResponseError?: boolean;
   };
@@ -52,7 +52,7 @@ export async function proxyRequest(
   const fetchHeaders = mergeHeaders(
     getProxyRequestHeaders(event, {
       host: target.startsWith("/"),
-      trustedHeaders: opts.trustedHeaders,
+      forwardHeaders: opts.forwardHeaders,
     }),
     opts.fetchOptions?.headers,
     opts.headers,
@@ -153,12 +153,12 @@ export async function proxy(
  */
 export function getProxyRequestHeaders(
   event: H3Event,
-  opts?: { host?: boolean; trustedHeaders?: string[] },
+  opts?: { host?: boolean; forwardHeaders?: string[] },
 ): Record<string, string> {
   const headers = new EmptyObject();
   for (const [name, value] of event.req.headers.entries()) {
     if (
-      opts?.trustedHeaders?.includes(name) ||
+      opts?.forwardHeaders?.includes(name) ||
       !ignoredHeaders.has(name) ||
       (name === "host" && opts?.host)
     ) {

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -14,6 +14,7 @@ import { EmptyObject } from "./internal/obj.ts";
 export interface ProxyOptions {
   headers?: HeadersInit;
   forwardHeaders?: string[];
+  filterHeaders?: string[];
   fetchOptions?: RequestInit & { duplex?: "half" | "full" } & {
     ignoreResponseError?: boolean;
   };
@@ -53,6 +54,7 @@ export async function proxyRequest(
     getProxyRequestHeaders(event, {
       host: target.startsWith("/"),
       forwardHeaders: opts.forwardHeaders,
+      filterHeaders: opts.filterHeaders,
     }),
     opts.fetchOptions?.headers,
     opts.headers,
@@ -153,12 +155,17 @@ export async function proxy(
  */
 export function getProxyRequestHeaders(
   event: H3Event,
-  opts?: { host?: boolean; forwardHeaders?: string[] },
+  opts?: {
+    host?: boolean;
+    forwardHeaders?: string[];
+    filterHeaders?: string[];
+  },
 ): Record<string, string> {
   const headers = new EmptyObject();
   for (const [name, value] of event.req.headers.entries()) {
     if (
       opts?.forwardHeaders?.includes(name) ||
+      (opts?.filterHeaders && !opts.filterHeaders.includes(name)) ||
       !ignoredHeaders.has(name) ||
       (name === "host" && opts?.host)
     ) {

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -50,7 +50,10 @@ export async function proxyRequest(
 
   // Headers
   const fetchHeaders = mergeHeaders(
-    getProxyRequestHeaders(event, { host: target.startsWith("/") }),
+    getProxyRequestHeaders(event, {
+      host: target.startsWith("/"),
+      trustedHeaders: opts.trustedHeaders,
+    }),
     opts.fetchOptions?.headers,
     opts.headers,
   );

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -13,6 +13,7 @@ import { EmptyObject } from "./internal/obj.ts";
 
 export interface ProxyOptions {
   headers?: HeadersInit;
+  preserveHeaders?: string[];
   fetchOptions?: RequestInit & { duplex?: "half" | "full" } & {
     ignoreResponseError?: boolean;
   };
@@ -149,11 +150,15 @@ export async function proxy(
  */
 export function getProxyRequestHeaders(
   event: H3Event,
-  opts?: { host?: boolean },
+  opts?: { host?: boolean; preserveHeaders?: string[] },
 ): Record<string, string> {
   const headers = new EmptyObject();
   for (const [name, value] of event.req.headers.entries()) {
-    if (!ignoredHeaders.has(name) || (name === "host" && opts?.host)) {
+    if (
+      opts?.preserveHeaders?.includes(name) ||
+      !ignoredHeaders.has(name) ||
+      (name === "host" && opts?.host)
+    ) {
       headers[name] = value;
     }
   }

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -13,7 +13,7 @@ import { EmptyObject } from "./internal/obj.ts";
 
 export interface ProxyOptions {
   headers?: HeadersInit;
-  preserveHeaders?: string[];
+  trustedHeaders?: string[];
   fetchOptions?: RequestInit & { duplex?: "half" | "full" } & {
     ignoreResponseError?: boolean;
   };
@@ -150,12 +150,12 @@ export async function proxy(
  */
 export function getProxyRequestHeaders(
   event: H3Event,
-  opts?: { host?: boolean; preserveHeaders?: string[] },
+  opts?: { host?: boolean; trustedHeaders?: string[] },
 ): Record<string, string> {
   const headers = new EmptyObject();
   for (const [name, value] of event.req.headers.entries()) {
     if (
-      opts?.preserveHeaders?.includes(name) ||
+      opts?.trustedHeaders?.includes(name) ||
       !ignoredHeaders.has(name) ||
       (name === "host" && opts?.host)
     ) {


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

resolves #825
resolves #709

related: #504
related: https://github.com/nitrojs/nitro/issues/3160

TODO:
- [ ] Maybe [`opts.host` of `getProxyRequestHeaders`](https://github.com/h3js/h3/blob/f1115f3f577a1fef2ed2cf8f11db64d9760b5db6/src/utils/proxy.ts#L152) could be deprecated with this new option 🤔
