### PR TITLE
feat(validate): standard schema support

### DIFF
--- a/src/utils/internal/standard-schema.ts
+++ b/src/utils/internal/standard-schema.ts
@@ -1,0 +1,70 @@
+// https://github.com/standard-schema/standard-schema
+
+/** The Standard Schema interface. */
+export interface StandardSchemaV1<Input = unknown, Output = Input> {
+  /** The Standard Schema properties. */
+  readonly "~standard": Props<Input, Output>;
+}
+
+/** The Standard Schema properties interface. */
+export interface Props<Input = unknown, Output = Input> {
+  /** The version number of the standard. */
+  readonly version: 1;
+  /** The vendor name of the schema library. */
+  readonly vendor: string;
+  /** Validates unknown input values. */
+  readonly validate: (
+    value: unknown,
+  ) => Result<Output> | Promise<Result<Output>>;
+  /** Inferred types associated with the schema. */
+  readonly types?: Types<Input, Output> | undefined;
+}
+
+/** The result interface of the validate function. */
+export type Result<Output> = SuccessResult<Output> | FailureResult;
+
+/** The result interface if validation succeeds. */
+export interface SuccessResult<Output> {
+  /** The typed output value. */
+  readonly value: Output;
+  /** The non-existent issues. */
+  readonly issues?: undefined;
+}
+
+/** The result interface if validation fails. */
+export interface FailureResult {
+  /** The issues of failed validation. */
+  readonly issues: ReadonlyArray<Issue>;
+}
+
+/** The issue interface of the failure output. */
+export interface Issue {
+  /** The error message of the issue. */
+  readonly message: string;
+  /** The path of the issue, if any. */
+  readonly path?: ReadonlyArray<PropertyKey | PathSegment> | undefined;
+}
+
+/** The path segment interface of the issue. */
+export interface PathSegment {
+  /** The key representing a path segment. */
+  readonly key: PropertyKey;
+}
+
+/** The Standard Schema types interface. */
+export interface Types<Input = unknown, Output = Input> {
+  /** The input type of the schema. */
+  readonly input: Input;
+  /** The output type of the schema. */
+  readonly output: Output;
+}
+
+/** Infers the input type of a Standard Schema. */
+export type InferInput<Schema extends StandardSchemaV1> = NonNullable<
+  Schema["~standard"]["types"]
+>["input"];
+
+/** Infers the output type of a Standard Schema. */
+export type InferOutput<Schema extends StandardSchemaV1> = NonNullable<
+  Schema["~standard"]["types"]
+>["output"];

--- a/src/utils/internal/validate.ts
+++ b/src/utils/internal/validate.ts
@@ -1,13 +1,11 @@
 import { createError } from "../../error.ts";
+import type { StandardSchemaV1 } from "./standard-schema.ts";
 
 export type ValidateResult<T> = T | true | false | void;
 
-export type ValidateFunction<T> = (
-  data: unknown,
-) => ValidateResult<T> | Promise<ValidateResult<T>>;
-
-// TODO: Consider using similar method of typeschema for external library compatibility
-// https://github.com/decs/typeschema/blob/v0.1.3/src/assert.ts
+export type ValidateFunction<T> =
+  | StandardSchemaV1<T>
+  | ((data: unknown) => ValidateResult<T> | Promise<ValidateResult<T>>);
 
 /**
  * Validates the given data using the provided validation function.
@@ -21,10 +19,21 @@ export async function validateData<T>(
   data: unknown,
   fn: ValidateFunction<T>,
 ): Promise<T> {
+  if ("~standard" in fn) {
+    const result = await fn["~standard"].validate(data);
+    if (result.issues) {
+      throw createValidationError({
+        message: "Validation failed",
+        issues: result.issues,
+      });
+    }
+    return result.value;
+  }
+
   try {
     const res = await fn(data);
     if (res === false) {
-      throw createValidationError();
+      throw createValidationError({ message: "Validation failed" });
     }
     if (res === true) {
       return data as T;

--- a/src/utils/internal/validate.ts
+++ b/src/utils/internal/validate.ts
@@ -47,8 +47,8 @@ export async function validateData<T>(
 function createValidationError(validateError?: any) {
   throw createError({
     status: 400,
-    statusMessage: "Validation Error",
-    message: validateError?.message || "Validation Error",
+    statusMessage: "Validation failed",
+    message: validateError?.message || "Validation failed",
     data: validateError,
     cause: validateError,
   });


### PR DESCRIPTION
Smaller rework of #964 (thanks @sandros94 ❤️ ) resolves #963 to support [standard schema](https://github.com/standard-schema/standard-schema) validators (zod, valibot, etc)

