### PR TITLE
chore: import `ProxyOptions` type separately

### DIFF
--- a/src/_deprecated.ts
+++ b/src/_deprecated.ts
@@ -5,11 +5,12 @@ import {
   toNodeHandler,
 } from "./adapters.ts";
 import { defineHandler, defineLazyEventHandler } from "./handler.ts";
-import { proxy, type ProxyOptions } from "./utils/proxy.ts";
+import { proxy } from "./utils/proxy.ts";
 import { H3 } from "./h3.ts";
 import { withBase } from "./utils/base.ts";
 import { sanitizeStatusCode, sanitizeStatusMessage } from "./utils/sanitize.ts";
 
+import type { ProxyOptions } from "./utils/proxy.ts";
 import type { NodeHandler, NodeMiddleware } from "./adapters.ts";
 import type { H3Event } from "./event.ts";
 import type { EventHandler } from "./types/handler.ts";


### PR DESCRIPTION
Actually I have seen we import types separately and function separately . For example, here we have toNodeHandler function is imported separately and NodeHandler type is also imported separately from the same file. That is why I thought we can import ProxyOptions type separately as well here. 