### PR TITLE
refactor(serveStatic): check mtime before etag

### DIFF
--- a/src/utils/static.ts
+++ b/src/utils/static.ts
@@ -117,18 +117,6 @@ export async function serveStatic(
     throw new HTTPError({ statusCode: 404 });
   }
 
-  if (meta.etag && !event.res.headers.has("etag")) {
-    event.res.headers.set("etag", meta.etag);
-  }
-
-  const ifNotMatch =
-    meta.etag && event.req.headers.get("if-none-match") === meta.etag;
-  if (ifNotMatch) {
-    event.res.status = 304;
-    event.res.statusText = "Not Modified";
-    return "";
-  }
-
   if (meta.mtime) {
     const mtimeDate = new Date(meta.mtime);
 
@@ -142,6 +130,18 @@ export async function serveStatic(
     if (!event.res.headers.get("last-modified")) {
       event.res.headers.set("last-modified", mtimeDate.toUTCString());
     }
+  }
+
+  if (meta.etag && !event.res.headers.has("etag")) {
+    event.res.headers.set("etag", meta.etag);
+  }
+
+  const ifNotMatch =
+    meta.etag && event.req.headers.get("if-none-match") === meta.etag;
+  if (ifNotMatch) {
+    event.res.status = 304;
+    event.res.statusText = "Not Modified";
+    return "";
   }
 
   if (meta.type && !event.res.headers.get("content-type")) {


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

I think we should check mtime first and then ETag. 

Because when generating ETag, we always need to read the file content and perform heavy CPU computations. 
In contrast, checking mtime only requires accessing the file's modification time metadata.

There are no breaking changes - just a logical order adjustment. 
It's a small change, but it dramatically improves service performance.