### PR TITLE
feat: export `H3Core`

### DIFF
--- a/src/h3.ts
+++ b/src/h3.ts
@@ -3,7 +3,7 @@ import { H3Event } from "./event.ts";
 import { toResponse, kNotFound } from "./response.ts";
 import { callMiddleware, normalizeMiddleware } from "./middleware.ts";
 
-import type { RouterContext } from "rou3";
+import type { RouterContext, MatchedRoute } from "rou3";
 import type {
   FetchHandler,
   H3Config,
@@ -22,15 +22,15 @@ import type {
 } from "./types/h3.ts";
 import type { ServerRequest } from "srvx";
 
-export type H3 = H3Type;
-
-export const H3 = /* @__PURE__ */ (() => {
+export const H3Core = /* @__PURE__ */ (() => {
   // prettier-ignore
   const HTTPMethods = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "CONNECT", "TRACE" ] as const;
 
-  class H3 implements Omit<H3Type, Lowercase<(typeof HTTPMethods)[number]>> {
+  class H3Core
+    implements Omit<H3Type, Lowercase<(typeof HTTPMethods)[number]>>
+  {
     _middleware: Middleware[];
-    _routes?: RouterContext<H3Route>;
+    _routes: H3Route[] = [];
 
     readonly config: H3Config;
 
@@ -90,10 +90,14 @@ export const H3 = /* @__PURE__ */ (() => {
       return this as unknown as H3Type;
     }
 
+    _findRoute(_event: H3Event): MatchedRoute<H3Route> | void {}
+
+    _addRoute(_route: H3Route): void {
+      this._routes.push(_route);
+    }
+
     handler(event: H3Event): unknown | Promise<unknown> {
-      const route = this._routes
-        ? findRoute(this._routes, event.req.method, event.url.pathname)
-        : undefined;
+      const route = this._findRoute(event);
       if (route) {
         event.context.params = route.params;
         event.context.matchedRoute = route.data;
@@ -126,9 +130,6 @@ export const H3 = /* @__PURE__ */ (() => {
       handler: RouteHandler,
       opts?: RouteOptions,
     ): H3Type {
-      if (!this._routes) {
-        this._routes = createRouter();
-      }
       const _method = (method || "").toUpperCase();
       let _handler: EventHandler;
       let meta: H3RouteMeta | undefined = opts?.meta;
@@ -139,13 +140,13 @@ export const H3 = /* @__PURE__ */ (() => {
         meta = { ...(handler as EventHandler).meta, ...meta };
       }
       route = new URL(route, "h://_").pathname;
-      addRoute(this._routes, _method, route, {
+      this._addRoute({
         method: _method as HTTPMethod,
         route,
         handler: _handler,
         middleware: opts?.middleware,
         meta,
-      } satisfies H3Route);
+      });
       return this as unknown as H3Type;
     }
 
@@ -162,14 +163,17 @@ export const H3 = /* @__PURE__ */ (() => {
         opts = arg2 as MiddlewareOptions;
       }
       this._middleware.push(
-        normalizeMiddleware(fn, route ? { ...opts, route } : opts),
+        normalizeMiddleware(
+          fn as Middleware,
+          route ? { ...opts, route } : opts,
+        ),
       );
       return this as unknown as H3Type;
     }
   }
 
   for (const method of HTTPMethods) {
-    (H3 as any).prototype[method.toLowerCase()] = function (
+    (H3Core as any).prototype[method.toLowerCase()] = function (
       this: H3Type,
       route: string,
       handler: EventHandler | H3Type,
@@ -179,8 +183,26 @@ export const H3 = /* @__PURE__ */ (() => {
     };
   }
 
-  return H3;
-})() as unknown as typeof H3Type;
+  return H3Core;
+})() as unknown as { new (config?: H3Config): H3Type };
+
+export class H3 extends H3Core {
+  _rou3: RouterContext<H3Route>;
+
+  constructor(config: H3Config = {}) {
+    super(config);
+    this._rou3 = createRouter();
+  }
+
+  override _findRoute(_event: H3Event): MatchedRoute<H3Route> | void {
+    return findRoute(this._rou3, _event.req.method, _event.url.pathname);
+  }
+
+  override _addRoute(_route: H3Route): void {
+    addRoute(this._rou3, _route.method, _route.route!, _route);
+    super._addRoute(_route);
+  }
+}
 
 export function toRequest(
   _request: ServerRequest | URL | string,

--- a/src/h3.ts
+++ b/src/h3.ts
@@ -187,6 +187,9 @@ export const H3Core = /* @__PURE__ */ (() => {
 })() as unknown as { new (config?: H3Config): H3Type };
 
 export class H3 extends H3Core {
+  /**
+   * @internal
+   */
   _rou3: RouterContext<H3Route>;
 
   constructor(config: H3Config = {}) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export type {
 
 export { definePlugin } from "./types/h3.ts";
 
-export { H3 } from "./h3.ts";
+export { H3Core, H3 } from "./h3.ts";
 
 // Event
 

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -3,7 +3,7 @@ import type { EventHandler, Middleware } from "./handler.ts";
 import type { HTTPError } from "../error.ts";
 import type { MaybePromise } from "./_utils.ts";
 import type { ServerRequest } from "srvx";
-import type { MatchedRoute, RouterContext } from "rou3";
+import type { MatchedRoute } from "rou3";
 import type { H3Event } from "../event.ts";
 
 // --- Misc ---

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -3,7 +3,7 @@ import type { EventHandler, Middleware } from "./handler.ts";
 import type { HTTPError } from "../error.ts";
 import type { MaybePromise } from "./_utils.ts";
 import type { ServerRequest } from "srvx";
-import type { RouterContext } from "rou3";
+import type { MatchedRoute, RouterContext } from "rou3";
 import type { H3Event } from "../event.ts";
 
 // --- Misc ---
@@ -71,7 +71,7 @@ export declare class H3 {
   /**
    * @internal
    */
-  _routes?: RouterContext<H3Route>;
+  _routes?: H3Route[];
 
   /**
    * H3 instance config.
@@ -103,9 +103,19 @@ export declare class H3 {
   ): Response | Promise<Response>;
 
   /**
+   * @internal
+   */
+  _findRoute(_event: H3Event): MatchedRoute<H3Route> | void;
+
+  /**
+   * @internal
+   */
+  _addRoute(_route: H3Route): void;
+
+  /**
    * Immediately register an H3 plugin.
    */
-  register(plugin: H3Plugin): H3;
+  register(plugin: H3Plugin): this;
 
   /**
    * An h3 compatible event handler useful to compose multiple h3 app instances.
@@ -115,13 +125,13 @@ export declare class H3 {
   /**
    * Mount a `.fetch` compatible server (like Hono or Elysia) to the H3 app.
    */
-  mount(base: string, input: FetchHandler | { fetch: FetchHandler }): H3;
+  mount(base: string, input: FetchHandler | { fetch: FetchHandler }): this;
 
   /**
    * Register a global middleware.
    */
-  use(route: string, handler: Middleware | H3, opts?: MiddlewareOptions): H3;
-  use(handler: Middleware | H3, opts?: MiddlewareOptions): H3;
+  use(route: string, handler: Middleware | H3, opts?: MiddlewareOptions): this;
+  use(handler: Middleware | H3, opts?: MiddlewareOptions): this;
 
   /**
    * Register a route handler for the specified HTTP method and route.
@@ -131,20 +141,20 @@ export declare class H3 {
     route: string,
     handler: RouteHandler,
     opts?: RouteOptions,
-  ): H3;
+  ): this;
 
   /**
    * Register a route handler for all HTTP methods.
    */
-  all(route: string, handler: RouteHandler, opts?: RouteOptions): H3;
+  all(route: string, handler: RouteHandler, opts?: RouteOptions): this;
 
-  get(route: string, handler: RouteHandler, opts?: RouteOptions): H3;
-  post(route: string, handler: RouteHandler, opts?: RouteOptions): H3;
-  put(route: string, handler: RouteHandler, opts?: RouteOptions): H3;
-  delete(route: string, handler: RouteHandler, opts?: RouteOptions): H3;
-  patch(route: string, handler: RouteHandler, opts?: RouteOptions): H3;
-  head(route: string, handler: RouteHandler, opts?: RouteOptions): H3;
-  options(route: string, handler: RouteHandler, opts?: RouteOptions): H3;
-  connect(route: string, handler: RouteHandler, opts?: RouteOptions): H3;
-  trace(route: string, handler: RouteHandler, opts?: RouteOptions): H3;
+  get(route: string, handler: RouteHandler, opts?: RouteOptions): this;
+  post(route: string, handler: RouteHandler, opts?: RouteOptions): this;
+  put(route: string, handler: RouteHandler, opts?: RouteOptions): this;
+  delete(route: string, handler: RouteHandler, opts?: RouteOptions): this;
+  patch(route: string, handler: RouteHandler, opts?: RouteOptions): this;
+  head(route: string, handler: RouteHandler, opts?: RouteOptions): this;
+  options(route: string, handler: RouteHandler, opts?: RouteOptions): this;
+  connect(route: string, handler: RouteHandler, opts?: RouteOptions): this;
+  trace(route: string, handler: RouteHandler, opts?: RouteOptions): this;
 }

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -24,6 +24,24 @@ describe("benchmark", () => {
     expect(bundle.gzipSize).toBeLessThanOrEqual(4000); // <4kb
   });
 
+  it("bundle size (H3Core)", async () => {
+    const code = /* js */ `
+      import { H3Core } from "../../src/index.ts";
+      const app = new H3Core();
+    `;
+    const bundle = await getBundleSize(code);
+    if (inspect) {
+      return;
+    }
+    if (process.env.DEBUG) {
+      console.log(
+        `Bundle size (H3Core): ${bundle.bytes} (gzip: ${bundle.gzipSize})`,
+      );
+    }
+    expect(bundle.bytes).toBeLessThanOrEqual(8000); // <8kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(3500); // <3.5kb
+  });
+
   it("bundle size (defineHandler)", async () => {
     const code = /* js */ `
       import { defineHandler } from "h3";

--- a/test/unit/package.test.ts
+++ b/test/unit/package.test.ts
@@ -8,6 +8,7 @@ describe("h3 package", () => {
     expect(exportNames).toMatchInlineSnapshot(`
       [
         "H3",
+        "H3Core",
         "H3Error",
         "H3Event",
         "HTTPError",


### PR DESCRIPTION
This PR exposes `H3Core`, an abstract class without implementation for `_findRoute` to allow replacing the router.

Bundle size saving is medium (`7.4kB` core vs `9.6kB` with rou3), but the main benefit is giving better low-level control.

With this PR, we also expose `_routes: []` internal array useful for next steps, both accessing nested app route meta (#1111) and better sub-app (#1107) since we can "replay" route additions tothe  main app when mounting it.