### PR TITLE
fix: re-export used crossws types

### DIFF
--- a/src/utils/ws.ts
+++ b/src/utils/ws.ts
@@ -3,6 +3,8 @@ import { defineHandler } from "../handler.ts";
 import type { Hooks as WSHooks } from "crossws";
 import type { EventHandler } from "../types/handler.ts";
 
+export type { Hooks, Peer, AdapterInternal, Message } from "crossws";
+
 /**
  * Define WebSocket hooks.
  *


### PR DESCRIPTION
`h3` directly relies on `crossws` for it's WS handling, but doesn't make the `crossws` types available to consumers of `h3`. This in turn makes it quite hard to properly type functions that rely on the returned values in the WS handlers, as it forces the consumer of `h3` to also add `crossws` as a devDependency and ensure that the version of `crossws` exactly matches the version in use by `h3` to ensure there's no type conflicts. This is a pretty poor DX. By re-exporting the types used for the `crossws` logic that's relied on by `h3` this problem is resolved.

I've identified `Hooks`, `Peer`, `AdapterInternal`, and `Message` as the ones you immediately run into when using `defineWebSocketHandler`, but there might be others. I didn't want to go as far as to `export *` as that'll add a bunch of unused types and other noise to `h3`s global scope as well. 

Fixes #716

