### PR TITLE
Update 1.request.md

### DIFF
--- a/docs/2.utils/1.request.md
+++ b/docs/2.utils/1.request.md
@@ -33,7 +33,7 @@ Get a request header by name.
 
 ```ts
 export default defineEventHandler((event) => {
-  const contentType = getRequestHeader(event, "content-type"); // "application/json"
+  const contentType = getHeader(event, "content-type"); // "application/json"
 });
 ```
 
@@ -47,7 +47,7 @@ Array headers are joined with a comma.
 
 ```ts
 export default defineEventHandler((event) => {
-  const headers = getRequestHeaders(event); // { "content-type": "application/json", "x-custom-header": "value" }
+  const headers = getHeaders(event); // { "content-type": "application/json", "x-custom-header": "value" }
 });
 ```
 


### PR DESCRIPTION
Maybe we should consider removing getHeader and getHeaders entirely - no point in having two functions (`getHeader` and `getRequestHeader`) that do the same thing.

Makes it harder for people going through the documentation.

Perhaps we can do the same for all duplicated functions?
- getHeader and getRequestHeader
- setHeader and setResponseHeader
- defineEventHandler and eventHandler
- defineLazyEventHandler and lazyEventHandler ...

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
