### PR TITLE
fix(validation): standard-schema return type

### DIFF
--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -1,7 +1,11 @@
 import type { H3Event } from "../types/event.ts";
 import type { InferEventInput } from "../types/handler.ts";
 import { createError } from "../error.ts";
-import { validateData, type ValidateFunction } from "./internal/validate.ts";
+import { validateData, type ValidateResult } from "./internal/validate.ts";
+import type {
+  StandardSchemaV1,
+  InferOutput,
+} from "./internal/standard-schema.ts";
 import { parseURLEncodedBody } from "./internal/body.ts";
 
 /**
@@ -43,6 +47,20 @@ export async function readBody<
   }
 }
 
+export async function readValidatedBody<
+  Event extends H3Event,
+  S extends StandardSchemaV1,
+>(event: Event, validate: S): Promise<InferOutput<S>>;
+export async function readValidatedBody<
+  Event extends H3Event,
+  OutputT,
+  InputT = InferEventInput<"body", Event, OutputT>,
+>(
+  event: Event,
+  validate: (
+    data: InputT,
+  ) => ValidateResult<OutputT> | Promise<ValidateResult<OutputT>>,
+): Promise<OutputT>;
 /**
  * Tries to read the request body via `readBody`, then uses the provided validation function and either throws a validation error or returns the result.
  *
@@ -68,11 +86,10 @@ export async function readBody<
  * @return {*} The `Object`, `Array`, `String`, `Number`, `Boolean`, or `null` value corresponding to the request JSON body.
  * @see {readBody}
  */
-export async function readValidatedBody<
-  T,
-  Event extends H3Event = H3Event,
-  _T = InferEventInput<"body", Event, T>,
->(event: Event, validate: ValidateFunction<_T>): Promise<_T> {
+export async function readValidatedBody(
+  event: H3Event,
+  validate: any,
+): Promise<any> {
   const _body = await readBody(event);
   return validateData(_body, validate);
 }

--- a/src/utils/internal/validate.ts
+++ b/src/utils/internal/validate.ts
@@ -1,10 +1,13 @@
 import { createError } from "../../error.ts";
-import type { StandardSchemaV1 } from "./standard-schema.ts";
+import type { StandardSchemaV1, InferOutput } from "./standard-schema.ts";
 
 export type ValidateResult<T> = T | true | false | void;
 
-export type ValidateFunction<T> =
-  | StandardSchemaV1<T>
+export type ValidateFunction<
+  T,
+  Schema extends StandardSchemaV1 = StandardSchemaV1<any, T>,
+> =
+  | Schema
   | ((data: unknown) => ValidateResult<T> | Promise<ValidateResult<T>>);
 
 /**
@@ -15,6 +18,14 @@ export type ValidateFunction<T> =
  * @returns A Promise that resolves with the validated data if it passes validation, meaning the validation function does not throw and returns a value other than false.
  * @throws {ValidationError} If the validation function returns false or throws an error.
  */
+export async function validateData<Schema extends StandardSchemaV1>(
+  data: unknown,
+  fn: Schema,
+): Promise<InferOutput<Schema>>;
+export async function validateData<T>(
+  data: unknown,
+  fn: (data: unknown) => ValidateResult<T> | Promise<ValidateResult<T>>,
+): Promise<T>;
 export async function validateData<T>(
   data: unknown,
   fn: ValidateFunction<T>,

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,6 +1,10 @@
 import { createError } from "../error.ts";
 import { parseQuery } from "./internal/query.ts";
-import { validateData, type ValidateFunction } from "./internal/validate.ts";
+import { validateData, type ValidateResult } from "./internal/validate.ts";
+import type {
+  StandardSchemaV1,
+  InferOutput,
+} from "./internal/standard-schema.ts";
 
 import type { H3Event } from "../types/event.ts";
 import type { InferEventInput } from "../types/handler.ts";
@@ -22,6 +26,20 @@ export function getQuery<
   return parseQuery(event.url.search.slice(1)) as _T;
 }
 
+export function getValidatedQuery<
+  Event extends H3Event,
+  S extends StandardSchemaV1<any, any>,
+>(event: Event, validate: S): Promise<InferOutput<S>>;
+export function getValidatedQuery<
+  Event extends H3Event,
+  OutputT,
+  InputT = InferEventInput<"query", Event, OutputT>,
+>(
+  event: Event,
+  validate: (
+    data: InputT,
+  ) => ValidateResult<OutputT> | Promise<ValidateResult<OutputT>>,
+): Promise<OutputT>;
 /**
  * Get the query param from the request URL validated with validate function.
  *
@@ -45,11 +63,7 @@ export function getQuery<
  *   );
  * });
  */
-export function getValidatedQuery<
-  T,
-  Event extends H3Event = H3Event,
-  _T = InferEventInput<"query", Event, T>,
->(event: Event, validate: ValidateFunction<_T>): Promise<_T> {
+export function getValidatedQuery(event: H3Event, validate: any): Promise<any> {
   const query = getQuery(event);
   return validateData(query, validate);
 }
@@ -79,6 +93,25 @@ export function getRouterParams(
   return params;
 }
 
+export function getValidatedRouterParams<
+  Event extends H3Event,
+  S extends StandardSchemaV1,
+>(
+  event: Event,
+  validate: S,
+  opts?: { decode?: boolean },
+): Promise<InferOutput<S>>;
+export function getValidatedRouterParams<
+  Event extends H3Event,
+  OutputT,
+  InputT = InferEventInput<"routerParams", Event, OutputT>,
+>(
+  event: Event,
+  validate: (
+    data: InputT,
+  ) => ValidateResult<OutputT> | Promise<ValidateResult<OutputT>>,
+  opts?: { decode?: boolean },
+): Promise<OutputT>;
 /**
  * Get matched route params and validate with validate function.
  *
@@ -104,15 +137,11 @@ export function getRouterParams(
  *   );
  * });
  */
-export function getValidatedRouterParams<
-  T,
-  Event extends H3Event = H3Event,
-  _T = InferEventInput<"routerParams", Event, T>,
->(
-  event: Event,
-  validate: ValidateFunction<_T>,
+export function getValidatedRouterParams(
+  event: H3Event,
+  validate: any,
   opts: { decode?: boolean } = {},
-): Promise<_T> {
+): Promise<any> {
   const routerParams = getRouterParams(event, opts);
   return validateData(routerParams, validate);
 }


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

Reported in https://github.com/h3js/h3/pull/1068#issuecomment-2931648390

This solves the issue when a standard-schema compatible library both validates and transform the data. For example as demonstrated in the use-case of the above comment:

> Taking in example a simple query which contains a `page` and `size` for paginating content in the db, `/api/producs?page=3&size=20` we know that `3` and `20` will be considered strings. As such we can create a schema that would take this into account so that we both validate it and return the correct type:
>
> ```ts
> const stringToNumber = z
>   .string()
>   .regex(/^-?(?:\d+(?:\.\d+)?|\.\d+)$/, 'Must be a number string')
>   .transform(Number);
>
> const querySchema = z.object({
>   page: stringToNumber.optional(),
>   size: stringToNumber.optional(),
> });
> ```
