### PR TITLE
feat: support universal `{ fetch }` handlers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export type {
   PreparedResponse,
   RouteOptions,
   MiddlewareOptions,
-  FetchHandler,
+  RouteHandler,
 } from "./types/h3.ts";
 
 export { definePlugin } from "./types/h3.ts";
@@ -38,6 +38,8 @@ export type {
   LazyEventHandler,
   Middleware,
   EventHandlerObject,
+  FetchHandler,
+  FetchableObject,
 } from "./types/handler.ts";
 
 export {

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -1,8 +1,8 @@
 import type { H3EventContext } from "./context.ts";
-import type { EventHandler, Middleware } from "./handler.ts";
+import type { EventHandler, FetchableObject, Middleware } from "./handler.ts";
 import type { HTTPError } from "../error.ts";
 import type { MaybePromise } from "./_utils.ts";
-import type { ServerRequest } from "srvx";
+import type { FetchHandler, ServerRequest } from "srvx";
 import type { MatchedRoute } from "rou3";
 import type { H3Event } from "../event.ts";
 
@@ -44,7 +44,7 @@ export interface H3Route {
   handler: EventHandler;
 }
 
-// --- H3 Pluins ---
+// --- H3 Plugins ---
 
 export type H3Plugin = (h3: H3) => void;
 
@@ -56,7 +56,7 @@ export function definePlugin<T = unknown>(
 
 // --- H3 App ---
 
-export type FetchHandler = (req: ServerRequest) => Response | Promise<Response>;
+export type RouteHandler = EventHandler | FetchableObject;
 
 export type RouteOptions = {
   middleware?: Middleware[];
@@ -152,22 +152,26 @@ export declare class H3 {
   on(
     method: HTTPMethod | Lowercase<HTTPMethod> | "",
     route: string,
-    handler: EventHandler,
+    handler: RouteHandler,
     opts?: RouteOptions,
   ): this;
 
   /**
    * Register a route handler for all HTTP methods.
    */
-  all(route: string, handler: EventHandler, opts?: RouteOptions): this;
+  all(route: string, handler: RouteHandler, opts?: RouteOptions): this;
 
-  get(route: string, handler: EventHandler, opts?: RouteOptions): this;
-  post(route: string, handler: EventHandler, opts?: RouteOptions): this;
-  put(route: string, handler: EventHandler, opts?: RouteOptions): this;
-  delete(route: string, handler: EventHandler, opts?: RouteOptions): this;
-  patch(route: string, handler: EventHandler, opts?: RouteOptions): this;
-  head(route: string, handler: EventHandler, opts?: RouteOptions): this;
-  options(route: string, handler: EventHandler, opts?: RouteOptions): this;
-  connect(route: string, handler: EventHandler, opts?: RouteOptions): this;
-  trace(route: string, handler: EventHandler, opts?: RouteOptions): this;
+  get(route: string, handler: RouteHandler, opts?: RouteOptions): this;
+  post(
+    route: string,
+    handler: EventHandler | FetchableObject,
+    opts?: RouteOptions,
+  ): this;
+  put(route: string, handler: RouteHandler, opts?: RouteOptions): this;
+  delete(route: string, handler: RouteHandler, opts?: RouteOptions): this;
+  patch(route: string, handler: RouteHandler, opts?: RouteOptions): this;
+  head(route: string, handler: RouteHandler, opts?: RouteOptions): this;
+  options(route: string, handler: RouteHandler, opts?: RouteOptions): this;
+  connect(route: string, handler: RouteHandler, opts?: RouteOptions): this;
+  trace(route: string, handler: RouteHandler, opts?: RouteOptions): this;
 }

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -162,11 +162,7 @@ export declare class H3 {
   all(route: string, handler: RouteHandler, opts?: RouteOptions): this;
 
   get(route: string, handler: RouteHandler, opts?: RouteOptions): this;
-  post(
-    route: string,
-    handler: EventHandler | FetchableObject,
-    opts?: RouteOptions,
-  ): this;
+  post(route: string, handler: RouteHandler, opts?: RouteOptions): this;
   put(route: string, handler: RouteHandler, opts?: RouteOptions): this;
   delete(route: string, handler: RouteHandler, opts?: RouteOptions): this;
   patch(route: string, handler: RouteHandler, opts?: RouteOptions): this;

--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -14,15 +14,12 @@ export interface EventHandler<
   meta?: H3RouteMeta;
 }
 
-export type EventHandlerFetch<T extends Response | TypedResponse = Response> = (
-  req: ServerRequest | URL | string,
-) => Promise<T>;
-
 export interface EventHandlerObject<
   _RequestT extends EventHandlerRequest = EventHandlerRequest,
   _ResponseT extends EventHandlerResponse = EventHandlerResponse,
 > {
-  handler: EventHandler<_RequestT, _ResponseT>;
+  handler?: EventHandler<_RequestT, _ResponseT>;
+  fetch?: FetchHandler;
   middleware?: Middleware[];
   meta?: H3RouteMeta;
 }
@@ -35,13 +32,6 @@ export interface EventHandlerRequest {
 
 export type EventHandlerResponse<T = unknown> = T | Promise<T>;
 
-export type EventHandlerWithFetch<
-  _RequestT extends EventHandlerRequest = EventHandlerRequest,
-  _ResponseT extends EventHandlerResponse = EventHandlerResponse,
-> = EventHandler<_RequestT, _ResponseT> & {
-  fetch: EventHandlerFetch<TypedResponse<_ResponseT, ResponseHeaderMap>>;
-};
-
 export type TypedServerRequest<
   _RequestT extends EventHandlerRequest = EventHandlerRequest,
 > = Omit<ServerRequest, "json" | "headers" | "clone"> &
@@ -52,6 +42,22 @@ export type TypedServerRequest<
     >,
     "json" | "headers" | "clone"
   >;
+
+// --- fetchable ---
+
+export type FetchHandler = (req: ServerRequest) => Response | Promise<Response>;
+export type FetchableObject = { fetch: FetchHandler };
+
+export type EventHandlerWithFetch<
+  _RequestT extends EventHandlerRequest = EventHandlerRequest,
+  _ResponseT extends EventHandlerResponse = EventHandlerResponse,
+> = EventHandler<_RequestT, _ResponseT> & {
+  fetch: EventHandlerFetch<TypedResponse<_ResponseT, ResponseHeaderMap>>;
+};
+
+export type EventHandlerFetch<T extends Response | TypedResponse = Response> = (
+  req: ServerRequest | URL | string,
+) => Promise<T>;
 
 //  --- middleware ---
 

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -230,6 +230,16 @@ describeMatrix("app", (t, { it, expect }) => {
     expect(await res.text()).toBe("42");
   });
 
+  it("can use fetchable routes", async () => {
+    t.app.get("/fetchable", {
+      fetch: async () => {
+        return new Response("fetchable");
+      },
+    });
+    const res = await t.fetch("/fetchable");
+    expect(await res.text()).toBe("fetchable");
+  });
+
   it("handles next() call with no routes matching", async () => {
     t.app.use(() => {});
     t.app.use(() => {});

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -18,13 +18,23 @@ describe("handler.ts", () => {
       expect(eventHandler).toBe(handler);
     });
 
-    it("object syntax", () => {
+    it("object syntax (h3 handler)", () => {
       const handler = vi.fn();
       const middleware = [vi.fn()];
       const eventHandler = defineHandler({ handler, middleware });
       eventHandler({} as H3Event);
       expect(middleware[0]).toHaveBeenCalled();
       expect(handler).toHaveBeenCalled();
+    });
+
+    it("object syntax (fetchable)", () => {
+      const fetchHandler = vi.fn();
+      const middleware = [vi.fn()];
+      const eventHandler = defineHandler({ fetch: fetchHandler, middleware });
+      eventHandler({} as H3Event);
+      expect(eventHandler.fetch).toBe(fetchHandler);
+      expect(middleware[0]).toHaveBeenCalled();
+      expect(fetchHandler).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
H3 by default supports `(event: H3Event) => any` handler format.

For better external compatibility, we have introduced `app.mount(<base>, <fetchable>)` where it is possible to mount an external framework like Elysia or Hono, or simply use `{ fetch(req: Request) => Response }` universal alternative format.

This PR adds Fetchable object format support for also `h3App[method]("route", <fetchable>)` and `defineHandler`. 

```js
import { H3 } from "h3";

const app = new H3();

app.get("/hello/:id", {
  fetch: (req) => new Response("Standards FTW!"),
});

export default app;
```

This is particularly useful to be used together with filesystem routing like Nitro to mount any standard fetchable handler, also via filesystem routes.

```ts
// routes/hello/[id].ts

// Standard handler
import { defineHandler } from "h3"
export default defineHandler({
  fetch: (req) => new Response("Standards FTW!"),
})

// Hono (https://hono.dev/)
import { Hono } from "hono";
export default new Hono().get("/", (c) =>
   c.text("Hello from server entry (Hono)!")
 );

// Elysia (https://elysiajs.com/)
import { Elysia } from "elysia";
export default new Elysia().get("/", () => "Hello from server entry (Elysia)!");
```