### PR TITLE
refactor: add back object syntax for `defineEventHandler`

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,4 +1,3 @@
-import { set } from "zod";
 import type {
   EventHandler,
   EventHandlerRequest,

--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -11,6 +11,14 @@ export interface EventHandler<
   middleware?: Middleware[];
 }
 
+export interface EventHandlerObject<
+  Request extends EventHandlerRequest = EventHandlerRequest,
+  Response extends EventHandlerResponse = EventHandlerResponse,
+> {
+  handler: EventHandler<Request, Response>;
+  middleware?: Middleware[];
+}
+
 export interface EventHandlerRequest {
   body?: unknown;
   query?: Record<string, string>;

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -14,6 +14,14 @@ describe("handler.ts", () => {
       const eventHandler = defineEventHandler(handler);
       expect(eventHandler).toBe(handler);
     });
+
+    it("object syntax", () => {
+      const handler = vi.fn();
+      const middleware = [vi.fn()];
+      const eventHandler = defineEventHandler({ handler, middleware });
+      expect(eventHandler).toBe(handler);
+      expect(eventHandler.middleware).toBe(middleware);
+    });
   });
 
   describe("dynamicEventHandler", () => {

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -46,15 +46,13 @@ describeMatrix("middleware", (t, { it, expect }) => {
       "/**",
       defineEventHandler(
         (event) => {
+          event.context._middleware.push(`route (define)`);
+        },
+        (event) => {
           return {
             log: event.context._middleware.join(" > "),
           };
         },
-        [
-          (event) => {
-            event.context._middleware.push(`route (define)`);
-          },
-        ],
       ),
       [
         (event) => {

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -44,16 +44,18 @@ describeMatrix("middleware", (t, { it, expect }) => {
 
     t.app.get(
       "/**",
-      defineEventHandler(
-        (event) => {
-          event.context._middleware.push(`route (define)`);
-        },
-        (event) => {
+      defineEventHandler({
+        middleware: [
+          (event) => {
+            event.context._middleware.push(`route (define)`);
+          },
+        ],
+        handler: (event) => {
           return {
             log: event.context._middleware.join(" > "),
           };
         },
-      ),
+      }),
       [
         (event) => {
           event.context._middleware.push(`route (register)`);

--- a/test/unit/types.test-d.ts
+++ b/test/unit/types.test-d.ts
@@ -12,7 +12,7 @@ import {
 describe("types", () => {
   describe("eventHandler", () => {
     it("return type (inferred)", () => {
-      const handler = defineEventHandler((_event) => {
+      const handler = defineEventHandler(() => {
         return {
           foo: "bar",
         };

--- a/test/unit/types.test-d.ts
+++ b/test/unit/types.test-d.ts
@@ -12,7 +12,7 @@ import {
 describe("types", () => {
   describe("eventHandler", () => {
     it("return type (inferred)", () => {
-      const handler = defineEventHandler(() => {
+      const handler = defineEventHandler((_event) => {
         return {
           foo: "bar",
         };


### PR DESCRIPTION
Update: Adding back object syntax of h3 v1 with `defineEventHandler({ handler, middleware })`. It is safest bet to 1) keep backward compatibility 2) think more about proper order for shorthand overload of function (either B or C) in next betas.

---

Trying to find the best ergonomic API for `defineEventHandler` with middleware (see #1075)

General findings:
- A is often found best by first look and is progressive (optional last), but as the handler logic length increases, middleware becomes less visible. Also, it does not show the right order of execution.
- C, it is best to give a clearer/simpler API, but an array might be harder to infer types from
- B is a little less organized but has the benefits of C and might be better for types 


```js
defineEventHandler((event) => {
  // [A: current]
}, [basicAuth(), validateBody()])

defineEventHandler(basicAuth(), validateBody(), (event) => {
  // [B]
})

defineEventHandler([basicAuth(), validateBody()], (event) => {
  // [C]
})
```

---

polls:

- https://x.com/_pi0_/status/1929828254908567849
- https://bsky.app/profile/pi0.io/post/3lqox5e7lms2x
- https://discord.com/channels/1363770380833128508/1363770380833128511/1379352036788670534 ([invite](https://discord.h3.dev))
