### PR TITLE
refactor: `onBeforeResponse` => `onResponse`

### DIFF
--- a/docs/1.guide/1.basics/1.lifecycle.md
+++ b/docs/1.guide/1.basics/1.lifecycle.md
@@ -55,12 +55,12 @@ click C2 "/guide/basics/middleware"
 
 ## 4. Send Response
 
-H3 [converts](/guide/basics/response#response-types) returned value and [prepared headers](/guide/basics/response#preparing-response) into a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response), calls [`onBeforeResponse`](/guide/api/h3#global-hooks) global hook and finally returns response back to the server fetch handler.
+H3 [converts](/guide/basics/response#response-types) returned value and [prepared headers](/guide/basics/response#preparing-response) into a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response), calls [`onResponse`](/guide/api/h3#global-hooks) global hook and finally returns response back to the server fetch handler.
 
 ```mermaid
 %%{init: {'theme':'neutral'}}%%
 flowchart LR
- D1["Returned Value => Response"] --> D2["<code>onBeforeResponse(response)</code>"] --> D3["Response"]
+ D1["Returned Value => Response"] --> D2["<code>onResponse(response)</code>"] --> D3["Response"]
 
 click D1 "/guide/basics/response"
 click D2 "/guide/api/h3#global-hooks"

--- a/docs/1.guide/900.api/1.h3.md
+++ b/docs/1.guide/900.api/1.h3.md
@@ -133,7 +133,7 @@ When initializing an H3 app, you can register global hooks:
 
 - `onError`
 - `onRequest`
-- `onBeforeResponse`
+- `onResponse`
 
 These hooks are called for every request and can be used to add global logic to your app such as logging, error handling, etc.
 
@@ -145,7 +145,7 @@ const app = new H3({
   onRequest: (event) => {
     console.log("Request:", event.path);
   },
-  onBeforeResponse: (event) => {
+  onResponse: (event) => {
     console.log("Response:", event.path);
   },
 });

--- a/docs/99.blog/1.v1.8.md
+++ b/docs/99.blog/1.v1.8.md
@@ -94,7 +94,7 @@ const compression = defineResponseMiddleware((event) => {
 
 export default eventHandler({
   onRequest: [auth],
-  onBeforeResponse: [compression],
+  onResponse: [compression],
   async handler(event) {
     return `Hello ${event.context.auth?.name || "Guest"}`;
   },

--- a/examples/handler-obj.mjs
+++ b/examples/handler-obj.mjs
@@ -10,7 +10,7 @@ app.get(
       console.log("onRequest");
       // Never return anything from onRequest to avoid to close the connection
     },
-    onBeforeResponse: () => {
+    onResponse: () => {
       // Do anything you want here like logging, collecting metrics, or output compression, etc.
       console.log("onResponse");
       // Never return anything from onResponse to avoid to close the connection

--- a/src/response.ts
+++ b/src/response.ts
@@ -24,9 +24,9 @@ export function handleResponse(
     return handleResponse(response, event, config);
   }
 
-  const { onBeforeResponse } = config;
-  return onBeforeResponse
-    ? Promise.resolve(onBeforeResponse(event, response)).then(() => response)
+  const { onResponse } = config;
+  return onResponse
+    ? Promise.resolve(onResponse(event, response)).then(() => response)
     : response;
 }
 

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -15,7 +15,7 @@ export interface H3Config {
 
   onError?: (error: HTTPError, event: H3Event) => MaybePromise<void | unknown>;
   onRequest?: (event: H3Event) => MaybePromise<void>;
-  onBeforeResponse?: (
+  onResponse?: (
     event: H3Event,
     response: Response | PreparedResponse,
   ) => MaybePromise<void>;

--- a/test/_setup.ts
+++ b/test/_setup.ts
@@ -139,7 +139,7 @@ function setupBaseTest(
     ctx.hooks = {
       onRequest: vi.fn(),
       onError: vi.fn(),
-      onBeforeResponse: vi.fn(),
+      onResponse: vi.fn(),
     };
 
     ctx.errors = [];
@@ -154,7 +154,7 @@ function setupBaseTest(
       debug: true,
       onError: ctx.hooks.onError,
       onRequest: ctx.hooks.onRequest,
-      onBeforeResponse: ctx.hooks.onBeforeResponse,
+      onResponse: ctx.hooks.onResponse,
     });
   });
 
@@ -190,7 +190,7 @@ export interface TestContext {
   hooks: {
     onRequest: Mock<Exclude<H3Config["onRequest"], undefined>>;
     onError: Mock<Exclude<H3Config["onError"], undefined>>;
-    onBeforeResponse: Mock<Exclude<H3Config["onBeforeResponse"], undefined>>;
+    onResponse: Mock<Exclude<H3Config["onResponse"], undefined>>;
   };
 
   target: "web" | "node";

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -12,11 +12,11 @@ describeMatrix("hooks", (t, { it, expect }) => {
 
     expect(t.hooks.onError).toHaveBeenCalledTimes(0);
 
-    expect(t.hooks.onBeforeResponse).toHaveBeenCalledTimes(1);
+    expect(t.hooks.onResponse).toHaveBeenCalledTimes(1);
 
     // In Node.js, srvx garbage collects the response body after preparing it for Node.js
     if (t.target !== "node") {
-      const res = t.hooks.onBeforeResponse.mock.calls[0]![1]!;
+      const res = t.hooks.onResponse.mock.calls[0]![1]!;
       const resBody = res instanceof Response ? await res.text() : res.body;
       expect(resBody).toBe("Hello World!");
     }
@@ -35,7 +35,7 @@ describeMatrix("hooks", (t, { it, expect }) => {
     expect(t.hooks.onError.mock.calls[0]![0]!.status).toBe(503);
     expect(t.hooks.onError.mock.calls[0]![1]!.path).toBe("/foo");
 
-    expect(t.hooks.onBeforeResponse).toHaveBeenCalledTimes(1);
+    expect(t.hooks.onResponse).toHaveBeenCalledTimes(1);
   });
 
   it("calls onRequest and onResponse when an error is thrown", async () => {
@@ -51,7 +51,7 @@ describeMatrix("hooks", (t, { it, expect }) => {
     expect(t.hooks.onError.mock.calls[0]![0]!.status).toBe(404);
     expect(t.hooks.onError.mock.calls[0]![1]!.path).toBe("/foo");
 
-    expect(t.hooks.onBeforeResponse).toHaveBeenCalledTimes(1);
+    expect(t.hooks.onResponse).toHaveBeenCalledTimes(1);
   });
 
   it("calls onRequest and onResponse when an unhandled error occurs", async () => {
@@ -77,6 +77,6 @@ describeMatrix("hooks", (t, { it, expect }) => {
     expect(t.hooks.onError.mock.calls[0]![0]!.cause).toBeInstanceOf(TypeError);
     expect(t.hooks.onError.mock.calls[0]![1]!.path).toBe("/foo");
 
-    expect(t.hooks.onBeforeResponse).toHaveBeenCalledTimes(1);
+    expect(t.hooks.onResponse).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Rename `onBeforeResponse` (global hook and middleware) to `onResponse`.

Reasons:
- More consistent with other hooks `onRequest`/`onError`
- Shorter
- Less confusing somehow because `onAfterResponse` does not makes any sense in web standards (there is `event.waitUntil` does goes _in parallel_ to and after response)