### PR TITLE
refactor!(defineValidatedHandler, defineRoute): use `validate: {}` namespace

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -59,9 +59,11 @@ export function defineValidatedHandler<
   Res extends EventHandlerResponse = EventHandlerResponse,
 >(
   def: Omit<EventHandlerObject, "handler"> & {
-    body?: RequestBody;
-    headers?: RequestHeaders;
-    query?: RequestQuery;
+    validate?: {
+      body?: RequestBody;
+      headers?: RequestHeaders;
+      query?: RequestQuery;
+    };
     handler: EventHandler<
       {
         body: InferOutput<RequestBody>;
@@ -74,11 +76,20 @@ export function defineValidatedHandler<
   TypedRequest<InferOutput<RequestBody>, InferOutput<RequestHeaders>>,
   Res
 > {
+  if (!def.validate) {
+    return defineHandler(def) as any;
+  }
   return defineHandler({
     ...def,
     handler: (event) => {
-      (event as any) /* readonly */.req = validatedRequest(event.req, def);
-      (event as any) /* readonly */.url = validatedURL(event.url, def);
+      (event as any) /* readonly */.req = validatedRequest(
+        event.req,
+        def.validate!,
+      );
+      (event as any) /* readonly */.url = validatedURL(
+        event.url,
+        def.validate!,
+      );
       return def.handler(event as any);
     },
   }) as any;

--- a/src/utils/internal/validate.ts
+++ b/src/utils/internal/validate.ts
@@ -65,36 +65,36 @@ export function validatedRequest<
   RequestHeaders extends StandardSchemaV1,
 >(
   req: ServerRequest,
-  validators: {
+  validate: {
     body?: RequestBody;
     headers?: RequestHeaders;
   },
 ): ServerRequest {
   // Validate Headers
-  if (validators.headers) {
+  if (validate.headers) {
     const validatedheaders = syncValidate(
       "headers",
       Object.fromEntries(req.headers.entries()),
-      validators.headers as StandardSchemaV1<Record<string, string>>,
+      validate.headers as StandardSchemaV1<Record<string, string>>,
     );
     for (const [key, value] of Object.entries(validatedheaders)) {
       req.headers.set(key, value);
     }
   }
 
-  if (!validators.body) {
+  if (!validate.body) {
     return req;
   }
 
   // Create proxy for lazy body validation
   return new Proxy(req, {
     get(_target, prop: keyof ServerRequest) {
-      if (validators.body) {
+      if (validate.body) {
         if (prop === "json") {
           return () =>
             req
               .json()
-              .then((data) => validators.body!["~standard"].validate(data))
+              .then((data) => validate.body!["~standard"].validate(data))
               .then((result) =>
                 result.issues
                   ? Promise.reject(createValidationError(result))
@@ -113,18 +113,18 @@ export function validatedRequest<
 
 export function validatedURL(
   url: URL,
-  validators: {
+  validate: {
     query?: StandardSchemaV1;
   },
 ): URL {
-  if (!validators.query) {
+  if (!validate.query) {
     return url;
   }
 
   const validatedQuery = syncValidate(
     "query",
     Object.fromEntries(url.searchParams.entries()),
-    validators.query as StandardSchemaV1<Record<string, string>>,
+    validate.query as StandardSchemaV1<Record<string, string>>,
   );
 
   for (const [key, value] of Object.entries(validatedQuery)) {

--- a/src/utils/route.ts
+++ b/src/utils/route.ts
@@ -34,11 +34,12 @@ export interface RouteDefinition {
   meta?: Record<string, unknown>;
 
   // Validation schemas
-  // TODO: Support response and router params validation in defineValidatedHandler
-  // TODO: (breaking change) use `validate` namespace
-  body?: StandardSchemaV1;
-  headers?: StandardSchemaV1;
-  query?: StandardSchemaV1;
+  // TODO: Support generics for better typing `handler` input
+  validate?: {
+    body?: StandardSchemaV1;
+    headers?: StandardSchemaV1;
+    query?: StandardSchemaV1;
+  };
 }
 
 /**
@@ -50,9 +51,10 @@ export interface RouteDefinition {
  *
  * const userRoute = defineRoute({
  *    method: 'POST',
- *    route: '/api/users/:id',
- *    query: z.object({ id: z.string().uuid() }),
- *    body: z.object({ name: z.string() }),
+ *    validate: {
+ *      query: z.object({ id: z.string().uuid() }),
+ *      body: z.object({ name: z.string() }),
+ *    },
  *    handler: (event) => {
  *      return { success: true };
  *    }

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -82,16 +82,18 @@ describe("handler.ts", () => {
 
   describe("defineValidatedHandler", () => {
     const handler = defineValidatedHandler({
-      body: z.object({
-        name: z.string(),
-        age: z.number().optional().default(20),
-      }),
-      headers: z.object({
-        "x-token": z.string(),
-      }),
-      query: z.object({
-        id: z.string().min(3),
-      }),
+      validate: {
+        body: z.object({
+          name: z.string(),
+          age: z.number().optional().default(20),
+        }),
+        headers: z.object({
+          "x-token": z.string(),
+        }),
+        query: z.object({
+          id: z.string().min(3),
+        }),
+      },
       handler: async (event) => {
         return {
           body: await event.req.json(),

--- a/test/route.test.ts
+++ b/test/route.test.ts
@@ -62,7 +62,9 @@ describe("defineRoute", () => {
     const routePlugin = defineRoute({
       method: "POST",
       route: "/users",
-      query: z.object({ id: z.string().uuid() }),
+      validate: {
+        query: z.object({ id: z.string().uuid() }),
+      },
       handler: () => "user created",
     });
     app.register(routePlugin);

--- a/test/unit/types.test-d.ts
+++ b/test/unit/types.test-d.ts
@@ -59,15 +59,17 @@ describe("types", () => {
 
     it("typed via validated event handler", () => {
       defineValidatedHandler({
-        body: z.object({
-          id: z.string(),
-        }),
-        headers: z.object({
-          "x-thing": z.string(),
-        }),
-        query: z.object({
-          search: z.string().optional(),
-        }),
+        validate: {
+          body: z.object({
+            id: z.string(),
+          }),
+          headers: z.object({
+            "x-thing": z.string(),
+          }),
+          query: z.object({
+            search: z.string().optional(),
+          }),
+        },
         async handler(event) {
           const query = getQuery(event);
           expectTypeOf(query.search).not.toBeAny();


### PR DESCRIPTION
This PR refactors experimental `defineValidatedHandler` (#1097) and `defineRoute` (#1143) to use a more clear `validate: {}` namespace in definition.