### PR TITLE
feat: inherit `req.context` and `ServerRequestContext` types

### DIFF
--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -28,9 +28,11 @@ export type NodeMiddleware = (
  */
 export function toWebHandler(
   app: H3,
-): (request: ServerRequest, context?: H3Event) => Promise<Response> {
+): (request: ServerRequest, context?: H3EventContext) => Promise<Response> {
   return (request, context) => {
-    return Promise.resolve(app.request(request, undefined, context));
+    return Promise.resolve(
+      app.request(request, undefined, context || request.context),
+    );
   };
 }
 

--- a/src/event.ts
+++ b/src/event.ts
@@ -47,7 +47,7 @@ export class H3Event<
   _res?: H3EventResponse;
 
   constructor(req: ServerRequest, context?: H3EventContext, app?: H3Core) {
-    this.context = context || new EmptyObject();
+    this.context = context || req.context || new EmptyObject();
     this.req = req;
     this.app = app;
     // Parsed URL can be provided by srvx (node) and other runtimes

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -1,7 +1,8 @@
 import type { Session } from "../utils/session.ts";
 import type { H3Route } from "./h3.ts";
+import type { ServerRequestContext } from "srvx";
 
-export interface H3EventContext extends Record<string, any> {
+export interface H3EventContext extends ServerRequestContext {
   /* Matched router parameters */
   params?: Record<string, string>;
 

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -10,27 +10,29 @@ describeMatrix("middleware", (t, { it, expect }) => {
         return "Intercepted 1";
       }
       event.context._middleware = [];
-      event.context._middleware.push(`(event)`);
+      (event.context._middleware as string[]).push(`(event)`);
     });
 
     t.app.use(async (event) => {
-      event.context._middleware.push(`async (event)`);
+      (event.context._middleware as string[]).push(`async (event)`);
       await Promise.resolve();
     });
 
     t.app.use(async (event, next) => {
-      event.context._middleware.push(`async (event, next)`);
+      (event.context._middleware as string[]).push(`async (event, next)`);
       const value = await next();
       return value;
     });
 
     t.app.use(async (event, next) => {
-      event.context._middleware.push(`async (event, next) (passthrough)`);
+      (event.context._middleware as string[]).push(
+        `async (event, next) (passthrough)`,
+      );
       await next();
     });
 
     t.app.use((event, next) => {
-      event.context._middleware.push(`(event, next)`);
+      (event.context._middleware as string[]).push(`(event, next)`);
       return next();
     });
 
@@ -53,21 +55,21 @@ describeMatrix("middleware", (t, { it, expect }) => {
       defineHandler({
         middleware: [
           (event) => {
-            event.context._middleware.push(`route (define)`);
+            (event.context._middleware as string[]).push(`route (define)`);
           },
         ],
         handler: (event) => {
           count++;
           return {
             count,
-            log: event.context._middleware.join(" > "),
+            log: (event.context._middleware as string[]).join(" > "),
           };
         },
       }),
       {
         middleware: [
           (event) => {
-            event.context._middleware.push(`route (register)`);
+            (event.context._middleware as string[]).push(`route (register)`);
           },
         ],
       },


### PR DESCRIPTION
This PR adds support for `ServerRequest.context` to be automatically used for `H3Event.context` instead of initiating another ref for broader compatibility.

Also now `h3.H3EventContext` inherits `srvxServerRequestContext` for sharing types.