### PR TITLE
docs: fix typo `event.req` is instance of request

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -33,7 +33,7 @@ When using Node.js, H3 uses a compatibility layer ([💥 srvx](https://srvx.h3.d
 
 Access to the native `event.node.{req,res}` is only available when running server in Node.js runtime.
 
-`event.web` is renamed to `event.req` (instance of web [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response)).
+`event.web` is renamed to `event.req` (instance of web [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request)).
 
 ## Response Handling
 


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

Fixes a small typo in the migration guide.
