### PR TITLE
fix: use `H3RouteMeta` in `RouteDefinition` types

### DIFF
--- a/src/utils/route.ts
+++ b/src/utils/route.ts
@@ -1,4 +1,4 @@
-import type { HTTPMethod } from "../types/h3.ts";
+import type { H3RouteMeta, HTTPMethod } from "../types/h3.ts";
 import type { EventHandler, Middleware } from "../types/handler.ts";
 import type { H3Plugin, H3 } from "../types/h3.ts";
 import type { StandardSchemaV1 } from "./internal/standard-schema.ts";
@@ -31,7 +31,7 @@ export interface RouteDefinition {
   /**
    * Additional route metadata.
    */
-  meta?: Record<string, unknown>;
+  meta?: H3RouteMeta;
 
   // Validation schemas
   // TODO: Support generics for better typing `handler` input


### PR DESCRIPTION
This PR fixes the `meta` type inside `RouteDefinition` to use the `H3RouteMeta`. This aligns it with the rest of the meta properties and enables consistent type augmentation across all route definitions.

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
