### PR TITLE
refactor: use `ServerRequest`

### DIFF
--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -2,7 +2,11 @@ import { toNodeHandler as _toNodeHandler } from "srvx/node";
 import { HTTPError } from "./error.ts";
 import { kHandled } from "./response.ts";
 
-import type { NodeServerRequest, NodeServerResponse } from "srvx/types";
+import type {
+  NodeServerRequest,
+  NodeServerResponse,
+  ServerRequest,
+} from "srvx/types";
 import type { H3 } from "./h3.ts";
 import type { H3Event, H3EventContext } from "./types/event.ts";
 import type { EventHandler, EventHandlerResponse } from "./types/handler.ts";
@@ -23,14 +27,17 @@ export type NodeMiddleware = (
  */
 export function toWebHandler(
   app: H3,
-): (request: Request, context?: H3Event) => Promise<Response> {
+): (request: ServerRequest, context?: H3Event) => Promise<Response> {
   return (request, context) => {
     return Promise.resolve(app._fetch(request, undefined, context));
   };
 }
 
 export function fromWebHandler(
-  handler: (request: Request, context?: H3EventContext) => Promise<Response>,
+  handler: (
+    request: ServerRequest,
+    context?: H3EventContext,
+  ) => Promise<Response>,
 ): EventHandler {
   return (event) => handler(event.req, event.context);
 }

--- a/src/h3.ts
+++ b/src/h3.ts
@@ -15,6 +15,7 @@ import type {
   RouteHandler,
   MiddlewareOptions,
 } from "./types/h3.ts";
+import type { ServerRequest } from "srvx/types";
 
 export type H3 = H3Type;
 
@@ -36,7 +37,7 @@ export const H3 = /* @__PURE__ */ (() => {
     }
 
     fetch(
-      request: Request | URL | string,
+      request: ServerRequest | URL | string,
       options?: RequestInit,
     ): Promise<Response> {
       try {
@@ -47,12 +48,12 @@ export const H3 = /* @__PURE__ */ (() => {
     }
 
     _fetch(
-      _req: Request | URL | string,
+      _req: ServerRequest | URL | string,
       _init?: RequestInit,
       context?: H3EventContext,
     ): Response | Promise<Response> {
       // Convert the request to a Request object
-      const request: Request = toRequest(_req, _init);
+      const request: ServerRequest = toRequest(_req, _init);
 
       // Create a new event instance
       const event = new H3Event(request, context);
@@ -162,9 +163,9 @@ export const H3 = /* @__PURE__ */ (() => {
 })() as unknown as typeof H3Type;
 
 export function toRequest(
-  _request: Request | URL | string,
+  _request: ServerRequest | URL | string,
   _init?: RequestInit,
-): Request {
+): ServerRequest {
   if (typeof _request === "string") {
     let url = _request;
     if (url[0] === "/") {
@@ -178,5 +179,5 @@ export function toRequest(
   } else if (_init || _request instanceof URL) {
     return new Request(_request, _init);
   }
-  return _request as Request;
+  return _request;
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,3 +1,4 @@
+import type { ServerRequest } from "srvx/types";
 import { H3Event } from "./event.ts";
 import { toRequest } from "./h3.ts";
 import { callMiddleware } from "./middleware.ts";
@@ -45,7 +46,7 @@ function handlerWithFetch<
 >(handler: EventHandler<Req, Res>): EventHandlerWithFetch<Req, Res> {
   return Object.assign(handler, {
     fetch: (
-      _req: Request | URL | string,
+      _req: ServerRequest | URL | string,
       _init?: RequestInit,
     ): Promise<Response> => {
       const req = toRequest(_req, _init);

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -64,13 +64,13 @@ export declare class H3 {
    * Returned value is a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) Promise.
    */
   fetch(
-    _request: Request | URL | string,
+    _request: ServerRequest | URL | string,
     options?: RequestInit,
   ): Promise<Response>;
 
   /** (internal fetch) */
   _fetch(
-    _request: Request | URL | string,
+    _request: ServerRequest | URL | string,
     options?: RequestInit,
     context?: H3EventContext,
   ): Response | Promise<Response>;

--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -1,3 +1,4 @@
+import type { ServerRequest } from "srvx/types";
 import type { MaybePromise } from "./_utils.ts";
 import type { H3Event } from "./event.ts";
 
@@ -9,7 +10,7 @@ export type EventHandler<
 > = (event: H3Event<Req>) => Res;
 
 export type EventHandlerFetch = (
-  req: Request | URL | string,
+  req: ServerRequest | URL | string,
   init?: RequestInit,
 ) => Promise<Response>;
 


### PR DESCRIPTION
Use `ServerRequest` from srvx in all places (all addons are fully optional so it should remain type-compatible with `Request` global types)