### PR TITLE
refactor: `defineEventHandler` => `defineHandler`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -125,7 +125,7 @@ H3 v2 deprecated some legacy and aliased utilities.
 
 ### Handler utils
 
-- `eventHandler`: Migrate to `defineEventHandler` (or remove it!).
+- `eventHandler`/`defineEventHandler`: Migrate to `defineHandler` (you can also directly use a function!).
 - `lazyEventHandler`: Migrate to `defineLazyEventHandler`.
 - `toEventHandler`: Remove wrapper.
 - `isEventHandler`: (removed) Any function can be an event handler.

--- a/docs/1.guide/1.basics/4.handler.md
+++ b/docs/1.guide/1.basics/4.handler.md
@@ -6,26 +6,26 @@ icon: mdi:function
 
 > An event handler is a function that receives an H3Event and returns a response.
 
-You can define typed event handlers using `defineEventHandler`.
+You can define typed event handlers using `defineHandler`.
 
 ```js
-import { H3, defineEventHandler } from "h3";
+import { H3, defineHandler } from "h3";
 
 const app = new H3();
 
-const handler = defineEventHandler((event) => "Response");
+const handler = defineHandler((event) => "Response");
 
 app.get("/", handler);
 ```
 
 > [!NOTE]
-> Using `defineEventHandler` is optional.
+> Using `defineHandler` is optional.
 > You can instead, simply use a function that accepts an [`H3Event`](/guide/api/h3event) and returns a response.
 
 The callback function can be sync or async:
 
 ```js
-defineEventHandler(async (event) => "Response");
+defineHandler(async (event) => "Response");
 ```
 
 You can optionally register some [middleware](/guide/basics/middleware) to run with event handler to intercept request, response or errors.
@@ -33,7 +33,7 @@ You can optionally register some [middleware](/guide/basics/middleware) to run w
 ```js
 import { basicAuth } from "h3";
 
-defineEventHandler({
+defineHandler({
   middleware: [basicAuth({ password: "test" })],
   handler: (event) => "Hi!",
 });
@@ -45,12 +45,10 @@ defineEventHandler({
 
 ## Handler `.fetch`
 
-Event handlers defined with `defineEventHandler`, can act as a web handler without even using [H3](/guide/api/h3) class.
+Event handlers defined with `defineHandler`, can act as a web handler without even using [H3](/guide/api/h3) class.
 
 ```js
-const handler = defineEventHandler(
-  async (event) => `Request: ${event.req.url}`,
-);
+const handler = defineHandler(async (event) => `Request: ${event.req.url}`);
 
 const response = await handler.fetch("http://localhost/");
 console.log(response, await response.text());
