### PR TITLE
fix(defineValidatedHandler): accept all `EventHandlerObject` props

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -58,24 +58,25 @@ export function defineValidatedHandler<
   RequestHeaders extends StandardSchemaV1,
   RequestQuery extends StandardSchemaV1,
   Res extends EventHandlerResponse = EventHandlerResponse,
->(def: {
-  middleware?: Middleware[];
-  body?: RequestBody;
-  headers?: RequestHeaders;
-  query?: RequestQuery;
-  handler: EventHandler<
-    {
-      body: InferOutput<RequestBody>;
-      query: StringHeaders<InferOutput<RequestQuery>>;
-    },
-    Res
-  >;
-}): EventHandlerWithFetch<
+>(
+  def: Omit<EventHandlerObject, "handler"> & {
+    body?: RequestBody;
+    headers?: RequestHeaders;
+    query?: RequestQuery;
+    handler: EventHandler<
+      {
+        body: InferOutput<RequestBody>;
+        query: StringHeaders<InferOutput<RequestQuery>>;
+      },
+      Res
+    >;
+  },
+): EventHandlerWithFetch<
   TypedRequest<InferOutput<RequestBody>, InferOutput<RequestHeaders>>,
   Res
 > {
   return defineHandler({
-    middleware: def.middleware,
+    ...def,
     handler: (event) => {
       (event as any) /* readonly */.req = validatedRequest(event.req, def);
       (event as any) /* readonly */.url = validatedURL(event.url, def);

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -11,7 +11,6 @@ import type {
   EventHandlerResponse,
   DynamicEventHandler,
   EventHandlerWithFetch,
-  Middleware,
 } from "./types/handler.ts";
 import type {
   InferOutput,

--- a/src/utils/route.ts
+++ b/src/utils/route.ts
@@ -63,7 +63,6 @@ export interface RouteDefinition {
  */
 export function defineRoute(def: RouteDefinition): H3Plugin {
   const handler = defineValidatedHandler(def) as any;
-  handler.meta = def.meta;
   return (h3: H3) => {
     h3.on(def.method, def.route, handler);
   };


### PR DESCRIPTION
Experimental `defineValidatedHandler` (#1097) should accept all possible `EventHandlerObject` props (typed superset)

This PR fixes issue that `.meta` was ignored.