### PR TITLE
feat:  plugins

### DIFF
--- a/docs/1.guide/900.api/1.h3.md
+++ b/docs/1.guide/900.api/1.h3.md
@@ -70,6 +70,33 @@ const app = new H3()
 
 :read-more{to="/guide/basics/middleware" title="Middleware"}
 
+### `H3.register`
+
+Register a H3 plugin to extend app.
+
+**Example:** Logger plugin.
+
+```js [plugin.mjs]
+import { definePlugin } from "h3";
+
+export const logger = (_options) =>
+  definePlugin((h3) => {
+    if (h3.config.debug) {
+      h3.use((req) => {
+        console.log(`[${req.method}] ${req.url}`);
+      });
+    }
+  });
+```
+
+```js [app.mjs]
+import { H3 } from "h3";
+
+const app = new H3({ debug: true })
+  .register(logger())
+  .all("/**", () => "Hello!");
+```
+
 ### `H3.handler`
 
 An H3 [event handler](/guide/basics/handler) useful to compose multiple H3 app instances.
@@ -117,6 +144,11 @@ const app = new H3()
 ## `H3` Options
 
 You can pass global app configuration when initializing an app.
+
+Supported options:
+
+- `debug`
+- `plugins`: (see [`app.register`](#h3register) for example).
 
 **Example:** Create an app with debug logging enabled.
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,6 +16,7 @@ export default unjs(
       "unicorn/prefer-code-point": "off",
       "unicorn/no-nested-ternary": "off",
       "unicorn/prefer-regexp-test": "off",
+      "unicorn/no-array-for-each": "off",
     },
   },
 );

--- a/examples/plugin.mjs
+++ b/examples/plugin.mjs
@@ -1,0 +1,16 @@
+import { H3, serve, definePlugin } from "h3";
+
+export const logger = (_options) =>
+  definePlugin((h3) => {
+    if (h3.config.debug) {
+      h3.use((req) => {
+        console.log(`[${req.method}] ${req.url}`);
+      });
+    }
+  });
+
+const app = new H3({ debug: true })
+  .register(logger())
+  .all("/**", () => "Hello!");
+
+serve(app);

--- a/src/h3.ts
+++ b/src/h3.ts
@@ -4,7 +4,7 @@ import { handleResponse, kNotFound } from "./response.ts";
 import { callMiddleware, normalizeMiddleware } from "./middleware.ts";
 
 import type { RouterContext } from "rou3";
-import type { FetchHandler, H3Config } from "./types/h3.ts";
+import type { FetchHandler, H3Config, H3Plugin } from "./types/h3.ts";
 import type { H3EventContext } from "./types/event.ts";
 import type { EventHandler, Middleware } from "./types/handler.ts";
 import type {
@@ -77,6 +77,11 @@ export const H3 = /* @__PURE__ */ (() => {
 
       // Prepare response
       return handleResponse(handlerRes, event, this.config);
+    }
+
+    register(plugin: H3Plugin): H3Type {
+      plugin(this as unknown as H3Type);
+      return this as unknown as H3Type;
     }
 
     handler(event: H3Event): unknown | Promise<unknown> {

--- a/src/h3.ts
+++ b/src/h3.ts
@@ -34,6 +34,7 @@ export const H3 = /* @__PURE__ */ (() => {
       this.fetch = this.fetch.bind(this);
       this._fetch = this._fetch.bind(this);
       this.handler = this.handler.bind(this);
+      config.plugins?.forEach((plugin) => plugin(this as unknown as H3Type));
     }
 
     fetch(

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 
 export type {
   H3Config,
+  H3Plugin,
   H3Route,
   HTTPMethod,
   PreparedResponse,
@@ -10,6 +11,8 @@ export type {
   MiddlewareOptions,
   FetchHandler,
 } from "./types/h3.ts";
+
+export { definePlugin } from "./types/h3.ts";
 
 export { H3 } from "./h3.ts";
 

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -13,6 +13,8 @@ export type HTTPMethod =  "GET" | "HEAD" | "PATCH" | "POST" | "PUT" | "DELETE" |
 export interface H3Config {
   debug?: boolean;
 
+  plugins?: H3Plugin[];
+
   onError?: (error: HTTPError, event: H3Event) => MaybePromise<void | unknown>;
   onRequest?: (event: H3Event) => MaybePromise<void>;
   onResponse?: (
@@ -29,6 +31,10 @@ export interface H3Route {
   middleware?: Middleware[];
   handler: EventHandler;
 }
+
+// --- H3 Pluins ---
+
+export type H3Plugin = (h3: H3) => void;
 
 // --- H3 App ---
 

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -36,6 +36,10 @@ export interface H3Route {
 
 export type H3Plugin = (h3: H3) => void;
 
+export function definePlugin(plugin: H3Plugin): H3Plugin {
+  return plugin;
+}
+
 // --- H3 App ---
 
 export type RouteHandler = EventHandler | { handler: EventHandler };
@@ -80,6 +84,11 @@ export declare class H3 {
     options?: RequestInit,
     context?: H3EventContext,
   ): Response | Promise<Response>;
+
+  /**
+   * Immediately register an H3 plugin.
+   */
+  register(plugin: H3Plugin): H3;
 
   /**
    * An h3 compatible event handler useful to compose multiple h3 app instances.

--- a/test/unit/h3.test.ts
+++ b/test/unit/h3.test.ts
@@ -3,8 +3,10 @@ import { H3 } from "../../src/h3.ts";
 
 describe("H3", () => {
   it("plugins work", () => {
-    const plugin = vi.fn();
-    const app = new H3({ plugins: [plugin] });
-    expect(plugin).toHaveBeenCalledWith(app);
+    const pluginA = vi.fn();
+    const pluginB = vi.fn();
+    const app = new H3({ plugins: [pluginA] }).register(pluginB);
+    expect(pluginA).toHaveBeenCalledWith(app);
+    expect(pluginB).toHaveBeenCalledWith(app);
   });
 });

--- a/test/unit/h3.test.ts
+++ b/test/unit/h3.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, vi, expect } from "vitest";
+import { H3 } from "../../src/h3.ts";
+
+describe("H3", () => {
+  it("plugins work", () => {
+    const plugin = vi.fn();
+    const app = new H3({ plugins: [plugin] });
+    expect(plugin).toHaveBeenCalledWith(app);
+  });
+});

--- a/test/unit/package.test.ts
+++ b/test/unit/package.test.ts
@@ -33,6 +33,7 @@ describe("h3 package", () => {
         "defineNodeHandler",
         "defineNodeListener",
         "defineNodeMiddleware",
+        "definePlugin",
         "defineValidatedHandler",
         "defineWebSocket",
         "defineWebSocketHandler",


### PR DESCRIPTION
This PR adds a similar feature to srvx plugins. H3 plugins are essentially a function that hook to H3 app instance and can extend internals, such as adding new routes, global middleware or modifying class behavior for a declarative, reusable system (related to #1088)

Implementation is intentionally kept super minimal to avoid any overhead and maximise possibilities. We might add extendable hooks later to make plugins easier to implement.

**Example:** Logger plugin.

```js [plugin.mjs]
import { definePlugin } from "h3";

export const logger = (_options) =>
  definePlugin((h3) => {
    if (h3.config.debug) {
      h3.use((req) => {
        console.log(`[${req.method}] ${req.url}`);
      });
    }
  });
```

```js [app.mjs]
import { H3 } from "h3";

new H3({ debug: true })
  .register(logger())
  .all("/**", () => "Hello!");

// or

new H3({ debug: true, plugins: [logger()] })
  .all("/**", () => "Hello!");

```