@@ -91,9 +89,9 @@ app.all(
 ```
 
 ```js [route.mjs]
-import { defineEventHandler } from "h3";
+import { defineHandler } from "h3";
 
-export default defineEventHandler((event) => "Hello!");
+export default defineHandler((event) => "Hello!");
 ```
 
 ## Converting to Handler

--- a/docs/1.guide/1.basics/5.response.md
+++ b/docs/1.guide/1.basics/5.response.md
@@ -11,7 +11,7 @@ Values returned from [Event Handlers](/guide/basics/handler) are automatically c
 **Example:** Simple event handler function.
 
 ```js
-const handler = defineEventHandler((event) => ({ hello: "world" }));
+const handler = defineHandler((event) => ({ hello: "world" }));
 ```
 
 H3 smartly converts handler into:
@@ -39,7 +39,7 @@ If an error is thrown, H3 automatically handles it with error handler.
 Before returning a response in main handler, you can prepare response headers and status using [`event.res`](/guide/api/h3event#eventres).
 
 ```js
-defineEventHandler((event) => {
+defineHandler((event) => {
   event.res.status = 200;
   event.res.statusText = "OK";
   event.res.headers.set("Content-Type", "text/html");

--- a/docs/2.utils/4.security.md
+++ b/docs/2.utils/4.security.md
@@ -30,8 +30,8 @@ Apply basic authentication for current request.
 **Example:**
 
 ```ts
-import { defineEventHandler, requireBasicAuth } from "h3";
-export default defineEventHandler(async (event) => {
+import { defineHandler, requireBasicAuth } from "h3";
+export default defineHandler(async (event) => {
   await requireBasicAuth(event, { password: "test" });
   return `Hello, ${event.context.basicAuth.username}!`;
 });

--- a/docs/99.blog/1.v1.8.md
+++ b/docs/99.blog/1.v1.8.md
@@ -60,7 +60,7 @@ H3 now supports native [Readable Stream](https://developer.mozilla.org/en-US/doc
 Leveraging this functionality is straightforward—simply return a [Readable Stream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) or [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) object from your event handlers.
 
 ```ts
-export default defineEventHandler((event) => {
+export default defineHandler((event) => {
   setResponseHeader(event, "Content-Type", "text/html");
   const encoder = new TextEncoder();
   const stream = new ReadableStream({
@@ -128,7 +128,7 @@ const userSchema = z.object({
   email: z.string().email(),
 });
 
-export default defineEventHandler(async (event) => {
+export default defineHandler(async (event) => {
   const result = await readValidatedBody(event, (body) =>
     userSchema.safeParse(body),
   ); // or `.parse` to directly throw an error

--- a/examples/handler-fetch.mjs
+++ b/examples/handler-fetch.mjs
@@ -1,11 +1,11 @@
-import { defineEventHandler } from "h3"; // 5kB (2kB gzipped)
+import { defineHandler } from "h3"; // 5kB (2kB gzipped)
 
 const log = (event) => {
   console.log(`[${event.req.method}] ${event.req.url}`);
 };
 
 // ✔ Inferred Types: (event: H3Event<EventHandlerRequest>) => { hello: string; }
-const handler = defineEventHandler({
+const handler = defineHandler({
   // ✔ Request middleware
   middleware: [log],
   // ✔ Directly return a value or throw an error

--- a/examples/handler-obj.mjs
+++ b/examples/handler-obj.mjs
@@ -1,10 +1,10 @@
-import { H3, serve, defineEventHandler } from "h3";
+import { H3, serve, defineHandler } from "h3";
 
 export const app = new H3();
 
 app.get(
   "/",
-  defineEventHandler({
+  defineHandler({
     onRequest: () => {
       // Do anything you want here like authentication, rate limiting, etc.
       console.log("onRequest");

--- a/src/_deprecated.ts
+++ b/src/_deprecated.ts
@@ -4,7 +4,7 @@ import {
   fromNodeHandler,
   toNodeHandler,
 } from "./adapters.ts";
-import { defineEventHandler, defineLazyEventHandler } from "./handler.ts";
+import { defineHandler, defineLazyEventHandler } from "./handler.ts";
 import { proxy, type ProxyOptions } from "./utils/proxy.ts";
 import { H3 } from "./h3.ts";
 import { withBase } from "./utils/base.ts";
@@ -292,9 +292,13 @@ export function clearResponseHeaders(
 
 // -- Event handler --
 
-/** Please use `defineEventHandler`  */
+/** Please use `defineHandler`  */
+export const defineEventHandler: (handler: EventHandler) => EventHandler =
+  defineHandler;
+
+/** Please use `defineHandler`  */
 export const eventHandler: (handler: EventHandler) => EventHandler =
-  defineEventHandler;
+  defineHandler;
 
 /** Please use `defineLazyEventHandler` */
 export const lazyEventHandler: (

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -14,17 +14,17 @@ import type {
 
 // --- event handler ---
 
-export function defineEventHandler<
+export function defineHandler<
   Req extends EventHandlerRequest = EventHandlerRequest,
   Res = EventHandlerResponse,
 >(handler: EventHandler<Req, Res>): EventHandlerWithFetch<Req, Res>;
 
-export function defineEventHandler<
+export function defineHandler<
   Req extends EventHandlerRequest = EventHandlerRequest,
   Res = EventHandlerResponse,
 >(def: EventHandlerObject<Req, Res>): EventHandlerWithFetch<Req, Res>;
 
-export function defineEventHandler(arg1: unknown): EventHandlerWithFetch {
+export function defineHandler(arg1: unknown): EventHandlerWithFetch {
   if (typeof arg1 === "function") {
     return handlerWithFetch(arg1 as EventHandler);
   }
@@ -68,7 +68,7 @@ export function dynamicEventHandler(
 ): DynamicEventHandler {
   let current: EventHandler | undefined = initial;
   return Object.assign(
-    defineEventHandler((event: H3Event) => current?.(event)),
+    defineHandler((event: H3Event) => current?.(event)),
     {
       set: (handler: EventHandler) => {
         current = handler;
@@ -105,7 +105,7 @@ export function defineLazyEventHandler(
     return _promise;
   };
 
-  return defineEventHandler((event) => {
+  return defineHandler((event) => {
     if (_resolved) {
       return _resolved.handler(event);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export type {
 } from "./types/handler.ts";
 
 export {
-  defineEventHandler,
+  defineHandler,
   defineLazyEventHandler,
   dynamicEventHandler,
 } from "./handler.ts";

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -36,8 +36,8 @@ export type BasicAuthOptions = Partial<_BasicAuthOptions> &
  * Apply basic authentication for current request.
  *
  * @example
- * import { defineEventHandler, requireBasicAuth } from "h3";
- * export default defineEventHandler(async (event) => {
+ * import { defineHandler, requireBasicAuth } from "h3";
+ * export default defineHandler(async (event) => {
  *   await requireBasicAuth(event, { password: "test" });
  *   return `Hello, ${event.context.basicAuth.username}!`;
  * });

--- a/src/utils/ws.ts
+++ b/src/utils/ws.ts
@@ -1,4 +1,4 @@
-import { defineEventHandler } from "../handler.ts";
+import { defineHandler } from "../handler.ts";
 
 import type { Hooks as WSHooks } from "crossws";
 import type { EventHandler } from "../types/handler.ts";
@@ -18,7 +18,7 @@ export function defineWebSocket(hooks: Partial<WSHooks>): Partial<WSHooks> {
  * @see https://h3.dev/guide/websocket
  */
 export function defineWebSocketHandler(hooks: Partial<WSHooks>): EventHandler {
-  return defineEventHandler(() => {
+  return defineHandler(() => {
     return Object.assign(
       new Response("WebSocket upgrade is required.", {
         status: 426,

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -24,10 +24,10 @@ describe("benchmark", () => {
     expect(bundle.gzipSize).toBeLessThanOrEqual(4000); // <4kb
   });
 
-  it("bundle size (defineEventHandler)", async () => {
+  it("bundle size (defineHandler)", async () => {
     const code = /* js */ `
-      import { defineEventHandler } from "h3";
-      const handler = defineEventHandler({});
+      import { defineHandler } from "h3";
+      const handler = defineHandler({});
     `;
     const bundle = await getBundleSize(code);
     if (inspect) {
@@ -35,7 +35,7 @@ describe("benchmark", () => {
     }
     if (process.env.DEBUG) {
       console.log(
-        `Bundle size (defineEventHandler): ${bundle.bytes} (gzip: ${bundle.gzipSize})`,
+        `Bundle size (defineHandler): ${bundle.bytes} (gzip: ${bundle.gzipSize})`,
       );
     }
     expect(bundle.bytes).toBeLessThanOrEqual(5300); // <5.3kb

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import {
-  defineEventHandler,
+  defineHandler,
   dynamicEventHandler,
   defineLazyEventHandler,
 } from "../src/index.ts";
@@ -8,17 +8,17 @@ import {
 import type { H3Event } from "../src/types/event.ts";
 
 describe("handler.ts", () => {
-  describe("defineEventHandler", () => {
+  describe("defineHandler", () => {
     it("should return the handler function when passed a function", () => {
       const handler = vi.fn();
-      const eventHandler = defineEventHandler(handler);
+      const eventHandler = defineHandler(handler);
       expect(eventHandler).toBe(handler);
     });
 
     it("object syntax", () => {
       const handler = vi.fn();
       const middleware = [vi.fn()];
-      const eventHandler = defineEventHandler({ handler, middleware });
+      const eventHandler = defineHandler({ handler, middleware });
       eventHandler({} as H3Event);
       expect(middleware[0]).toHaveBeenCalled();
       expect(handler).toHaveBeenCalled();

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach } from "vitest";
 import { describeMatrix } from "./_setup.ts";
 import { H3 } from "../src/h3.ts";
-import { defineEventHandler } from "../src/handler.ts";
+import { defineHandler } from "../src/handler.ts";
 
 describeMatrix("middleware", (t, { it, expect }) => {
   beforeEach(() => {
@@ -44,7 +44,7 @@ describeMatrix("middleware", (t, { it, expect }) => {
 
     t.app.get(
       "/**",
-      defineEventHandler({
+      defineHandler({
         middleware: [
           (event) => {
             event.context._middleware.push(`route (define)`);

--- a/test/unit/package.test.ts
+++ b/test/unit/package.test.ts
@@ -27,6 +27,7 @@ describe("h3 package", () => {
         "createRouter",
         "defaultContentType",
         "defineEventHandler",
+        "defineHandler",
         "defineLazyEventHandler",
         "defineMiddleware",
         "defineNodeHandler",

--- a/test/unit/types.test-d.ts
+++ b/test/unit/types.test-d.ts
@@ -2,7 +2,7 @@
 import type { H3Event } from "../../src/index.ts";
 import { describe, it, expectTypeOf } from "vitest";
 import {
-  defineEventHandler,
+  defineHandler,
   getQuery,
   readBody,
   readValidatedBody,
@@ -12,7 +12,7 @@ import {
 describe("types", () => {
   describe("eventHandler", () => {
     it("return type (inferred)", () => {
-      const handler = defineEventHandler(() => {
+      const handler = defineHandler(() => {
         return {
           foo: "bar",
         };
@@ -24,14 +24,14 @@ describe("types", () => {
 
   describe("readBody", () => {
     it("untyped", () => {
-      defineEventHandler(async (event) => {
+      defineHandler(async (event) => {
         const body = await readBody(event);
         expectTypeOf(body).toBeUnknown;
       });
     });
 
     it("typed via generic", () => {
-      defineEventHandler(async (event) => {
+      defineHandler(async (event) => {
         const body = await readBody<string>(event);
         expectTypeOf(body).not.toBeAny;
         expectTypeOf(body!).toBeString;
@@ -39,7 +39,7 @@ describe("types", () => {
     });
 
     it("typed via validator", () => {
-      defineEventHandler(async (event) => {
+      defineHandler(async (event) => {
         const validator = (body: unknown) => body as { id: string };
         const body = await readValidatedBody(event, validator);
         expectTypeOf(body).not.toBeAny;
@@ -48,7 +48,7 @@ describe("types", () => {
     });
 
     it("typed via event handler", () => {
-      defineEventHandler<{ body: { id: string } }>(async (event) => {
+      defineHandler<{ body: { id: string } }>(async (event) => {
         const body = await readBody(event);
         expectTypeOf(body).not.toBeAny;
         expectTypeOf(body).toEqualTypeOf<{ id: string } | undefined>();
@@ -58,7 +58,7 @@ describe("types", () => {
 
   describe("getQuery", () => {
     it("untyped", () => {
-      defineEventHandler((event) => {
+      defineHandler((event) => {
         const query = getQuery(event);
         expectTypeOf(query).not.toBeAny;
         expectTypeOf(query).toEqualTypeOf<Record<string, string>>();
@@ -66,7 +66,7 @@ describe("types", () => {
     });
 
     it("typed via generic", () => {
-      defineEventHandler((event) => {
+      defineHandler((event) => {
         const query = getQuery<{ id: string }>(event);
         expectTypeOf(query).not.toBeAny;
         expectTypeOf(query).toEqualTypeOf<{ id: string }>();
@@ -74,7 +74,7 @@ describe("types", () => {
     });
 
     it("typed via validator", () => {
-      defineEventHandler(async (event) => {
+      defineHandler(async (event) => {
         const validator = (body: unknown) => body as { id: string };
         const body = await getValidatedQuery(event, validator);
         expectTypeOf(body).not.toBeAny;
@@ -83,7 +83,7 @@ describe("types", () => {
     });
 
     it("typed via event handler", () => {
-      defineEventHandler<{ query: { id: string } }>((event) => {
+      defineHandler<{ query: { id: string } }>((event) => {
         const query = getQuery(event);
         expectTypeOf(query).not.toBeAny;
         expectTypeOf(query).toEqualTypeOf<{ id: string }>();


### PR DESCRIPTION
Rename `defineEventHandler` to a shorter `defineHandler` for usage. (deprecated export exists for BW compat)