### PR TITLE
refactor: only accept `request` for `H3.fetch`

### DIFF
--- a/src/h3.ts
+++ b/src/h3.ts
@@ -36,12 +36,9 @@ export const H3 = /* @__PURE__ */ (() => {
       this.handler = this.handler.bind(this);
     }
 
-    fetch(
-      request: ServerRequest | URL | string,
-      options?: RequestInit,
-    ): Promise<Response> {
+    fetch(request: ServerRequest | URL | string): Promise<Response> {
       try {
-        return Promise.resolve(this._fetch(request, options));
+        return Promise.resolve(this._fetch(request));
       } catch (error: any) {
         return Promise.reject(error);
       }

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -63,10 +63,7 @@ export declare class H3 {
    *
    * Returned value is a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) Promise.
    */
-  fetch(
-    _request: ServerRequest | URL | string,
-    options?: RequestInit,
-  ): Promise<Response>;
+  fetch(_request: ServerRequest | URL | string): Promise<Response>;
 
   /** (internal fetch) */
   _fetch(


### PR DESCRIPTION
[Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) signuture is `(req, init?)`; however, no other runtimes agree on this, yet called it `.fetch`...

- Bun: `fetch(request, server)`
- Deno: `fetch(request, info)`
- Cloudflare: `fetch(request, env, ctx)`

It might be safer to have `h3.fetch` strictly only accept a single `(request)`. This also helps avoid wrongly added overhead if one does `export default app.fetch` (which causes recreating `Request` with a second irrelevant arg considered RequestInit)

Downside, it takes away the easy DX of doing `app.fetch("url", { headers: {} })` :(