### PR TITLE
refactor: consistent hooks

### DIFF
--- a/docs/1.guide/1.basics/3.middleware.md
+++ b/docs/1.guide/1.basics/3.middleware.md
@@ -88,13 +88,13 @@ app.use(
 );
 
 app.use(
-  onResponse((event, { body }) => {
+  onResponse((response, event) => {
     console.log(`[${event.req.method}] ${event.url.pathname} ~>`, body);
   }),
 );
 
 app.use(
-  onError((event, error) => {
+  onError((error, event) => {
     console.log(
       `[${event.req.method}] ${event.url.pathname} !! ${error.message}`,
     );

--- a/docs/1.guide/900.api/1.h3.md
+++ b/docs/1.guide/900.api/1.h3.md
@@ -171,14 +171,14 @@ These hooks are called for every request and can be used to add global logic to 
 
 ```js
 const app = new H3({
-  onError: (error) => {
-    console.error(error);
-  },
   onRequest: (event) => {
-    console.log("Request:", event.path);
+    console.log("Request:", event.req.url);
   },
-  onResponse: (event) => {
-    console.log("Response:", event.path);
+  onResponse: (response, event) => {
+    console.log("Response:", event.path, response.status);
+  },
+  onError: (error, event) => {
+    console.error(error);
   },
 });
 ```

--- a/docs/2.utils/9.more.md
+++ b/docs/2.utils/9.more.md
@@ -41,17 +41,17 @@ Checks if the input is an H3Event object.
 
 <!-- automd:jsdocs src="../../src/utils/middleware.ts" -->
 
-### `onError(handler)`
+### `onError(hook)`
 
 Define a middleware that runs when an error occurs.
 
 You can return a new Response from the handler to gracefully handle the error.
 
-### `onRequest(handler)`
+### `onRequest(hook)`
 
 Define a middleware that runs on each request.
 
-### `onResponse()`
+### `onResponse(hook)`
 
 Define a middleware that runs after Response is generated.
 

--- a/docs/2.utils/9.more.md
+++ b/docs/2.utils/9.more.md
@@ -45,13 +45,17 @@ Checks if the input is an H3Event object.
 
 Define a middleware that runs when an error occurs.
 
+You can return a new Response from the handler to gracefully handle the error.
+
 ### `onRequest(handler)`
 
 Define a middleware that runs on each request.
 
-### `onResponse(handler)`
+### `onResponse()`
 
 Define a middleware that runs after Response is generated.
+
+You can return a new Response from the handler to replace the original response.
 
 <!-- /automd -->
 

--- a/examples/middleware.mjs
+++ b/examples/middleware.mjs
@@ -17,8 +17,10 @@ app
     }),
   )
   .use(
-    onResponse((event, { body }) => {
-      console.log(`[${event.req.method}] ${event.url.pathname} ~>`, body);
+    onResponse((response, event) => {
+      console.log(
+        `[${event.req.method}] ${event.url.pathname} ~> ${response.statusCode}`,
+      );
     }),
   )
   .use(

--- a/src/response.ts
+++ b/src/response.ts
@@ -26,7 +26,7 @@ export function handleResponse(
 
   const { onResponse } = config;
   return onResponse
-    ? Promise.resolve(onResponse(event, response)).then(() => response)
+    ? Promise.resolve(onResponse(response, event)).then(() => response)
     : response;
 }
 

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -15,12 +15,9 @@ export interface H3Config {
 
   plugins?: H3Plugin[];
 
-  onError?: (error: HTTPError, event: H3Event) => MaybePromise<void | unknown>;
   onRequest?: (event: H3Event) => MaybePromise<void>;
-  onResponse?: (
-    event: H3Event,
-    response: Response | PreparedResponse,
-  ) => MaybePromise<void>;
+  onResponse?: (response: Response, event: H3Event) => MaybePromise<void>;
+  onError?: (error: HTTPError, event: H3Event) => MaybePromise<void | unknown>;
 }
 
 export type PreparedResponse = ResponseInit & { body?: BodyInit | null };

--- a/src/utils/middleware.ts
+++ b/src/utils/middleware.ts
@@ -1,4 +1,7 @@
-import type { HTTPError } from "../error.ts";
+import { HTTPError } from "../error.ts";
+import { handleResponse } from "../response.ts";
+import type { MaybePromise } from "../types/_utils.ts";
+
 import type { H3Event } from "../types/event.ts";
 import type { Middleware } from "../types/handler.ts";
 
@@ -15,28 +18,50 @@ export function onRequest(
 
 /**
  * Define a middleware that runs after Response is generated.
+ *
+ * You can return a new Response from the handler to replace the original response.
  */
 export function onResponse(
-  handler: (event: H3Event, res: { body: any }) => void | Promise<void>,
+  handler: (
+    response: Response,
+    event: H3Event,
+  ) => MaybePromise<void | Response>,
 ): Middleware {
   return async (event, next) => {
-    const body = await next();
-    await handler(event, { body });
-    return body;
+    const rawBody = await next();
+    const response = await handleResponse(rawBody, event);
+    const newResponse = await handler(response, event);
+    return newResponse || response;
   };
 }
 
 /**
  * Define a middleware that runs when an error occurs.
+ *
+ * You can return a new Response from the handler to gracefully handle the error.
  */
 export function onError(
-  handler: (event: H3Event, error: Error | HTTPError) => void | Promise<void>,
+  handler: (error: HTTPError, event: H3Event) => MaybePromise<void | unknown>,
 ): Middleware {
   return async (event, next) => {
     try {
       return await next();
-    } catch (error) {
-      await handler(event, error as Error | HTTPError);
+    } catch (rawError: any) {
+      const isHTTPError = HTTPError.isError(rawError);
+      const error = isHTTPError
+        ? (rawError as HTTPError)
+        : new HTTPError(rawError);
+      if (!isHTTPError) {
+        // @ts-expect-error unhandled is readonly for public interface
+        error.unhandled = true;
+        if (rawError?.stack) {
+          error.stack = rawError.stack;
+        }
+      }
+      const newResponse = await handler(error, event);
+      if (newResponse !== undefined) {
+        return newResponse;
+      }
       throw error;
     }
   };

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -16,9 +16,8 @@ describeMatrix("hooks", (t, { it, expect }) => {
 
     // In Node.js, srvx garbage collects the response body after preparing it for Node.js
     if (t.target !== "node") {
-      const res = t.hooks.onResponse.mock.calls[0]![1]!;
-      const resBody = res instanceof Response ? await res.text() : res.body;
-      expect(resBody).toBe("Hello World!");
+      const res = t.hooks.onResponse.mock.calls[0]![0]!;
+      expect(await res.text()).toBe("Hello World!");
     }
   });
 


### PR DESCRIPTION
Use consistent argument types between global and middleware hooks for `onRequest`, `onResponse` and `onError`

This PR also improves middleware shortcuts to allow overriding error or response.