### PR TITLE
feat: customizable validation errors

### DIFF
--- a/docs/2.utils/1.request.md
+++ b/docs/2.utils/1.request.md
@@ -22,7 +22,7 @@ app.get("/", async (event) => {
 });
 ```
 
-### `readValidatedBody(event, validate)`
+### `readValidatedBody(event, validate, error?)`
 
 Tries to read the request body via `readBody`, then uses the provided validation schema or function and either throws a validation error or returns the result.
 
@@ -31,7 +31,7 @@ You can use a simple function to validate the body or use a Standard-Schema comp
 **Example:**
 
 ```ts
-app.get("/", async (event) => {
+app.post("/", async (event) => {
   const body = await readValidatedBody(event, (body) => {
     return typeof body === "object" && body !== null;
   });
@@ -42,12 +42,31 @@ app.get("/", async (event) => {
 
 ```ts
 import { z } from "zod";
-app.get("/", async (event) => {
+app.post("/", async (event) => {
   const objectSchema = z.object({
     name: z.string().min(3).max(20),
     age: z.number({ coerce: true }).positive().int(),
   });
   const body = await readValidatedBody(event, objectSchema);
+});
+```
+
+**Example:**
+
+```ts
+import * as v from "valibot";
+app.post("/", async (event) => {
+  const body = await readValidatedBody(
+    event,
+    v.object({
+      name: v.pipe(v.string(), v.minLength(3), v.maxLength(20)),
+      age: v.pipe(v.number(), v.integer(), v.minValue(1)),
+    }),
+    (issues) => ({
+      statusText: "Custom validation error",
+      message: v.summarize(issues),
+    }),
+  );
 });
 ```
 
@@ -188,7 +207,7 @@ app.get("/", (event) => {
 });
 ```
 
-### `getValidatedQuery(event, validate)`
+### `getValidatedQuery(event, validate, error?)`
 
 Get the query param from the request URL validated with validate function.
 
@@ -218,7 +237,25 @@ app.get("/", async (event) => {
 });
 ```
 
-### `getValidatedRouterParams(event, validate, opts: { decode? })`
+**Example:**
+
+```ts
+import * as v from "valibot";
+app.get("/", async (event) => {
+  const params = await getValidatedQuery(
+    event,
+    v.object({
+      key: v.string(),
+    }),
+    (issues) => ({
+      statusText: "Custom validation error",
+      message: v.summarize(issues),
+    }),
+  );
+});
+```
+
+### `getValidatedRouterParams(event, validate, opts: { decode? }, error?)`
 
 Get matched route params and validate with validate function.
 
@@ -229,7 +266,7 @@ You can use a simple function to validate the params object or use a Standard-Sc
 **Example:**
 
 ```ts
-app.get("/", async (event) => {
+app.get("/:key", async (event) => {
   const params = await getValidatedRouterParams(event, (data) => {
     return "key" in data && typeof data.key === "string";
   });
@@ -240,11 +277,30 @@ app.get("/", async (event) => {
 
 ```ts
 import { z } from "zod";
-app.get("/", async (event) => {
+app.get("/:key", async (event) => {
   const params = await getValidatedRouterParams(
     event,
     z.object({
       key: z.string(),
+    }),
+  );
+});
+```
+
+**Example:**
+
+```ts
+import * as v from "valibot";
+app.get("/:key", async (event) => {
+  const params = await getValidatedRouterParams(
+    event,
+    v.object({
+      key: v.pipe(v.string(), v.picklist(["route-1", "route-2", "route-3"])),
+    }),
+    { decode: true },
+    (issues) => ({
+      statusText: "Custom validation error",
+      message: v.summarize(issues),
     }),
   );
 });

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -18,7 +18,11 @@ import type {
   StandardSchemaV1,
 } from "./utils/internal/standard-schema.ts";
 import type { TypedRequest } from "fetchdts";
-import { validatedRequest, validatedURL } from "./utils/internal/validate.ts";
+import {
+  type ValidateError,
+  validatedRequest,
+  validatedURL,
+} from "./utils/internal/validate.ts";
 
 // --- event handler ---
 
@@ -61,8 +65,11 @@ export function defineValidatedHandler<
 >(def: {
   middleware?: Middleware[];
   body?: RequestBody;
+  bodyErrors?: ValidateError;
   headers?: RequestHeaders;
+  headersErrors?: ValidateError;
   query?: RequestQuery;
+  queryErrors?: ValidateError;
   handler: EventHandler<
     {
       body: InferOutput<RequestBody>;

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -1,6 +1,9 @@
-import type { ValidateFunction } from "../src/utils/internal/validate.ts";
+import type {
+  ValidateFunction,
+  ValidateIssues,
+} from "../src/utils/internal/validate.ts";
 import { beforeEach } from "vitest";
-import { z } from "zod";
+import { z } from "zod/v4";
 import {
   readValidatedBody,
   getValidatedQuery,
@@ -17,6 +20,17 @@ describeMatrix("validate", (t, { it, describe, expect }) => {
   }> = (data: any) => {
     if (data.invalid) {
       throw new Error("Invalid key");
+    }
+    data.default = "default";
+    return data;
+  };
+  const customValidateWithoutError: ValidateFunction<{
+    invalidKey: never;
+    default: string;
+    field?: string;
+  }> = (data: any) => {
+    if (data.invalid) {
+      return false;
     }
     data.default = "default";
     return data;
@@ -38,6 +52,29 @@ describeMatrix("validate", (t, { it, describe, expect }) => {
 
       t.app.post("/zod", async (event) => {
         const data = await readValidatedBody(event, zodValidate);
+        return data;
+      });
+
+      t.app.post("/custom-error", async (event) => {
+        const data = await readValidatedBody(
+          event,
+          customValidateWithoutError,
+          {
+            status: 500,
+            statusText: "Custom validation error",
+          },
+        );
+
+        return data;
+      });
+
+      t.app.post("/custom-error-zod", async (event) => {
+        const data = await readValidatedBody(event, zodValidate, (issues) => ({
+          status: 500,
+          statusText: "Custom Zod validation error",
+          message: summarize(issues),
+        }));
+
         return data;
       });
     });
@@ -122,6 +159,34 @@ describeMatrix("validate", (t, { it, describe, expect }) => {
         });
       });
     });
+
+    describe("custom error", () => {
+      it("Custom error message", async () => {
+        const res = await t.fetch("/custom-error", {
+          method: "POST",
+          body: JSON.stringify({ invalid: true }),
+        });
+
+        expect(res.status).toEqual(500);
+        expect(await res.json()).toMatchObject({
+          statusText: "Custom validation error",
+        });
+      });
+
+      it("Custom error with zod", async () => {
+        const res = await t.fetch("/custom-error-zod", {
+          method: "POST",
+          body: JSON.stringify({ invalid: true, field: 2 }),
+        });
+
+        expect(res.status).toEqual(500);
+        expect(await res.json()).toMatchObject({
+          statusText: "Custom Zod validation error",
+          message:
+            "- Invalid input: expected string, received number\n- Invalid input: expected never, received boolean",
+        });
+      });
+    });
   });
 
   describe("getQuery", () => {
@@ -133,6 +198,29 @@ describeMatrix("validate", (t, { it, describe, expect }) => {
 
       t.app.get("/zod", async (event) => {
         const data = await getValidatedQuery(event, zodValidate);
+        return data;
+      });
+
+      t.app.get("/custom-error", async (event) => {
+        const data = await getValidatedQuery(
+          event,
+          customValidateWithoutError,
+          {
+            status: 500,
+            statusText: "Custom validation error",
+          },
+        );
+
+        return data;
+      });
+
+      t.app.get("/custom-error-zod", async (event) => {
+        const data = await getValidatedQuery(event, zodValidate, (issues) => ({
+          status: 500,
+          statusText: "Custom Zod validation error",
+          message: summarize(issues),
+        }));
+
         return data;
       });
     });
@@ -169,6 +257,27 @@ describeMatrix("validate", (t, { it, describe, expect }) => {
         expect(res.status).toEqual(400);
       });
     });
+
+    describe("custom error", () => {
+      it("Custom error message", async () => {
+        const res = await t.fetch("/custom-error?invalid=true");
+
+        expect(res.status).toEqual(500);
+        expect(await res.json()).toMatchObject({
+          statusText: "Custom validation error",
+        });
+      });
+
+      it("Custom error with zod", async () => {
+        const res = await t.fetch("/custom-error-zod?invalid=true");
+
+        expect(res.status).toEqual(500);
+        expect(await res.json()).toMatchObject({
+          statusText: "Custom Zod validation error",
+          message: "- Invalid input: expected never, received string",
+        });
+      });
+    });
   });
 
   describe("getRouterParams", () => {
@@ -194,7 +303,10 @@ describeMatrix("validate", (t, { it, describe, expect }) => {
     const zodParamValidate = z.object({
       id: z
         .string()
-        .regex(REGEX_NUMBER_STRING, "Must be a number string")
+        .regex(
+          REGEX_NUMBER_STRING,
+          "Invalid input: expected number, received string",
+        )
         .transform(Number),
     });
 
@@ -206,6 +318,21 @@ describeMatrix("validate", (t, { it, describe, expect }) => {
 
       t.app.get("/zod/:id", async (event) => {
         const data = await getValidatedRouterParams(event, zodParamValidate);
+        return data;
+      });
+
+      t.app.get("/custom-error-zod/:id", async (event) => {
+        const data = await getValidatedRouterParams(
+          event,
+          zodParamValidate,
+          {},
+          (issues) => ({
+            status: 500,
+            statusText: "Custom Zod validation error",
+            message: summarize(issues),
+          }),
+        );
+
         return data;
       });
     });
@@ -240,5 +367,37 @@ describeMatrix("validate", (t, { it, describe, expect }) => {
         expect(res.status).toEqual(400);
       });
     });
+
+    describe("custom error", () => {
+      it("Custom error with zod", async () => {
+        const res = await t.fetch("/custom-error-zod/abc");
+
+        expect(res.status).toEqual(500);
+        expect(await res.json()).toMatchObject({
+          statusText: "Custom Zod validation error",
+          message: "- Invalid input: expected number, received string",
+        });
+      });
+    });
   });
 });
+
+/**
+ * Fork of valibot's `summarize` function.
+ *
+ * LICENSE: MIT
+ * SOURCE: https://github.com/fabian-hiller/valibot/blob/44b2e6499562e19d0a66ade1e25e44087e0d2c16/library/src/methods/summarize/summarize.ts
+ */
+function summarize(issues: ValidateIssues): string {
+  let summary = "";
+
+  for (const issue of issues) {
+    if (summary) {
+      summary += "\n";
+    }
+
+    summary += `- ${issue.message}`;
+  }
+
+  return summary;
+}


### PR DESCRIPTION
resolves https://github.com/h3js/h3/issues/982

I've added an additional argument to each `readValidatedBody`, `getValidatedQuery` and `getValidatedRouteParams` which can be either an error object or a function that returns one. If a standard-schema is being used, then the `issues` array is available as an argument for the function variant.

This allows for the following custom error, which will ouput a markdown list of all the errors recorded:
```ts
import * as v from "valibot";

app.post("/", async (event) => {
  const body = await readValidatedBody(
    event,
    v.object({
      name: v.pipe(v.string(), v.minLength(3), v.maxLength(20)),
      age: v.pipe(v.number(), v.integer(), v.minValue(1)),
    }),
    (issues) => ({
      statusText: "Custom validation error",
      message: v.summarize(issues),
    }),
  );
});
```

I've also updated the `defineValidatedHandler`, which brings three more properties: `bodyErrors`, `headersErrors` and `queryErrors`. All allowing for either error object or function that returns one

Added two types, but I'm not super satisfied with `ValidateIssues` naming (I'm open for suggestions):
```ts
export type ValidateIssues = ReadonlyArray<Issue>;
export type ValidateError =
  | ErrorDetails
  | ((issues: ValidateIssues) => ErrorDetails);
```

I've also made sure that if a `new HTTPError` is thrown during validation, its content will be directly passed as is, quite useful for non-standard-schema validations.