### PR TITLE
feat: error with custom headers

### DIFF
--- a/examples/errors.mjs
+++ b/examples/errors.mjs
@@ -14,6 +14,7 @@ app
       status: 400,
       message: "Bad request",
       statusMessage: "Bad request message",
+      headers: { "X-Custom-Header": "Custom Value" },
     });
   })
   .get("/fatal-error", () => {

--- a/src/error.ts
+++ b/src/error.ts
@@ -20,6 +20,7 @@ export class H3Error<DataT = unknown> extends Error {
   statusMessage?: string;
   data?: DataT;
   cause?: unknown;
+  headers?: Headers;
 
   constructor(message: string, opts: { cause?: unknown } = {}) {
     // @ts-ignore https://v8.dev/features/error-cause
@@ -84,7 +85,11 @@ export class H3Error<DataT = unknown> extends Error {
 export function createError<DataT = unknown>(
   input:
     | string
-    | (Partial<H3Error<DataT>> & { status?: number; statusText?: string }),
+    | (Partial<H3Error<DataT>> & {
+        status?: number;
+        statusText?: string;
+        headers?: HeadersInit;
+      }),
 ): H3Error<DataT> {
   if (typeof input === "string") {
     return new H3Error<DataT>(input);
@@ -143,6 +148,10 @@ export function createError<DataT = unknown>(
   const unhandled = input.unhandled ?? (cause as H3Error)?.unhandled;
   if (unhandled !== undefined) {
     err.unhandled = unhandled;
+  }
+
+  if (input.headers) {
+    err.headers = new Headers(input.headers);
   }
 
   return err;

--- a/src/response.ts
+++ b/src/response.ts
@@ -204,9 +204,9 @@ function errorResponse(error: H3Error, debug?: boolean): Response {
     {
       status: error.statusCode,
       statusText: error.statusMessage,
-      headers: {
-        "content-type": "application/json; charset=utf-8",
-      },
+      headers: error.headers
+        ? mergeHeaders(jsonHeaders, error.headers)
+        : jsonHeaders,
     },
   );
 }


### PR DESCRIPTION
When throwing response errors with `throw createError()`, any existing set headers with `event.res.headers` will be discarded (as they are meant to prepare for final normal response)

This PR adds support for `throw createError({ headers: {...} })`.