### PR TITLE
fix(response): only add `content-disposition` for `File` with name

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -162,8 +162,9 @@ function prepareResponseBody(
     };
 
     // File
-    if ("name" in val) {
-      const filename = encodeURIComponent(val.name as string);
+    let filename = (val as File).name;
+    if (filename) {
+      filename = encodeURIComponent(filename);
       // Omit the disposition type ("inline" or "attachment") and let the client (browser) decide.
       headers["content-disposition"] =
         `filename="${filename}"; filename*=UTF-8''${filename}`;


### PR DESCRIPTION
Resolves #1132

Bun has a very strange implementation of `Blob` where `'name' in new Blob()` is true, making H3 to wrongly detect Blobs ad downloadable files.

This PR makes h3 more secure by making sure only to add the name if it has a value.