### PR TITLE
refactor!: explicit use of handlers or middleware

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,6 @@ export type {
   HTTPMethod,
   PreparedResponse,
   RouteOptions,
-  RouteHandler,
   MiddlewareOptions,
   FetchHandler,
 } from "./types/h3.ts";

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -48,8 +48,6 @@ export function definePlugin<T = unknown>(
 
 // --- H3 App ---
 
-export type RouteHandler = EventHandler | { handler: EventHandler };
-
 export type FetchHandler = (req: ServerRequest) => Response | Promise<Response>;
 
 export type RouteOptions = {
@@ -130,8 +128,8 @@ export declare class H3 {
   /**
    * Register a global middleware.
    */
-  use(route: string, handler: Middleware | H3, opts?: MiddlewareOptions): this;
-  use(handler: Middleware | H3, opts?: MiddlewareOptions): this;
+  use(route: string, handler: Middleware, opts?: MiddlewareOptions): this;
+  use(handler: Middleware, opts?: MiddlewareOptions): this;
 
   /**
    * Register a route handler for the specified HTTP method and route.
@@ -139,22 +137,22 @@ export declare class H3 {
   on(
     method: HTTPMethod | Lowercase<HTTPMethod> | "",
     route: string,
-    handler: RouteHandler,
+    handler: EventHandler,
     opts?: RouteOptions,
   ): this;
 
   /**
    * Register a route handler for all HTTP methods.
    */
-  all(route: string, handler: RouteHandler, opts?: RouteOptions): this;
+  all(route: string, handler: EventHandler, opts?: RouteOptions): this;
 
-  get(route: string, handler: RouteHandler, opts?: RouteOptions): this;
-  post(route: string, handler: RouteHandler, opts?: RouteOptions): this;
-  put(route: string, handler: RouteHandler, opts?: RouteOptions): this;
-  delete(route: string, handler: RouteHandler, opts?: RouteOptions): this;
-  patch(route: string, handler: RouteHandler, opts?: RouteOptions): this;
-  head(route: string, handler: RouteHandler, opts?: RouteOptions): this;
-  options(route: string, handler: RouteHandler, opts?: RouteOptions): this;
-  connect(route: string, handler: RouteHandler, opts?: RouteOptions): this;
-  trace(route: string, handler: RouteHandler, opts?: RouteOptions): this;
+  get(route: string, handler: EventHandler, opts?: RouteOptions): this;
+  post(route: string, handler: EventHandler, opts?: RouteOptions): this;
+  put(route: string, handler: EventHandler, opts?: RouteOptions): this;
+  delete(route: string, handler: EventHandler, opts?: RouteOptions): this;
+  patch(route: string, handler: EventHandler, opts?: RouteOptions): this;
+  head(route: string, handler: EventHandler, opts?: RouteOptions): this;
+  options(route: string, handler: EventHandler, opts?: RouteOptions): this;
+  connect(route: string, handler: EventHandler, opts?: RouteOptions): this;
+  trace(route: string, handler: EventHandler, opts?: RouteOptions): this;
 }

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -35,7 +35,7 @@ describeMatrix("middleware", (t, { it, expect }) => {
         event.req.headers.has("x-async")
           ? Promise.resolve("Hello World!")
           : "Hello World!",
-      ),
+      ).handler,
       {
         method: "GET",
         match: (event) => !event.req.headers.has("x-skip"),

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -20,7 +20,7 @@ describeMatrix("router", (t, { it, expect, describe }) => {
   it("Multiple Routers", async () => {
     const secondRouter = new H3().get("/router2", () => "router2");
 
-    t.app.use(secondRouter);
+    t.app.use(secondRouter.handler);
 
     const res1 = await t.fetch("/");
     expect(await res1.text()).toEqual("Hello");
@@ -84,7 +84,7 @@ describeMatrix("router", (t, { it, expect, describe }) => {
       router = new H3()
         .get("/preemptive/test", () => "Test")
         .get("/preemptive/undefined", () => undefined);
-      t.app.all("/**", router);
+      t.app.all("/**", router.handler);
     });
 
     it("Handle /test", async () => {
@@ -120,7 +120,7 @@ describeMatrix("router", (t, { it, expect, describe }) => {
           expect(getRouterParams(event)).toMatchObject({ name: "string" });
           return "200";
         });
-        t.app.use(router);
+        t.app.use(router.handler);
         const result = await t.fetch("/test/params/string");
 
         expect(await result.text()).toBe("200");
@@ -133,7 +133,7 @@ describeMatrix("router", (t, { it, expect, describe }) => {
           });
           return "200";
         });
-        t.app.use(router);
+        t.app.use(router.handler);
         const result = await t.fetch("/test/params/string with space");
 
         expect(await result.text()).toBe("200");
@@ -160,7 +160,7 @@ describeMatrix("router", (t, { it, expect, describe }) => {
           expect(getRouterParam(event, "name")).toEqual("string");
           return "200";
         });
-        t.app.use(router);
+        t.app.use(router.handler);
         const result = await t.fetch("/test/params/string");
 
         expect(await result.text()).toBe("200");
@@ -173,7 +173,7 @@ describeMatrix("router", (t, { it, expect, describe }) => {
           );
           return "200";
         });
-        t.app.use(router);
+        t.app.use(router.handler);
         const result = await t.fetch("/test/params/string with space");
 
         expect(await result.text()).toBe("200");
@@ -204,7 +204,7 @@ describeMatrix("router", (t, { it, expect, describe }) => {
           });
           return "200";
         });
-        t.app.use(router);
+        t.app.use(router.handler);
         const result = await t.fetch("/test/path");
 
         expect(await result.text()).toBe("200");

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -24,7 +24,7 @@ describeMatrix("session", (t, { it, expect }) => {
       }
       return { session };
     });
-    t.app.use(app);
+    t.app.use(app.handler);
   });
 
   it("initiates session", async () => {


### PR DESCRIPTION
[WIP]

This PR requires explicit use of `app.handler` for registering it as a route handler or middleware instead of converting `H3` to `H3.handler`.

This PR also adds better handling for middleware that is an h3 sub-app handler, automatically falls back in case of `kNotFound`.


