### PR TITLE
refactor: make `app.fetch` matching `fetch`

### DIFF
--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -25,7 +25,7 @@ export function toWebHandler(
   app: H3,
 ): (request: Request, context?: H3Event) => Promise<Response> {
   return (request, context) => {
-    return Promise.resolve(app.fetch(request, undefined, context));
+    return Promise.resolve(app._fetch(request, undefined, context));
   };
 }
 

--- a/src/h3.ts
+++ b/src/h3.ts
@@ -44,6 +44,17 @@ export const H3 = /* @__PURE__ */ (() => {
     }
 
     fetch(
+      request: Request | URL | string,
+      options?: RequestInit,
+    ): Promise<Response> {
+      try {
+        return Promise.resolve(this._fetch(request, options));
+      } catch (error: any) {
+        return Promise.reject(error);
+      }
+    }
+
+    _fetch(
       _request: Request | URL | string,
       options?: RequestInit,
       context?: H3EventContext,

--- a/src/h3.ts
+++ b/src/h3.ts
@@ -24,7 +24,7 @@ export type H3 = H3Type;
  * Serve the h3 app, automatically handles current runtime behavior.
  */
 export function serve(app: H3, options?: Omit<ServerOptions, "fetch">): Server {
-  return srvxServe({ fetch: app.fetch, ...options });
+  return srvxServe({ fetch: app._fetch, ...options });
 }
 
 export const H3 = /* @__PURE__ */ (() => {

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -58,9 +58,15 @@ export declare class H3 {
    *
    * Input can be a URL, relative path or standard [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object.
    *
-   * Returned value is a standard [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) or a promise resolving to a Response.
+   * Returned value is a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) Promise.
    */
   fetch(
+    _request: Request | URL | string,
+    options?: RequestInit,
+  ): Promise<Response>;
+
+  /** (internal fetch) */
+  _fetch(
     _request: Request | URL | string,
     options?: RequestInit,
     context?: H3EventContext,


### PR DESCRIPTION
`app.fetch` in v2 accepts 3rd context param, which is not standard. Also can return non-promise values (because runtime fetch can handle it).

This PR moved it under `app._fetch`, making sure `app.fetch` strictly matches the standard `fetch` signature and behavior.