### PR TITLE
fix(cors): use defaults in handleCors

### DIFF
--- a/src/utils/cors.ts
+++ b/src/utils/cors.ts
@@ -150,9 +150,9 @@ export function appendCorsHeaders(event: H3Event, options: CorsOptions): void {
 export function handleCors(event: H3Event, options: CorsOptions): false | "" {
   const _options = resolveCorsOptions(options);
   if (isPreflightRequest(event)) {
-    appendCorsPreflightHeaders(event, options);
+    appendCorsPreflightHeaders(event, _options);
     return noContent(event, _options.preflight.statusCode);
   }
-  appendCorsHeaders(event, options);
+  appendCorsHeaders(event, _options);
   return false;
 }

--- a/test/unit/cors.test.ts
+++ b/test/unit/cors.test.ts
@@ -5,6 +5,7 @@ import {
   isCorsOriginAllowed,
   appendCorsPreflightHeaders,
   appendCorsHeaders,
+  handleCors,
 } from "../../src/index.ts";
 import {
   resolveCorsOptions,
@@ -674,6 +675,53 @@ describe("cors (unit)", () => {
           eventMock.res.headers.get("access-control-allow-credentials"),
         ).toEqual("true");
       }
+    });
+  });
+
+  describe("handleCors", () => {
+    it("handles preflight request", () => {
+      const eventMock = mockEvent("/", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://example.com",
+          "access-control-request-method": "POST",
+        },
+      });
+
+      // use defaults
+      handleCors(eventMock, {});
+
+      expect(eventMock.res.headers.get("access-control-allow-origin")).toEqual(
+        "*",
+      );
+      expect(eventMock.res.headers.get("access-control-allow-methods")).toEqual(
+        "*",
+      );
+      expect(
+        eventMock.res.headers.has("access-control-expose-headers"),
+      ).toEqual(false);
+    });
+
+    it("handles normal request", () => {
+      const eventMock = mockEvent("/", {
+        method: "POST",
+        headers: {
+          origin: "https://example.com",
+        },
+      });
+
+      // use defaults
+      handleCors(eventMock, {});
+
+      expect(eventMock.res.headers.get("access-control-allow-origin")).toEqual(
+        "*",
+      );
+      expect(eventMock.res.headers.has("access-control-allow-methods")).toEqual(
+        false,
+      );
+      expect(
+        eventMock.res.headers.get("access-control-expose-headers"),
+      ).toEqual("*");
     });
   });
 });


### PR DESCRIPTION
Resolves #1160.

Adds regression tests for `handleCors` (there weren't any).