### PR TITLE
refactor(useSession): backport `SessionManager` interface to fix types

### DIFF
--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -18,6 +18,13 @@ export interface Session<T extends SessionDataT = SessionDataT> {
   [getSessionPromise]?: Promise<Session<T>>;
 }
 
+export interface SessionManager<T extends SessionDataT = SessionDataT> {
+  readonly id: string | undefined;
+  readonly data: SessionData<T>;
+  update: (update: SessionUpdate<T>) => Promise<SessionManager<T>>;
+  clear: () => Promise<SessionManager<T>>;
+}
+
 export interface SessionConfig {
   /** Private key used to encrypt session tokens */
   password: string;
@@ -53,7 +60,7 @@ type CompatEvent =
 export async function useSession<T extends SessionDataT = SessionDataT>(
   event: H3Event | CompatEvent,
   config: SessionConfig,
-) {
+): Promise<SessionManager<T>> {
   // Create a synced wrapper around the session
   const sessionName = config.name || DEFAULT_NAME;
   await getSession(event, config); // Force init


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
resolves https://github.com/h3js/h3/issues/1057

A small quick fix for the missing types of `useSession` for `v1`, backported from `v2` ❤️