### PR TITLE
fix: safer `HTTPError` check

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -78,6 +78,10 @@ export class HTTPError<DataT = unknown>
   extends Error
   implements ErrorBody<DataT>
 {
+  override get name(): string {
+    return "HTTPError";
+  }
+
   /**
    * HTTP status code in range [200...599]
    */
@@ -126,7 +130,7 @@ export class HTTPError<DataT = unknown>
    * It is safer than using `instanceof` because it works across different contexts (e.g., if the error was thrown in a different module).
    */
   static isError(input: any): input is HTTPError {
-    return input?.constructor?.name === "HTTPError";
+    return input instanceof Error && input?.name === "HTTPError";
   }
 
   /**

--- a/test/body.test.ts
+++ b/test/body.test.ts
@@ -304,7 +304,7 @@ describeMatrix("body", (t, { it, expect, describe }) => {
 
     expect(result.status).toBe(400);
     expect(resultJson.statusText).toBe("Bad Request");
-    expect(resultJson.stack[0]).toBe("Error: Invalid JSON body");
+    expect(resultJson.stack[0]).toBe("HTTPError: Invalid JSON body");
   });
 
   describe("readFormDataBody", () => {


### PR DESCRIPTION
Bundlers (and runtimes) can sometimes rename class name for `HTTPError` which makes it unreliable for checking.

This PR adds `HTTPError.name: "HTTPError"` also safer `HTTPError.isError` check.