### PR TITLE
refactor: update usage of middleware

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ export type {
   InferEventInput,
   LazyEventHandler,
   Middleware,
-  MiddlewareOptions,
+  EventHandlerObject,
 } from "./types/handler.ts";
 
 export {

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -1,5 +1,5 @@
 import type { H3Event, H3EventContext } from "./event.ts";
-import type { EventHandler, Middleware, MiddlewareOptions } from "./handler.ts";
+import type { EventHandler, Middleware } from "./handler.ts";
 import type { H3Error } from "../error.ts";
 import type { MaybePromise } from "./_utils.ts";
 
@@ -31,7 +31,16 @@ export interface H3Route {
 
 // --- H3 App ---
 
-type InputHandler = EventHandler | H3;
+export type RouteHandler = EventHandler | H3;
+
+export type RouteOptions = {
+  middleware?: Middleware[];
+};
+
+export type MiddlewareOptions = {
+  method?: string;
+  match?: (event: H3Event) => boolean;
+};
 
 export declare class H3 {
   /**
@@ -65,7 +74,8 @@ export declare class H3 {
   /**
    * Register a global middleware.
    */
-  use(input: Middleware | H3, opts?: MiddlewareOptions): H3;
+  use(route: string, handler: Middleware | H3, opts?: MiddlewareOptions): H3;
+  use(handler: Middleware | H3, opts?: MiddlewareOptions): H3;
 
   /**
    * Register a route handler for the specified HTTP method and route.
@@ -73,22 +83,22 @@ export declare class H3 {
   on(
     method: HTTPMethod | Lowercase<HTTPMethod> | "",
     route: string,
-    handler: InputHandler,
-    middleware?: Middleware[],
+    handler: RouteHandler,
+    opts?: RouteOptions,
   ): H3;
 
   /**
    * Register a route handler for all HTTP methods.
    */
-  all(route: string, handler: InputHandler, middleware?: Middleware[]): H3;
+  all(route: string, handler: RouteHandler, opts?: RouteOptions): H3;
 
-  get(route: string, handler: InputHandler, middleware?: Middleware[]): H3;
-  post(route: string, handler: InputHandler, middleware?: Middleware[]): H3;
-  put(route: string, handler: InputHandler, middleware?: Middleware[]): H3;
-  delete(route: string, handler: InputHandler, middleware?: Middleware[]): H3;
-  patch(route: string, handler: InputHandler, middleware?: Middleware[]): H3;
-  head(route: string, handler: InputHandler, middleware?: Middleware[]): H3;
-  options(route: string, handler: InputHandler, middleware?: Middleware[]): H3;
-  connect(route: string, handler: InputHandler, middleware?: Middleware[]): H3;
-  trace(route: string, handler: InputHandler, middleware?: Middleware[]): H3;
+  get(route: string, handler: RouteHandler, opts?: RouteOptions): H3;
+  post(route: string, handler: RouteHandler, opts?: RouteOptions): H3;
+  put(route: string, handler: RouteHandler, opts?: RouteOptions): H3;
+  delete(route: string, handler: RouteHandler, opts?: RouteOptions): H3;
+  patch(route: string, handler: RouteHandler, opts?: RouteOptions): H3;
+  head(route: string, handler: RouteHandler, opts?: RouteOptions): H3;
+  options(route: string, handler: RouteHandler, opts?: RouteOptions): H3;
+  connect(route: string, handler: RouteHandler, opts?: RouteOptions): H3;
+  trace(route: string, handler: RouteHandler, opts?: RouteOptions): H3;
 }

--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -37,12 +37,6 @@ export interface Middleware {
   match?: (event: H3Event) => boolean;
 }
 
-export interface MiddlewareOptions {
-  route?: string;
-  method?: string;
-  match?: (event: H3Event) => boolean;
-}
-
 // --- lazy event handler ---
 
 export type LazyEventHandler = () => EventHandler | Promise<EventHandler>;

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -202,7 +202,7 @@ describeMatrix("app", (t, { it, expect }) => {
   });
 
   it("can chain .use calls", async () => {
-    t.app.get("/1", () => "prefix1").use(() => "prefix2", { route: "/2" });
+    t.app.get("/1", () => "prefix1").use("/2", () => "prefix2");
     const res = await t.fetch("/2");
 
     expect(await res.text()).toBe("prefix2");

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -5,7 +5,7 @@ describeMatrix("auth", (t, { it, expect }) => {
   const auth = basicAuth({ username: "test", password: "123!" });
 
   it("responds 401 for a missing authorization header", async () => {
-    t.app.get("/test", () => "Hello, world!", [auth]);
+    t.app.get("/test", () => "Hello, world!", { middleware: [auth] });
     const result = await t.fetch("/test", {
       method: "GET",
     });
@@ -14,7 +14,7 @@ describeMatrix("auth", (t, { it, expect }) => {
   });
 
   it("responds 401 for an incorrect authorization header", async () => {
-    t.app.get("/test", () => "Hello, world!", [auth]);
+    t.app.get("/test", () => "Hello, world!", { middleware: [auth] });
     const result = await t.fetch("/test", {
       method: "GET",
       headers: {
@@ -27,7 +27,7 @@ describeMatrix("auth", (t, { it, expect }) => {
   });
 
   it("responds 200 for a correct authorization header", async () => {
-    t.app.get("/test", () => "Hello, world!", [auth]);
+    t.app.get("/test", () => "Hello, world!", { middleware: [auth] });
     const result = await t.fetch("/test", {
       method: "GET",
       headers: {

--- a/test/bench/bench.impl.ts
+++ b/test/bench/bench.impl.ts
@@ -88,26 +88,21 @@ export function h3Middleware(lib: typeof _h3src): AppFetch {
   app.use(() => Promise.resolve());
 
   // [GET] /
-  app.use(() => "Hi", { route: "/" });
+  app.use("/", () => "Hi");
 
   // [GET] /id/:id
-  app.use(
-    (event) => {
-      event.res.headers.set("x-powered-by", "benchmark");
-      const name = lib.getQuery(event).name;
-      return `${event.context.params!.id} ${name}`;
-    },
-    { route: "/id/:id" },
-  );
+  app.use("/id/:id", (event) => {
+    event.res.headers.set("x-powered-by", "benchmark");
+    const name = lib.getQuery(event).name;
+    return `${event.context.params!.id} ${name}`;
+  });
 
   // [POST] /json
-  app.use(
-    (event) =>
-      (
-        event.req ||
-        (event as unknown as { request: Request }) /* nightly */.request
-      ).json(),
-    { route: "/json" },
+  app.use("/json", (event) =>
+    (
+      event.req ||
+      (event as unknown as { request: Request }) /* nightly */.request
+    ).json(),
   );
 
   return app.fetch;

--- a/test/integrations.test.ts
+++ b/test/integrations.test.ts
@@ -40,9 +40,7 @@ describeMatrix("integrations", (t, { it, expect, describe }) => {
       expressApp.use("/", (_req, res) => {
         res.json({ express: "works" });
       });
-      t.app.use(fromNodeHandler(expressApp as NodeMiddleware), {
-        route: "/api/express",
-      });
+      t.app.use("/api/express", fromNodeHandler(expressApp as NodeMiddleware));
       const res = await t.fetch("/api/express");
 
       expect(await res.json()).toEqual({ express: "works" });
@@ -51,13 +49,14 @@ describeMatrix("integrations", (t, { it, expect, describe }) => {
     it("can be used as express middleware", async () => {
       const expressApp = express();
       t.app.use(
+        "/api/*",
         fromNodeHandler((_req, res, next) => {
           (res as any).prop = "42";
           next();
         }),
-        { route: "/api/*" },
       );
       t.app.use(
+        "/api/hello",
         fromNodeHandler(
           defineNodeHandler((req, res) => {
             res.end(
@@ -68,7 +67,6 @@ describeMatrix("integrations", (t, { it, expect, describe }) => {
             );
           }),
         ),
-        { route: "/api/hello" },
       );
       expressApp.use("/api", toNodeHandler(t.app) as any);
 
@@ -92,13 +90,14 @@ describeMatrix("integrations", (t, { it, expect, describe }) => {
     it("can be used as connect middleware", async () => {
       const connectApp = createConnectApp();
       t.app.use(
+        "/api/hello",
         fromNodeHandler((_req, res, next) => {
           (res as any).prop = "42";
           next?.();
         }),
-        { route: "/api/hello" },
       );
       t.app.use(
+        "/api/hello",
         fromNodeHandler(
           defineNodeHandler((req, res) => {
             res.end(
@@ -109,7 +108,6 @@ describeMatrix("integrations", (t, { it, expect, describe }) => {
             );
           }),
         ),
-        { route: "/api/hello" },
       );
       connectApp.use("/api", toNodeHandler(t.app));
 
@@ -124,7 +122,7 @@ describeMatrix("integrations", (t, { it, expect, describe }) => {
         "/hello",
         (event) => event.url.searchParams.get("x") ?? "hello",
       );
-      t.app.use(withBase("/api", router), { route: "/api/**" });
+      t.app.use("/api/**", withBase("/api", router));
       connectApp.use("/api", toNodeHandler(t.app));
 
       const res = await t.fetch("/api/hello/?x=y");

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -30,6 +30,7 @@ describeMatrix("middleware", (t, { it, expect }) => {
     });
 
     t.app.use(
+      "/test/**",
       new H3().all("/test", (event) =>
         event.req.headers.has("x-async")
           ? Promise.resolve("Hello World!")
@@ -37,7 +38,6 @@ describeMatrix("middleware", (t, { it, expect }) => {
       ),
       {
         method: "GET",
-        route: "/test/**",
         match: (event) => !event.req.headers.has("x-skip"),
       },
     );
@@ -56,11 +56,13 @@ describeMatrix("middleware", (t, { it, expect }) => {
           };
         },
       }),
-      [
-        (event) => {
-          event.context._middleware.push(`route (register)`);
-        },
-      ],
+      {
+        middleware: [
+          (event) => {
+            event.context._middleware.push(`route (register)`);
+          },
+        ],
+      },
     );
   });
 
@@ -114,12 +116,5 @@ describeMatrix("middleware", (t, { it, expect }) => {
     const response = await t.app.fetch("/test/...");
     expect(response.status).toBe(200);
     expect(await response.json()).toMatchObject({ log: expect.any(String) });
-  });
-
-  it("mounting invalid middleware", async () => {
-    const app = new H3();
-    expect(() => app.use({} as any)).toThrowError(
-      "Invalid middleware: [object Object]",
-    );
   });
 });


### PR DESCRIPTION
Update usage of middleware, partially revert some recent breaking changes.

- `app.use(fn, opts?)` or `app.use(route, fn, opts?)` (similar to v1)
- `app.[method](route, handler, { middleware? })`