### PR TITLE
refactor: remove object syntax support and legacy types

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -115,6 +115,7 @@ h3 v2 deprecated some legacy and aliased utilities.
 - `toEventHandler`: Remove wrapper.
 - `isEventHandler`: (removed) Any function can be an event handler.
 - `useBase`: Migrate to `withbase`.
+- `defineRequestMiddleware` and `defineResponseMiddleware` removed.
 
 **Request:**
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,106 +1,20 @@
-import type { H3Event } from "./types/event.ts";
-
 import type {
   EventHandler,
   EventHandlerRequest,
   EventHandlerResponse,
-  EventHandlerObject,
   DynamicEventHandler,
-  RequestMiddleware,
-  ResponseMiddleware,
 } from "./types/handler.ts";
 
-type _EventHandlerHooks<
-  Request extends EventHandlerRequest = EventHandlerRequest,
-  Response extends EventHandlerResponse = EventHandlerResponse,
-> = {
-  onRequest?: RequestMiddleware<Request>[];
-  onBeforeResponse?: ResponseMiddleware<Request, Response>[];
-};
+// --- event handler ---
 
 export function defineEventHandler<
   Request extends EventHandlerRequest = EventHandlerRequest,
   Response = EventHandlerResponse,
->(
-  handler:
-    | EventHandler<Request, Response>
-    | EventHandlerObject<Request, Response>,
-): EventHandler<Request, Response>;
-// TODO: remove when appropriate
-// This signature provides backwards compatibility with previous signature where first generic was return type
-export function defineEventHandler<
-  Request = EventHandlerRequest,
-  Response = EventHandlerResponse,
->(
-  handler: EventHandler<
-    Request extends EventHandlerRequest ? Request : EventHandlerRequest,
-    Request extends EventHandlerRequest ? Response : Request
-  >,
-): EventHandler<
-  Request extends EventHandlerRequest ? Request : EventHandlerRequest,
-  Request extends EventHandlerRequest ? Response : Request
->;
-export function defineEventHandler<
-  Request extends EventHandlerRequest,
-  Response = EventHandlerResponse,
->(
-  handler:
-    | EventHandler<Request, Response>
-    | EventHandlerObject<Request, Response>,
-): EventHandler<Request, Response> {
-  // Function Syntax
-  if (typeof handler === "function") {
-    return handler;
-  }
-  // Object Syntax
-  const _hooks: _EventHandlerHooks<Request, Response> = {
-    onRequest: _normalizeArray(handler.onRequest),
-    onBeforeResponse: _normalizeArray(handler.onBeforeResponse),
-  };
-  const _handler: EventHandler<Request, any> = (event) => {
-    return _callHandler(event, handler.handler, _hooks);
-  };
-  return _handler as EventHandler<Request, Response>;
+>(handler: EventHandler<Request, Response>): EventHandler<Request, Response> {
+  return handler;
 }
 
-function _normalizeArray<T>(input?: T | T[]): T[] | undefined {
-  return input ? (Array.isArray(input) ? input : [input]) : undefined;
-}
-
-async function _callHandler<
-  Request extends EventHandlerRequest = EventHandlerRequest,
-  Response extends EventHandlerResponse = EventHandlerResponse,
->(
-  event: H3Event,
-  handler: EventHandler<Request, Response>,
-  hooks: _EventHandlerHooks<Request, Response>,
-): Promise<Awaited<Response> | undefined> {
-  if (hooks.onRequest) {
-    for (const hook of hooks.onRequest) {
-      await hook(event);
-    }
-  }
-  const body = await handler(event);
-  const response = { body };
-  if (hooks.onBeforeResponse) {
-    for (const hook of hooks.onBeforeResponse) {
-      await hook(event, response);
-    }
-  }
-  return response.body;
-}
-
-export function defineRequestMiddleware<
-  Request extends EventHandlerRequest = EventHandlerRequest,
->(fn: RequestMiddleware<Request>): RequestMiddleware<Request> {
-  return fn;
-}
-
-export function defineResponseMiddleware<
-  Request extends EventHandlerRequest = EventHandlerRequest,
->(fn: ResponseMiddleware<Request>): ResponseMiddleware<Request> {
-  return fn;
-}
+//  --- dynamic event handler ---
 
 export function dynamicEventHandler(
   initial?: EventHandler,
@@ -116,6 +30,8 @@ export function dynamicEventHandler(
   };
   return wrapper;
 }
+
+// --- lazy event handler ---
 
 export function defineLazyEventHandler(
   load: () => Promise<EventHandler> | EventHandler,

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,21 +20,18 @@ export { isEvent, mockEvent } from "./utils/event.ts";
 export type {
   EventHandler,
   DynamicEventHandler,
-  EventHandlerObject,
   EventHandlerRequest,
   EventHandlerResponse,
   InferEventInput,
   LazyEventHandler,
-  RequestMiddleware,
-  ResponseMiddleware,
+  Middleware,
+  MiddlewareOptions,
 } from "./types/handler.ts";
 
 export {
   defineEventHandler,
   defineLazyEventHandler,
   dynamicEventHandler,
-  defineRequestMiddleware,
-  defineResponseMiddleware,
 } from "./handler.ts";
 
 // Error

--- a/src/types/_utils.ts
+++ b/src/types/_utils.ts
@@ -1,0 +1,1 @@
+export type MaybePromise<T = unknown> = T | Promise<T>;

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -1,13 +1,11 @@
-import type * as crossws from "crossws";
 import type { H3Event } from "./event.ts";
 import type { EventHandler } from "./handler.ts";
 import type { H3Error } from "../error.ts";
+import type { MaybePromise } from "./_utils.ts";
 
 // https://www.rfc-editor.org/rfc/rfc7231#section-4.1
 // prettier-ignore
 export type HTTPMethod =  "GET" | "HEAD" | "PATCH" | "POST" | "PUT" | "DELETE" | "CONNECT" | "OPTIONS" | "TRACE";
-
-type MaybePromise<T = unknown> = T | Promise<T>;
 
 export interface H3Config {
   debug?: boolean;

--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -1,5 +1,14 @@
+import type { MaybePromise } from "./_utils.ts";
 import type { H3Event } from "./event.ts";
-import type { H3 } from "../h3.ts";
+
+//  --- event handler ---
+
+export interface EventHandler<
+  Request extends EventHandlerRequest = EventHandlerRequest,
+  Response extends EventHandlerResponse = EventHandlerResponse,
+> {
+  (event: H3Event<Request>): Response;
+}
 
 export interface EventHandlerRequest {
   body?: unknown;
@@ -8,21 +17,6 @@ export interface EventHandlerRequest {
 }
 
 export type EventHandlerResponse<T = unknown> = T | Promise<T>;
-
-export type InferEventInput<
-  Key extends keyof EventHandlerRequest,
-  Event extends H3Event,
-  T,
-> = void extends T ? (Event extends H3Event<infer E> ? E[Key] : never) : T;
-
-type MaybePromise<T> = T | Promise<T>;
-
-export interface EventHandler<
-  Request extends EventHandlerRequest = EventHandlerRequest,
-  Response extends EventHandlerResponse = EventHandlerResponse,
-> extends Partial<Pick<H3, "handler" | "config">> {
-  (event: H3Event<Request>): Response;
-}
 
 //  --- middleware ---
 
@@ -47,3 +41,11 @@ export type LazyEventHandler = () => EventHandler | Promise<EventHandler>;
 export interface DynamicEventHandler extends EventHandler {
   set: (handler: EventHandler) => void;
 }
+
+// --- utils ---
+
+export type InferEventInput<
+  Key extends keyof EventHandlerRequest,
+  Event extends H3Event,
+  T,
+> = void extends T ? (Event extends H3Event<infer E> ? E[Key] : never) : T;

--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -1,14 +1,13 @@
 import type { H3Event } from "./event.ts";
-import type { Hooks as WSHooks } from "crossws";
 import type { H3 } from "../h3.ts";
-
-export type EventHandlerResponse<T = unknown> = T | Promise<T>;
 
 export interface EventHandlerRequest {
   body?: unknown;
   query?: Record<string, string>;
   routerParams?: Record<string, string>;
 }
+
+export type EventHandlerResponse<T = unknown> = T | Promise<T>;
 
 export type InferEventInput<
   Key extends keyof EventHandlerRequest,
@@ -25,11 +24,7 @@ export interface EventHandler<
   (event: H3Event<Request>): Response;
 }
 
-export interface MiddlewareOptions {
-  route?: string;
-  method?: string;
-  match?: (event: H3Event) => boolean;
-}
+//  --- middleware ---
 
 export interface Middleware {
   (
@@ -39,30 +34,13 @@ export interface Middleware {
   match?: (event: H3Event) => boolean;
 }
 
-export type RequestMiddleware<
-  Request extends EventHandlerRequest = EventHandlerRequest,
-> = (event: H3Event<Request>) => void | Promise<void>;
+export interface MiddlewareOptions {
+  route?: string;
+  method?: string;
+  match?: (event: H3Event) => boolean;
+}
 
-export type ResponseMiddleware<
-  Request extends EventHandlerRequest = EventHandlerRequest,
-  Response extends EventHandlerResponse = EventHandlerResponse,
-> = (
-  event: H3Event<Request>,
-  response: { body?: Awaited<Response> },
-) => void | Promise<void>;
-
-export type EventHandlerObject<
-  Request extends EventHandlerRequest = EventHandlerRequest,
-  Response extends EventHandlerResponse = EventHandlerResponse,
-> = {
-  onRequest?: RequestMiddleware<Request> | RequestMiddleware<Request>[];
-  onBeforeResponse?:
-    | ResponseMiddleware<Request, Response>
-    | ResponseMiddleware<Request, Response>[];
-  /** @experimental */
-  websocket?: Partial<WSHooks>;
-  handler: EventHandler<Request, Response>;
-};
+// --- lazy event handler ---
 
 export type LazyEventHandler = () => EventHandler | Promise<EventHandler>;
 

--- a/src/utils/ws.ts
+++ b/src/utils/ws.ts
@@ -18,16 +18,14 @@ export function defineWebSocket(hooks: Partial<WSHooks>): Partial<WSHooks> {
  * @see https://h3.dev/guide/websocket
  */
 export function defineWebSocketHandler(hooks: Partial<WSHooks>): EventHandler {
-  return defineEventHandler({
-    handler() {
-      return Object.assign(
-        new Response("WebSocket upgrade is required.", {
-          status: 426,
-        }),
-        {
-          crossws: hooks,
-        },
-      );
-    },
+  return defineEventHandler(() => {
+    return Object.assign(
+      new Response("WebSocket upgrade is required.", {
+        status: 426,
+      }),
+      {
+        crossws: hooks,
+      },
+    );
   });
 }

--- a/test/unit/package.test.ts
+++ b/test/unit/package.test.ts
@@ -25,8 +25,6 @@ describe("h3 package", () => {
         "defineNodeHandler",
         "defineNodeListener",
         "defineNodeMiddleware",
-        "defineRequestMiddleware",
-        "defineResponseMiddleware",
         "defineWebSocket",
         "defineWebSocketHandler",
         "deleteCookie",

--- a/test/unit/types.test-d.ts
+++ b/test/unit/types.test-d.ts
@@ -11,28 +11,6 @@ import {
 
 describe("types", () => {
   describe("eventHandler", () => {
-    it("object syntax definitions", async () => {
-      const handler = defineEventHandler({
-        onRequest: [
-          (event) => {
-            expectTypeOf(event).toEqualTypeOf<H3Event>();
-          },
-        ],
-        async handler(event) {
-          expectTypeOf(event).toEqualTypeOf<H3Event>();
-
-          const body = await readBody(event);
-          expectTypeOf(body).toBeUnknown;
-
-          return {
-            foo: "bar",
-          };
-        },
-      });
-      expectTypeOf(await handler({} as H3Event)).toEqualTypeOf<{
-        foo: string;
-      }>();
-    });
     it("return type (inferred)", () => {
       const handler = defineEventHandler(() => {
         return {
@@ -41,14 +19,6 @@ describe("types", () => {
       });
       const response = handler({} as H3Event);
       expectTypeOf(response).toEqualTypeOf<{ foo: string }>();
-    });
-
-    it("return type (simple generic)", () => {
-      const handler = defineEventHandler<string>(() => {
-        return "";
-      });
-      const response = handler({} as H3Event);
-      expectTypeOf(response).toEqualTypeOf<string>();
     });
   });
 


### PR DESCRIPTION
Remove legacy generic signature for event handler `<reponse>`.

Also removed object syntax. With new chainable middleware (#1065) we can support new `defineEventHandler(handler, { middleware: [...] })` / `app.*(handler, { ... })` to intercept before/after response and errors (in next PRs)