### PR TITLE
feat(defineEventHandler): support `.fetch` interface

### DIFF
--- a/examples/handler-fetch.mjs
+++ b/examples/handler-fetch.mjs
@@ -1,0 +1,19 @@
+import { defineEventHandler } from "h3"; // 5kB (2kB gzipped)
+
+const log = (event) => {
+  console.log(`[${event.req.method}] ${event.req.url}`);
+};
+
+// ✔ Inferred Types: (event: H3Event<EventHandlerRequest>) => { hello: string; }
+const handler = defineEventHandler({
+  // ✔ Request middleware
+  middleware: [log],
+  // ✔ Directly return a value or throw an error
+  handler: () => ({ hello: "world" }),
+});
+
+// ✔ compatible with .fetch API
+// Use for teesting or integrate into any compatible framework and runtime!
+// [GET] http://localhost/test
+// { hello: "world" }
+console.log(await handler.fetch("/test").then((res) => res.json()));

--- a/src/h3.ts
+++ b/src/h3.ts
@@ -56,29 +56,12 @@ export const H3 = /* @__PURE__ */ (() => {
     }
 
     _fetch(
-      _request: Request | URL | string,
-      options?: RequestInit,
+      _req: Request | URL | string,
+      _init?: RequestInit,
       context?: H3EventContext,
     ): Response | Promise<Response> {
-      // Normalize request
-      let request: Request;
-      if (typeof _request === "string") {
-        let url = _request;
-        if (url[0] === "/") {
-          const headers = options?.headers
-            ? new Headers(options.headers)
-            : undefined;
-          const host = headers?.get("host") || "localhost";
-          const proto =
-            headers?.get("x-forwarded-proto") === "https" ? "https" : "http";
-          url = `${proto}://${host}${url}`;
-        }
-        request = new Request(url, options);
-      } else if (options || _request instanceof URL) {
-        request = new Request(_request, options);
-      } else {
-        request = _request;
-      }
+      // Convert the request to a Request object
+      const request: Request = toRequest(_req, _init);
 
       // Create a new event instance
       const event = new H3Event(request, context);
@@ -186,3 +169,23 @@ export const H3 = /* @__PURE__ */ (() => {
 
   return H3;
 })() as unknown as typeof H3Type;
+
+export function toRequest(
+  _request: Request | URL | string,
+  _init?: RequestInit,
+): Request {
+  if (typeof _request === "string") {
+    let url = _request;
+    if (url[0] === "/") {
+      const headers = _init?.headers ? new Headers(_init.headers) : undefined;
+      const host = headers?.get("host") || "localhost";
+      const proto =
+        headers?.get("x-forwarded-proto") === "https" ? "https" : "http";
+      url = `${proto}://${host}${url}`;
+    }
+    return new Request(url, _init);
+  } else if (_init || _request instanceof URL) {
+    return new Request(_request, _init);
+  }
+  return _request as Request;
+}

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,4 +1,7 @@
+import { H3Event } from "./event.ts";
+import { toRequest } from "./h3.ts";
 import { callMiddleware } from "./middleware.ts";
+import { handleResponse } from "./response.ts";
 
 import type {
   EventHandler,
@@ -6,29 +9,56 @@ import type {
   EventHandlerRequest,
   EventHandlerResponse,
   DynamicEventHandler,
+  EventHandlerWithFetch,
 } from "./types/handler.ts";
 
 // --- event handler ---
 
 export function defineEventHandler<
-  Request extends EventHandlerRequest = EventHandlerRequest,
-  Response = EventHandlerResponse,
->(handler: EventHandler<Request, Response>): EventHandler<Request, Response>;
+  Req extends EventHandlerRequest = EventHandlerRequest,
+  Res = EventHandlerResponse,
+>(handler: EventHandler<Req, Res>): EventHandlerWithFetch<Req, Res>;
 
 export function defineEventHandler<
-  Request extends EventHandlerRequest = EventHandlerRequest,
-  Response = EventHandlerResponse,
->(def: EventHandlerObject): EventHandler<Request, Response>;
+  Req extends EventHandlerRequest = EventHandlerRequest,
+  Res = EventHandlerResponse,
+>(def: EventHandlerObject<Req, Res>): EventHandlerWithFetch<Req, Res>;
 
-export function defineEventHandler(arg1: unknown): EventHandler {
+export function defineEventHandler(arg1: unknown): EventHandlerWithFetch {
   if (typeof arg1 === "function") {
-    return arg1 as EventHandler<Request, Response>;
+    return handlerWithFetch(arg1 as EventHandler);
   }
   const { middleware, handler } = arg1 as EventHandlerObject;
   if (!middleware?.length) {
-    return handler;
+    return handlerWithFetch(handler);
   }
-  return (event) => callMiddleware(event, middleware, handler);
+  return handlerWithFetch((event) =>
+    callMiddleware(event, middleware, handler),
+  );
+}
+
+// --- handler .fetch ---
+
+function handlerWithFetch<
+  Req extends EventHandlerRequest = EventHandlerRequest,
+  Res = EventHandlerResponse,
+>(handler: EventHandler<Req, Res>): EventHandlerWithFetch<Req, Res> {
+  return Object.assign(handler, {
+    fetch: (
+      _req: Request | URL | string,
+      _init?: RequestInit,
+    ): Promise<Response> => {
+      const req = toRequest(_req, _init);
+      const event = new H3Event(req);
+      try {
+        return Promise.resolve(handler(event)).then((rawRes) =>
+          handleResponse(rawRes, event),
+        );
+      } catch (error: any) {
+        return Promise.reject(error);
+      }
+    },
+  });
 }
 
 //  --- dynamic event handler ---
@@ -37,22 +67,21 @@ export function dynamicEventHandler(
   initial?: EventHandler,
 ): DynamicEventHandler {
   let current: EventHandler | undefined = initial;
-  const wrapper = defineEventHandler((event) => {
-    if (current) {
-      return current(event);
-    }
-  }) as DynamicEventHandler;
-  wrapper.set = (handler) => {
-    current = handler;
-  };
-  return wrapper;
+  return Object.assign(
+    defineEventHandler((event: H3Event) => current?.(event)),
+    {
+      set: (handler: EventHandler) => {
+        current = handler;
+      },
+    },
+  );
 }
 
 // --- lazy event handler ---
 
 export function defineLazyEventHandler(
   load: () => Promise<EventHandler> | EventHandler,
-): EventHandler {
+): EventHandlerWithFetch {
   let _promise: Promise<typeof _resolved>;
   let _resolved: { handler: EventHandler };
 
@@ -76,12 +105,10 @@ export function defineLazyEventHandler(
     return _promise;
   };
 
-  const handler: EventHandler = (event) => {
+  return defineEventHandler((event) => {
     if (_resolved) {
       return _resolved.handler(event);
     }
     return resolveHandler().then((r) => r.handler(event));
-  };
-
-  return handler;
+  });
 }

--- a/src/response.ts
+++ b/src/response.ts
@@ -11,7 +11,7 @@ export const kHandled: symbol = /* @__PURE__ */ Symbol.for("h3.handled");
 export function handleResponse(
   val: unknown,
   event: H3Event,
-  config: H3Config,
+  config: H3Config = {},
 ): Response | Promise<Response> {
   if (val && val instanceof Promise) {
     return val

--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -4,15 +4,20 @@ import type { H3Event } from "./event.ts";
 //  --- event handler ---
 
 export type EventHandler<
-  Request extends EventHandlerRequest = EventHandlerRequest,
-  Response extends EventHandlerResponse = EventHandlerResponse,
-> = (event: H3Event<Request>) => Response;
+  Req extends EventHandlerRequest = EventHandlerRequest,
+  Res extends EventHandlerResponse = EventHandlerResponse,
+> = (event: H3Event<Req>) => Res;
+
+export type EventHandlerFetch = (
+  req: Request | URL | string,
+  init?: RequestInit,
+) => Promise<Response>;
 
 export interface EventHandlerObject<
-  Request extends EventHandlerRequest = EventHandlerRequest,
-  Response extends EventHandlerResponse = EventHandlerResponse,
+  Req extends EventHandlerRequest = EventHandlerRequest,
+  Res extends EventHandlerResponse = EventHandlerResponse,
 > {
-  handler: EventHandler<Request, Response>;
+  handler: EventHandler<Req, Res>;
   middleware?: Middleware[];
 }
 
@@ -23,6 +28,13 @@ export interface EventHandlerRequest {
 }
 
 export type EventHandlerResponse<T = unknown> = T | Promise<T>;
+
+export type EventHandlerWithFetch<
+  Req extends EventHandlerRequest = EventHandlerRequest,
+  Res extends EventHandlerResponse = EventHandlerResponse,
+> = EventHandler<Req, Res> & {
+  fetch: EventHandlerFetch;
+};
 
 //  --- middleware ---
 
@@ -35,7 +47,7 @@ export type Middleware = (
 
 export type LazyEventHandler = () => EventHandler | Promise<EventHandler>;
 
-export interface DynamicEventHandler extends EventHandler {
+export interface DynamicEventHandler extends EventHandlerWithFetch {
   set: (handler: EventHandler) => void;
 }
 

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -6,7 +6,7 @@ import zlib from "node:zlib";
 const inspect = !!process.env.BUNDLE_INSPECT;
 
 describe("benchmark", () => {
-  it("bundle size", async () => {
+  it("bundle size (H3)", async () => {
     const code = /* js */ `
       import { H3 } from "../../src/index.ts";
       const app = new H3();
@@ -16,10 +16,30 @@ describe("benchmark", () => {
       return;
     }
     if (process.env.DEBUG) {
-      console.log(`Bundle size:${bundle.bytes} (gzip: ${bundle.gzipSize})`);
+      console.log(
+        `Bundle size (H3): ${bundle.bytes} (gzip: ${bundle.gzipSize})`,
+      );
     }
     expect(bundle.bytes).toBeLessThanOrEqual(11_000); // <11kb
     expect(bundle.gzipSize).toBeLessThanOrEqual(4000); // <4kb
+  });
+
+  it("bundle size (defineEventHandler)", async () => {
+    const code = /* js */ `
+      import { defineEventHandler } from "h3";
+      const handler = defineEventHandler({});
+    `;
+    const bundle = await getBundleSize(code);
+    if (inspect) {
+      return;
+    }
+    if (process.env.DEBUG) {
+      console.log(
+        `Bundle size (defineEventHandler): ${bundle.bytes} (gzip: ${bundle.gzipSize})`,
+      );
+    }
+    expect(bundle.bytes).toBeLessThanOrEqual(5200); // <5.2kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(2200); // <2.2kb
   });
 });
 


### PR DESCRIPTION
Reuse existing composable internals to enable event handlers defined with `defineEventHandler` directly be a usable `.fetch`-able interface!

Thanks to initial inspiration from @productdevbook since he was asking how to just use the (value => Response) part of h3 ❤️ 

```js
import { defineEventHandler } from "h3"; // 5kB (2kB gzipped)

const log = (event) => {
  console.log(`[${event.req.method}] ${event.req.url}`);
};

// ✔ Inferred Types: (event: H3Event<EventHandlerRequest>) => { hello: string; }
const handler = defineEventHandler({
  // ✔ Request middleware
  middleware: [log],
  // ✔ Directly return a value or throw an error
  handler: () => ({ hello: "world" }),
});

// ✔ compatible with .fetch API
// Use for teesting or integrate into any compatible framework and runtime!
// [GET] http://localhost/test
// { hello: "world" }
console.log(await handler.fetch("/test").then((res) => res.json()));
```