### PR TITLE
fix: Could not resolve "h3"

### DIFF
--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -44,7 +44,7 @@ describe("benchmark", () => {
 
   it("bundle size (defineHandler)", async () => {
     const code = /* js */ `
-      import { defineHandler } from "h3";
+      import { defineHandler } from "../../src/index.ts";
       const handler = defineHandler({});
     `;
     const bundle = await getBundleSize(code);


### PR DESCRIPTION
previously esbuild fails with `ERROR: Could not resolve "h3"`