### PR TITLE
docs: fix example for noContent util

### DIFF
--- a/docs/2.utils/2.response.md
+++ b/docs/2.utils/2.response.md
@@ -117,7 +117,7 @@ Respond with an empty payload.<br>
 **Example:**
 
 ```ts
-app.get("/", () => noContent());
+app.get("/", (event) => noContent(event));
 ```
 
 ### `redirect(event, location, code)`

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -11,7 +11,7 @@ import {
  * Respond with an empty payload.<br>
  *
  * @example
- * app.get("/", () => noContent());
+ * app.get("/", (event) => noContent(event));
  *
  * @param event H3 event
  * @param code status code to be send. By default, it is `204 No Content`.


### PR DESCRIPTION
resolves #1170

I chose to explicitly pass in the event rather than do it implicitly like this

```js
app.get("/", noContent);
```

in case there are [future signature changes](https://jakearchibald.com/2021/function-callback-risks/)