### PR TITLE
feat: support attached middleware for handlers

### DIFF
--- a/docs/1.guide/3.handler.md
+++ b/docs/1.guide/3.handler.md
@@ -29,16 +29,18 @@ The callback function can be sync or async:
 defineEventHandler(async (event) => "Response");
 ```
 
-### Object Syntax
-
-You can use an object syntax in `defineEventHandler` for more flexible options.
+You can optionally register some [middleware](#middleware) to run with event handler to intercept request, response or errors.
 
 ```js
-defineEventHandler({
-  onRequest: [],
-  onBeforeResponse: []
-  handler: () => "Response",
-})
+defineEventHandler(
+  async (event) => "Response",
+  [
+    auth(),
+    (event) => {
+      console.log("intercepting event");
+    },
+  ],
+);
 ```
 
 ## Responses Types

--- a/docs/1.guide/3.handler.md
+++ b/docs/1.guide/3.handler.md
@@ -32,15 +32,7 @@ defineEventHandler(async (event) => "Response");
 You can optionally register some [middleware](#middleware) to run with event handler to intercept request, response or errors.
 
 ```js
-defineEventHandler(
-  async (event) => "Response",
-  [
-    auth(),
-    (event) => {
-      console.log("intercepting event");
-    },
-  ],
-);
+defineEventHandler((event) => {}, [auth]);
 ```
 
 ## Responses Types

--- a/docs/1.guide/5.routing.md
+++ b/docs/1.guide/5.routing.md
@@ -143,11 +143,5 @@ app.use(
 When adding routes, you can register middleware to run with them:
 
 ```js
-app.get(
-  "/admin",
-  (event) => {
-    // Some private API
-  },
-  [auth()],
-);
+app.get("/admin", (event) => {}, [auth]);
 ```

--- a/docs/1.guide/5.routing.md
+++ b/docs/1.guide/5.routing.md
@@ -139,3 +139,15 @@ app.use(
   },
 );
 ```
+
+When adding routes, you can register middleware to run with them:
+
+```js
+app.get(
+  "/admin",
+  (event) => {
+    // Some private API
+  },
+  [auth()],
+);
+```

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -3,6 +3,7 @@ import type {
   EventHandlerRequest,
   EventHandlerResponse,
   DynamicEventHandler,
+  Middleware,
 } from "./types/handler.ts";
 
 // --- event handler ---
@@ -10,8 +11,11 @@ import type {
 export function defineEventHandler<
   Request extends EventHandlerRequest = EventHandlerRequest,
   Response = EventHandlerResponse,
->(handler: EventHandler<Request, Response>): EventHandler<Request, Response> {
-  return handler;
+>(
+  handler: EventHandler<Request, Response>,
+  middleware?: Middleware[],
+): EventHandler<Request, Response> {
+  return middleware?.length ? Object.assign(handler, { middleware }) : handler;
 }
 
 //  --- dynamic event handler ---

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -25,10 +25,13 @@ export type PreparedResponse = ResponseInit & { body?: BodyInit | null };
 export interface H3Route {
   route?: string;
   method?: HTTPMethod;
+  middleware?: Middleware[];
   handler: EventHandler;
 }
 
 // --- H3 App ---
+
+type InputHandler = EventHandler | H3;
 
 export declare class H3 {
   /**
@@ -70,17 +73,22 @@ export declare class H3 {
   on(
     method: HTTPMethod | Lowercase<HTTPMethod> | "",
     route: string,
-    handler: EventHandler | H3,
+    handler: InputHandler,
+    middleware?: Middleware[],
   ): H3;
 
-  all(route: string, handler: EventHandler | H3): H3;
-  get(route: string, handler: EventHandler | H3): H3;
-  post(route: string, handler: EventHandler | H3): H3;
-  put(route: string, handler: EventHandler | H3): H3;
-  delete(route: string, handler: EventHandler | H3): H3;
-  patch(route: string, handler: EventHandler | H3): H3;
-  head(route: string, handler: EventHandler | H3): H3;
-  options(route: string, handler: EventHandler | H3): H3;
-  connect(route: string, handler: EventHandler | H3): H3;
-  trace(route: string, handler: EventHandler | H3): H3;
+  /**
+   * Register a route handler for all HTTP methods.
+   */
+  all(route: string, handler: InputHandler, middleware?: Middleware[]): H3;
+
+  get(route: string, handler: InputHandler, middleware?: Middleware[]): H3;
+  post(route: string, handler: InputHandler, middleware?: Middleware[]): H3;
+  put(route: string, handler: InputHandler, middleware?: Middleware[]): H3;
+  delete(route: string, handler: InputHandler, middleware?: Middleware[]): H3;
+  patch(route: string, handler: InputHandler, middleware?: Middleware[]): H3;
+  head(route: string, handler: InputHandler, middleware?: Middleware[]): H3;
+  options(route: string, handler: InputHandler, middleware?: Middleware[]): H3;
+  connect(route: string, handler: InputHandler, middleware?: Middleware[]): H3;
+  trace(route: string, handler: InputHandler, middleware?: Middleware[]): H3;
 }

--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -8,6 +8,7 @@ export interface EventHandler<
   Response extends EventHandlerResponse = EventHandlerResponse,
 > {
   (event: H3Event<Request>): Response;
+  middleware?: Middleware[];
 }
 
 export interface EventHandlerRequest {


### PR DESCRIPTION
Follow-up on new chainable middleware #1065

This PR allows registering middleware like auth to be attached to registered event handlers.

Compared to global middleware, this kind of middleware is guaranteed to run in the scope of the registered event handler and also does not need to be globally filtered to be matched (which is more secure).

Register during definition:

```js
defineEventHandler((event) => {}, [auth]);
```

Register during registration:

```js
app.get("/edit", (event) => {}, [auth]);
```


