### PR TITLE
feat(proxy): use native `fetch` + `event.app.fetch`

### DIFF
--- a/docs/2.utils/5.proxy.md
+++ b/docs/2.utils/5.proxy.md
@@ -8,7 +8,7 @@ icon: arcticons:super-proxy
 
 <!-- automd:jsdocs src="../../src/utils/proxy.ts" -->
 
-### `fetchWithEvent(event, req, init?, options?: { fetch: F })`
+### `fetchWithEvent(event, req, init?)`
 
 Make a fetch request with the event's context and headers.
 

--- a/src/utils/internal/proxy.ts
+++ b/src/utils/internal/proxy.ts
@@ -15,18 +15,6 @@ export const ignoredHeaders: Set<string> = new Set([
   "accept",
 ]);
 
-export function getFetch<T = typeof fetch>(_fetch?: T): T {
-  if (_fetch) {
-    return _fetch;
-  }
-  if (globalThis.fetch) {
-    return globalThis.fetch as T;
-  }
-  throw new Error(
-    "fetch is not available. Try importing `node-fetch-native/polyfill` for Node.js.",
-  );
-}
-
 export function rewriteCookieProperty(
   header: string,
   map: string | Record<string, string>,


### PR DESCRIPTION
v1 proxy utils depended on specific behavior for Nitro and ofetch compatibility for direct fetch.

Since in v2 we are fully based on web standards, and with the addition of `event.app.fetch` (#1139) which allows direct fetch, we can fully switch to runtime natives!