### PR TITLE
docs: add nested apps section

### DIFF
--- a/docs/1.guide/1.basics/7.nested-apps.md
+++ b/docs/1.guide/1.basics/7.nested-apps.md
@@ -8,9 +8,7 @@ icon: material-symbols-light:layers-outline
 
 Typically, H3 projects consist of several [Event Handlers](/guide/basics/handler) defined in one or multiple files (even [lazy loaded](/guide/basics/handler#lazy-handlers) for faster startup times).
 
-It is sometimes more convenient to combine multiple `H3` instances or even use another HTTP framework employed by a different team and mount it to the main app instance.
-
-H3 provides a native [`.mount`](/guide/api/h3#h3mount) method to facilitate this.
+It is sometimes more convenient to combine multiple `H3` instances or even use another HTTP framework used by a different team and mount it to the main app instance. H3 provides a native [`.mount`](/guide/api/h3#h3mount) method to facilitate this.
 
 ## Nested H3 Apps
 

--- a/docs/1.guide/1.basics/7.nested-apps.md
+++ b/docs/1.guide/1.basics/7.nested-apps.md
@@ -31,6 +31,9 @@ const app = new H3().mount("/api", nestedApp);
 
 In the example above, when fetching the `/api/test` URL, `pathname` will be `/api/test` (the real path), and `slug` will be `/test` (wildcard param).
 
+> [!NOTE]
+> Global config and hooks won't be inherited from the nested app. Consider always setting them from the main app.
+
 ## Nested Web Standard Apps
 
 Mount a `.fetch` compatible server instance like [Hono](https://hono.dev/) or [Elysia](https://elysiajs.com/) under the base URL.

--- a/docs/1.guide/1.basics/7.nested-apps.md
+++ b/docs/1.guide/1.basics/7.nested-apps.md
@@ -29,7 +29,7 @@ const nestedApp = new H3()
 const app = new H3().mount("/api", nestedApp);
 ```
 
-In the example above, when fetching the `/api/test` URL, `pathname` will be `/api/test` (the real path), and `slug` will be `/test` (the sub-app prefixed pattern).
+In the example above, when fetching the `/api/test` URL, `pathname` will be `/api/test` (the real path), and `slug` will be `/test` (wildcard param).
 
 ## Nested Web Standard Apps
 

--- a/docs/1.guide/1.basics/7.nested-apps.md
+++ b/docs/1.guide/1.basics/7.nested-apps.md
@@ -12,10 +12,7 @@ It is sometimes more convenient to combine multiple `H3` instances or even use a
 
 ## Nested H3 Apps
 
-H3 natively allows mounting sub-apps. When mounted, sub-app routes and middleware are prefixed with the base and seamlessly **integrated** into the main app instance.
-
-> [!NOTE]
-> All sub-app routes will be
+H3 natively allows mounting sub-apps. When mounted, sub-app routes and middleware are **merged** with the base url prefix into the main app instance.
 
 ```js
 import { H3, serve } from "h3";

--- a/docs/1.guide/1.basics/7.nested-apps.md
+++ b/docs/1.guide/1.basics/7.nested-apps.md
@@ -29,7 +29,7 @@ const nestedApp = new H3()
 const app = new H3().mount("/api", nestedApp);
 ```
 
-In the example above, when fetching `/api/test` URL, `pathname` will become `/api/test` (real path) and `slug` will become `/test` (sub-app prefixed pattern).
+In the example above, when fetching the `/api/test` URL, `pathname` will be `/api/test` (the real path), and `slug` will be `/test` (the sub-app prefixed pattern).
 
 ## Nested Web Standard Apps
 

--- a/docs/1.guide/1.basics/7.nested-apps.md
+++ b/docs/1.guide/1.basics/7.nested-apps.md
@@ -6,7 +6,7 @@ icon: material-symbols-light:layers-outline
 
 > H3 has a native `mount` method for adding nested sub-apps to the main instance.
 
-Typically, H3 projects consist of several [Event Handlers](/guide/basics/handler) defined in one or multiple files (even [lazy loaded](/guide/basics/handler#lazy-handlers) for faster startup times).
+Typically, H3 projects consist of several [Event Handlers](/guide/basics/handler) defined in one or multiple files (or even [lazy loaded](/guide/basics/handler#lazy-handlers) for faster startup times).
 
 It is sometimes more convenient to combine multiple `H3` instances or even use another HTTP framework used by a different team and mount it to the main app instance. H3 provides a native [`.mount`](/guide/api/h3#h3mount) method to facilitate this.
 

--- a/docs/1.guide/1.basics/7.nested-apps.md
+++ b/docs/1.guide/1.basics/7.nested-apps.md
@@ -32,7 +32,7 @@ const nestedApp = new H3()
 const app = new H3().mount("/api", nestedApp);
 ```
 
-In the example above, when fetching `/api/test` url, `pathname` will become `/api/test` (real path) and `slug` will become `/test` (sub-app prefixed pattern).
+In the example above, when fetching `/api/test` URL, `pathname` will become `/api/test` (real path) and `slug` will become `/test` (sub-app prefixed pattern).
 
 ## Nested Web Standard Apps
 

--- a/docs/1.guide/1.basics/7.nested-apps.md
+++ b/docs/1.guide/1.basics/7.nested-apps.md
@@ -1,0 +1,64 @@
+---
+icon: material-symbols-light:layers-outline
+---
+
+# Nested Apps
+
+> H3 has a native `mount` method for adding nested sub-apps to the main instance.
+
+Typically, H3 projects consist of several [Event Handlers](/guide/basics/handler) defined in one or multiple files (even [lazy loaded](/guide/basics/handler#lazy-handlers) for faster startup times).
+
+It is sometimes more convenient to combine multiple `H3` instances or even use another HTTP framework employed by a different team and mount it to the main app instance.
+
+H3 provides a native [`.mount`](/guide/api/h3#h3mount) method to facilitate this.
+
+## Nested H3 Apps
+
+H3 natively allows mounting sub-apps. When mounted, sub-app routes and middleware are prefixed with the base and seamlessly **integrated** into the main app instance.
+
+> [!NOTE]
+> All sub-app routes will be
+
+```js
+import { H3, serve } from "h3";
+
+const nestedApp = new H3()
+  .use((event) => {
+    event.res.headers.set("x-api", "1");
+  })
+  .get("/**:slug", (event) => ({
+    pathname: event.url.pathname,
+    slug: event.context.params?.slug,
+  }));
+
+const app = new H3()
+  .mount("/api", nestedApp);
+```
+
+In the example above, when fetching `/api/test` url, `pathname` will become `/api/test` (real path) and `slug` will become `/test` (sub-app prefixed pattern).
+
+## Nested Web Standard Apps
+
+Mount a `.fetch` compatible server instance like [Hono](https://hono.dev/) or [Elysia](https://elysiajs.com/) under the base URL.
+
+> [!NOTE]
+> Base prefix will be removed from `request.url` passed to the mounted app.
+
+```js
+import { H3 } from "h3";
+import { Hono } from "hono";
+import { Elysia } from "elysia";
+
+const app = new H3()
+  .mount(
+    "/elysia",
+    new Elysia().get("/test", () => "Hello Elysia!"),
+  )
+  .mount(
+    "/hono",
+    new Hono().get("/test", (c) => c.text("Hello Hono!")),
+  );
+```
+
+> [!TIP]
+> Similarly, you can mount an H3 app in [Hono](https://hono.dev/docs/api/hono#mount) or [Elysia](https://elysiajs.com/patterns/mount#mount-1).

--- a/docs/1.guide/1.basics/7.nested-apps.md
+++ b/docs/1.guide/1.basics/7.nested-apps.md
@@ -31,8 +31,7 @@ const nestedApp = new H3()
     slug: event.context.params?.slug,
   }));
 
-const app = new H3()
-  .mount("/api", nestedApp);
+const app = new H3().mount("/api", nestedApp);
 ```
 
 In the example above, when fetching `/api/test` url, `pathname` will become `/api/test` (real path) and `slug` will become `/test` (sub-app prefixed pattern).

--- a/docs/1.guide/900.api/1.h3.md
+++ b/docs/1.guide/900.api/1.h3.md
@@ -96,29 +96,9 @@ serve(app);
 
 ### `H3.mount`
 
-Mount a `.fetch` compatible server instance like [Hono](https://hono.dev/) or [Elysia](https://elysiajs.com/) under the base URL.
+Using `.mount` method, you can register a sub-app with prefix.
 
-```js
-import { H3 } from "h3";
-import { Hono } from "hono";
-import { Elysia } from "elysia";
-
-const app = new H3()
-  .mount(
-    "/elysia",
-    new Elysia().get("/test", () => "Hello Elysia!"),
-  )
-  .mount(
-    "/hono",
-    new Hono().get("/test", (c) => c.text("Hello Hono!")),
-  );
-```
-
-> [!NOTE]
-> Base prefix will be removed from `request.url` passed to the mounted app.
-
-> [!TIP]
-> Similarly, you can mount an H3 app in [Hono](https://hono.dev/docs/api/hono#mount) or [Elysia](https://elysiajs.com/patterns/mount#mount-1).
+:read-more{to="/guide/basics/nested-apps" title="Nested Apps"}
 
 ## `H3` Options
 


### PR DESCRIPTION
Add a dedicated "Nested Apps" section for `app.mount` usage (cont. #1129)