### PR TITLE
feat(middleware): allow passthrough response without enforcing explicit return

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -69,7 +69,19 @@ export function callMiddleware(
     return handler(event);
   }
   const fn = middleware[index];
-  const next = () => callMiddleware(event, middleware, handler, index + 1);
+
+  let nextCalled = false;
+  let nextResult: unknown;
+  const next = () => {
+    if (nextCalled) {
+      return nextResult;
+    }
+
+    nextCalled = true;
+    nextResult = callMiddleware(event, middleware, handler, index + 1);
+    return nextResult;
+  };
+
   const ret = fn(event, next);
   return ret === undefined || ret === kNotFound
     ? next()


### PR DESCRIPTION
resolves https://github.com/h3js/h3/issues/1172

This PR enables middleware to pass through the response from other middlewares or handler without enforcing an explicit `return next()`.

This improves DX, especially when the user doesn't care about the response and is likely to forget to return after calling `next()`.

Before:

```ts
app.use(async (event, next) => {
  // before...
  const result = await next()
  // after...

  // ↓ this is likely to be forgotton.
  return result
})
```

After:

```ts
app.use(async (event, next) => {
  // before...
  await next()
  // after...

  // no needs to return
})
```
