### PR TITLE
feat!: `HTTPResponse`

### DIFF
--- a/docs/2.utils/2.response.md
+++ b/docs/2.utils/2.response.md
@@ -70,15 +70,7 @@ Dynamically serve static assets based on the request path.
 
 <!-- automd:jsdocs src="../../src/utils/response.ts" -->
 
-### `html(strings)`
-
-Respond with HTML content.
-
-**Example:**
-
-```ts
-app.get("/", () => html("<h1>Hello, World!</h1>"));
-```
+### `html(first)`
 
 ### `iterable(iterable)`
 

--- a/docs/2.utils/2.response.md
+++ b/docs/2.utils/2.response.md
@@ -120,7 +120,7 @@ Respond with an empty payload.<br>
 app.get("/", () => noContent());
 ```
 
-### `redirect(location, status)`
+### `redirect(location, status, statusText?)`
 
 Send a redirect response to the client.
 

--- a/docs/2.utils/2.response.md
+++ b/docs/2.utils/2.response.md
@@ -70,17 +70,17 @@ Dynamically serve static assets based on the request path.
 
 <!-- automd:jsdocs src="../../src/utils/response.ts" -->
 
-### `html(event, content)`
+### `html(strings)`
 
 Respond with HTML content.
 
 **Example:**
 
 ```ts
-app.get("/", (event) => html(event, "<h1>Hello, World!</h1>"));
+app.get("/", () => html("<h1>Hello, World!</h1>"));
 ```
 
-### `iterable(_event, iterable)`
+### `iterable(iterable)`
 
 Iterate a source of chunks and send back each chunk in order. Supports mixing async work together with emitting chunks.
 
@@ -110,17 +110,17 @@ async function delay(ms) {
 }
 ```
 
-### `noContent(event, code?)`
+### `noContent(code)`
 
 Respond with an empty payload.<br>
 
 **Example:**
 
 ```ts
-app.get("/", (event) => noContent(event));
+app.get("/", () => noContent());
 ```
 
-### `redirect(event, location, code)`
+### `redirect(location, status)`
 
 Send a redirect response to the client.
 
@@ -131,16 +131,16 @@ In the body, it sends a simple HTML page with a meta refresh tag to redirect the
 **Example:**
 
 ```ts
-app.get("/", (event) => {
-  return redirect(event, "https://example.com");
+app.get("/", () => {
+  return redirect("https://example.com");
 });
 ```
 
 **Example:**
 
 ```ts
-app.get("/", (event) => {
-  return redirect(event, "https://example.com", 301); // Permanent redirect
+app.get("/", () => {
+  return redirect("https://example.com", 301); // Permanent redirect
 });
 ```
 

--- a/docs/2.utils/2.response.md
+++ b/docs/2.utils/2.response.md
@@ -91,7 +91,7 @@ For generator (yielding) functions, the returned value is treated the same as yi
 **Example:**
 
 ```ts
-return iterable(event, async function* work() {
+return iterable(async function* work() {
   // Open document body
   yield "<!DOCTYPE html>\n<html><body><h1>Executing...</h1><ol>\n";
   // Do work ...
@@ -110,7 +110,7 @@ async function delay(ms) {
 }
 ```
 
-### `noContent(code)`
+### `noContent(status)`
 
 Respond with an empty payload.<br>
 

--- a/src/_deprecated.ts
+++ b/src/_deprecated.ts
@@ -168,7 +168,7 @@ export const sendProxy: (
   event: H3Event,
   target: string,
   opts?: ProxyOptions,
-) => Promise<BodyInit | undefined | null> = proxy;
+) => Promise<HTTPResponse> = proxy;
 
 /** @deprecated Please use `return iterable(event, value)` */
 export const sendIterable: <Value = unknown, Return = unknown>(

--- a/src/_deprecated.ts
+++ b/src/_deprecated.ts
@@ -20,7 +20,7 @@ import type {
   IteratorSerializer,
 } from "./utils/internal/iterable.ts";
 import { HTTPError, type ErrorDetails } from "./error.ts";
-import type { PseudoResponse } from "./response.ts";
+import type { HTTPResponse } from "./response.ts";
 
 // --- Error ---
 
@@ -146,17 +146,17 @@ export function sendStream(
 }
 
 /** @deprecated Please use `return noContent(event)` */
-export const sendNoContent: (
-  event: H3Event,
-  code?: number,
-) => PseudoResponse = (_, code) => noContent(code);
+export const sendNoContent: (event: H3Event, code?: number) => HTTPResponse = (
+  _,
+  code,
+) => noContent(code);
 
 /** @deprecated Please use `return redirect(event, code)` */
 export const sendRedirect: (
   event: H3Event,
   location: string,
   code: number,
-) => PseudoResponse = (_, loc, code) => redirect(loc, code);
+) => HTTPResponse = (_, loc, code) => redirect(loc, code);
 
 /** @deprecated Please directly return response */
 export const sendWebResponse: (response: Response) => Response = (
@@ -177,7 +177,7 @@ export const sendIterable: <Value = unknown, Return = unknown>(
   options?: {
     serializer: IteratorSerializer<Value | Return>;
   },
-) => PseudoResponse = (_event, val, options) => {
+) => HTTPResponse = (_event, val, options) => {
   return iterable(val, options);
 };
 

--- a/src/_deprecated.ts
+++ b/src/_deprecated.ts
@@ -20,6 +20,7 @@ import type {
   IteratorSerializer,
 } from "./utils/internal/iterable.ts";
 import { HTTPError, type ErrorDetails } from "./error.ts";
+import type { PseudoResponse } from "./response.ts";
 
 // --- Error ---
 
@@ -145,15 +146,17 @@ export function sendStream(
 }
 
 /** @deprecated Please use `return noContent(event)` */
-export const sendNoContent: (event: H3Event, code?: number) => Response =
-  noContent;
+export const sendNoContent: (
+  event: H3Event,
+  code?: number,
+) => PseudoResponse = (_, code) => noContent(code);
 
 /** @deprecated Please use `return redirect(event, code)` */
 export const sendRedirect: (
   event: H3Event,
   location: string,
   code: number,
-) => string = redirect;
+) => PseudoResponse = (_, loc, code) => redirect(loc, code);
 
 /** @deprecated Please directly return response */
 export const sendWebResponse: (response: Response) => Response = (
@@ -170,11 +173,13 @@ export const sendProxy: (
 /** @deprecated Please use `return iterable(event, value)` */
 export const sendIterable: <Value = unknown, Return = unknown>(
   _event: H3Event,
-  iterable: IterationSource<Value, Return>,
+  val: IterationSource<Value, Return>,
   options?: {
     serializer: IteratorSerializer<Value | Return>;
   },
-) => ReadableStream = iterable;
+) => PseudoResponse = (_event, val, options) => {
+  return iterable(val, options);
+};
 
 /** @deprecated Please use `event.res.statusText` */
 export function getResponseStatusText(event: H3Event): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ export { defineMiddleware, callMiddleware } from "./middleware.ts";
 
 // Response
 
-export { toResponse, PseudoResponse } from "./response.ts";
+export { toResponse, HTTPResponse } from "./response.ts";
 
 // Error
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ export { defineMiddleware, callMiddleware } from "./middleware.ts";
 
 // Response
 
-export { toResponse } from "./response.ts";
+export { toResponse, PseudoResponse } from "./response.ts";
 
 // Error
 

--- a/src/response.ts
+++ b/src/response.ts
@@ -55,12 +55,6 @@ export class HTTPResponse {
   get headers(): Headers {
     return (this.#headers ||= new Headers(this.#init?.headers));
   }
-  static [Symbol.hasInstance](instance: unknown): boolean {
-    return (
-      instance instanceof Response ||
-      instance?.constructor?.name === "HTTPResponse"
-    );
-  }
 }
 
 function prepareResponse(
@@ -183,7 +177,10 @@ function prepareResponseBody(
   }
 
   // Partial Response
-  if (val instanceof HTTPResponse) {
+  if (
+    val instanceof HTTPResponse ||
+    val?.constructor?.name === "HTTPResponse"
+  ) {
     return val;
   }
 

--- a/src/response.ts
+++ b/src/response.ts
@@ -35,7 +35,7 @@ export function toResponse(
     : response;
 }
 
-export class PseudoResponse {
+export class HTTPResponse {
   #headers?: Headers;
   #init?: Pick<ResponseInit, "status" | "statusText" | "headers"> | undefined;
   body?: BodyInit | null;
@@ -155,7 +155,7 @@ function prepareResponseBody(
   val: unknown,
   event: H3Event,
   config: H3Config,
-): Partial<PseudoResponse> {
+): Partial<HTTPResponse> {
   // Empty Content
   if (val === null || val === undefined) {
     return { body: "", headers: emptyHeaders };
@@ -177,7 +177,7 @@ function prepareResponseBody(
   }
 
   // Partial Response
-  if (val instanceof PseudoResponse) {
+  if (val instanceof HTTPResponse) {
     return val;
   }
 

--- a/src/response.ts
+++ b/src/response.ts
@@ -55,6 +55,12 @@ export class HTTPResponse {
   get headers(): Headers {
     return (this.#headers ||= new Headers(this.#init?.headers));
   }
+  static [Symbol.hasInstance](instance: unknown): boolean {
+    return (
+      instance instanceof Response ||
+      instance?.constructor?.name === "HTTPResponse"
+    );
+  }
 }
 
 function prepareResponse(

--- a/src/response.ts
+++ b/src/response.ts
@@ -35,6 +35,28 @@ export function toResponse(
     : response;
 }
 
+export class PseudoResponse {
+  #headers?: Headers;
+  #init?: Pick<ResponseInit, "status" | "statusText" | "headers"> | undefined;
+  body?: BodyInit | null;
+  constructor(
+    body: BodyInit | null,
+    init?: Pick<ResponseInit, "status" | "statusText" | "headers">,
+  ) {
+    this.body = body;
+    this.#init = init;
+  }
+  get status(): number {
+    return this.#init?.status || 200;
+  }
+  get statusText(): string {
+    return this.#init?.statusText || "OK";
+  }
+  get headers(): Headers {
+    return (this.#headers ||= new Headers(this.#init?.headers));
+  }
+}
+
 function prepareResponse(
   val: unknown,
   event: H3Event,
@@ -83,12 +105,12 @@ function prepareResponse(
 
   if (!(val instanceof Response)) {
     const res = prepareResponseBody(val, event, config);
-    const status = preparedRes?.status;
+    const status = res.status || preparedRes?.status;
     return new FastResponse(
       nullBody(event.req.method, status) ? null : res.body,
       {
         status,
-        statusText: preparedRes?.statusText,
+        statusText: res.statusText || preparedRes?.statusText,
         headers:
           res.headers && preparedHeaders
             ? mergeHeaders(res.headers, preparedHeaders)
@@ -133,7 +155,7 @@ function prepareResponseBody(
   val: unknown,
   event: H3Event,
   config: H3Config,
-): { body: BodyInit; headers?: HeadersInit } {
+): Partial<PseudoResponse> {
   // Empty Content
   if (val === null || val === undefined) {
     return { body: "", headers: emptyHeaders };
@@ -154,6 +176,11 @@ function prepareResponseBody(
     return { body: val as BufferSource };
   }
 
+  // Partial Response
+  if (val instanceof PseudoResponse) {
+    return val;
+  }
+
   // JSON
   if (isJSONSerializable(val, valType)) {
     return {
@@ -169,18 +196,20 @@ function prepareResponseBody(
 
   // Blob
   if (val instanceof Blob) {
-    const headers: Record<string, string> = {
+    const headers = new Headers({
       "content-type": val.type,
       "content-length": val.size.toString(),
-    };
+    });
 
     // File
     let filename = (val as File).name;
     if (filename) {
       filename = encodeURIComponent(filename);
       // Omit the disposition type ("inline" or "attachment") and let the client (browser) decide.
-      headers["content-disposition"] =
-        `filename="${filename}"; filename*=UTF-8''${filename}`;
+      headers.set(
+        "content-disposition",
+        `filename="${filename}"; filename*=UTF-8''${filename}`,
+      );
     }
 
     return { body: val.stream(), headers };

--- a/src/utils/cors.ts
+++ b/src/utils/cors.ts
@@ -9,6 +9,7 @@ import {
   createOriginHeaders,
   resolveCorsOptions,
 } from "./internal/cors.ts";
+import type { PseudoResponse } from "../response.ts";
 
 export { isCorsOriginAllowed } from "./internal/cors.ts";
 
@@ -150,11 +151,11 @@ export function appendCorsHeaders(event: H3Event, options: CorsOptions): void {
 export function handleCors(
   event: H3Event,
   options: CorsOptions,
-): false | Response {
+): false | PseudoResponse {
   const _options = resolveCorsOptions(options);
   if (isPreflightRequest(event)) {
     appendCorsPreflightHeaders(event, _options);
-    return noContent(event, _options.preflight.statusCode);
+    return noContent(_options.preflight.statusCode);
   }
   appendCorsHeaders(event, _options);
   return false;

--- a/src/utils/cors.ts
+++ b/src/utils/cors.ts
@@ -9,7 +9,7 @@ import {
   createOriginHeaders,
   resolveCorsOptions,
 } from "./internal/cors.ts";
-import type { PseudoResponse } from "../response.ts";
+import type { HTTPResponse } from "../response.ts";
 
 export { isCorsOriginAllowed } from "./internal/cors.ts";
 
@@ -151,7 +151,7 @@ export function appendCorsHeaders(event: H3Event, options: CorsOptions): void {
 export function handleCors(
   event: H3Event,
   options: CorsOptions,
-): false | PseudoResponse {
+): false | HTTPResponse {
   const _options = resolveCorsOptions(options);
   if (isPreflightRequest(event)) {
     appendCorsPreflightHeaders(event, _options);

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -1,7 +1,6 @@
 import type { H3Event } from "../event.ts";
 
 import { splitSetCookieString } from "cookie-es";
-import { sanitizeStatusMessage } from "./sanitize.ts";
 import { HTTPError } from "../error.ts";
 import {
   PayloadMethods,
@@ -11,6 +10,7 @@ import {
 } from "./internal/proxy.ts";
 import { EmptyObject } from "./internal/obj.ts";
 import type { ServerRequest } from "srvx";
+import { HTTPResponse } from "../response.ts";
 
 export interface ProxyOptions {
   headers?: HeadersInit;
@@ -29,7 +29,7 @@ export async function proxyRequest(
   event: H3Event,
   target: string,
   opts: ProxyOptions = {},
-): Promise<BodyInit | undefined | null> {
+): Promise<HTTPResponse> {
   // Request Body
   const requestBody = PayloadMethods.has(event.req.method)
     ? event.req.body
@@ -68,7 +68,7 @@ export async function proxy(
   event: H3Event,
   target: string,
   opts: ProxyOptions = {},
-): Promise<BodyInit | undefined | null> {
+): Promise<HTTPResponse> {
   const fetchOptions: RequestInit = {
     headers: opts.headers as HeadersInit,
     ...opts.fetchOptions,
@@ -83,7 +83,8 @@ export async function proxy(
   } catch (error) {
     throw new HTTPError({ status: 502, cause: error });
   }
-  event.res.statusText = sanitizeStatusMessage(response.statusText);
+
+  const headers = new Headers();
 
   const cookies: string[] = [];
 
@@ -98,7 +99,7 @@ export async function proxy(
       cookies.push(...splitSetCookieString(value));
       continue;
     }
-    event.res.headers.set(key, value);
+    headers.set(key, value);
   }
 
   if (cookies.length > 0) {
@@ -116,7 +117,7 @@ export async function proxy(
       return cookie;
     });
     for (const cookie of _cookies) {
-      event.res.headers.append("set-cookie", cookie);
+      headers.append("set-cookie", cookie);
     }
   }
 
@@ -124,7 +125,11 @@ export async function proxy(
     await opts.onResponse(event, response);
   }
 
-  return response.body;
+  return new HTTPResponse(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
 }
 
 /**

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -136,15 +136,21 @@ export function iterable<Value = unknown, Return = unknown>(
  *
  * @example
  * app.get("/", () => html("<h1>Hello, World!</h1>"));
+ * app.get("/", () => html`<h1>Hello, ${name}!</h1>`);
  */
 export function html(
   strings: TemplateStringsArray,
   ...values: unknown[]
+): HTTPResponse;
+export function html(markup: string): HTTPResponse;
+export function html(
+  first: TemplateStringsArray | string,
+  ...values: unknown[]
 ): HTTPResponse {
-  const body = strings.reduce(
-    (out, str, i) => out + str + (values[i] ?? ""),
-    "",
-  );
+  const body =
+    typeof first === "string"
+      ? first
+      : first.reduce((out, str, i) => out + str + (values[i] ?? ""), "");
   return new HTTPResponse(body, {
     headers: { "content-type": "text/html; charset=utf-8" },
   });

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -39,11 +39,16 @@ export function noContent(status: number = 204): HTTPResponse {
  *   return redirect("https://example.com", 301); // Permanent redirect
  * });
  */
-export function redirect(location: string, status: number = 302): HTTPResponse {
+export function redirect(
+  location: string,
+  status: number = 302,
+  statusText?: string,
+): HTTPResponse {
   const encodedLoc = location.replace(/"/g, "%22");
   const body = /* html */ `<html><head><meta http-equiv="refresh" content="0; url=${encodedLoc}" /></head></html>`;
   return new HTTPResponse(body, {
-    status: status,
+    status,
+    statusText: statusText || (status === 301 ? "Moved Permanently" : "Found"),
     headers: {
       "content-type": "text/html; charset=utf-8",
       location,

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -1,5 +1,5 @@
 import type { H3Event } from "../event.ts";
-import { PseudoResponse } from "../response.ts";
+import { HTTPResponse } from "../response.ts";
 import { sanitizeStatusCode } from "./sanitize.ts";
 import {
   serializeIterableValue,
@@ -17,8 +17,8 @@ import {
  * @param event H3 event
  * @param code status code to be send. By default, it is `204 No Content`.
  */
-export function noContent(code: number = 204): PseudoResponse {
-  return new PseudoResponse(null, {
+export function noContent(code: number = 204): HTTPResponse {
+  return new HTTPResponse(null, {
     status: sanitizeStatusCode(code),
     statusText: "No Content",
   });
@@ -41,13 +41,10 @@ export function noContent(code: number = 204): PseudoResponse {
  *   return redirect("https://example.com", 301); // Permanent redirect
  * });
  */
-export function redirect(
-  location: string,
-  status: number = 302,
-): PseudoResponse {
+export function redirect(location: string, status: number = 302): HTTPResponse {
   const encodedLoc = location.replace(/"/g, "%22");
   const body = /* html */ `<html><head><meta http-equiv="refresh" content="0; url=${encodedLoc}" /></head></html>`;
-  return new PseudoResponse(body, {
+  return new HTTPResponse(body, {
     status: status,
     headers: {
       "content-type": "text/html; charset=utf-8",
@@ -108,10 +105,10 @@ export function iterable<Value = unknown, Return = unknown>(
   options?: {
     serializer: IteratorSerializer<Value | Return>;
   },
-): PseudoResponse {
+): HTTPResponse {
   const serializer = options?.serializer ?? serializeIterableValue;
   const iterator = coerceIterable(iterable);
-  return new PseudoResponse(
+  return new HTTPResponse(
     new ReadableStream({
       async pull(controller) {
         const { value, done } = await iterator.next();
@@ -141,12 +138,12 @@ export function iterable<Value = unknown, Return = unknown>(
 export function html(
   strings: TemplateStringsArray,
   ...values: unknown[]
-): PseudoResponse {
+): HTTPResponse {
   const body = strings.reduce(
     (out, str, i) => out + str + (values[i] ?? ""),
     "",
   );
-  return new PseudoResponse(body, {
+  return new HTTPResponse(body, {
     headers: { "content-type": "text/html; charset=utf-8" },
   });
 }

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -1,6 +1,5 @@
 import type { H3Event } from "../event.ts";
 import { HTTPResponse } from "../response.ts";
-import { sanitizeStatusCode } from "./sanitize.ts";
 import {
   serializeIterableValue,
   coerceIterable,
@@ -14,12 +13,11 @@ import {
  * @example
  * app.get("/", () => noContent());
  *
- * @param event H3 event
- * @param code status code to be send. By default, it is `204 No Content`.
+ * @param status status code to be send. By default, it is `204 No Content`.
  */
-export function noContent(code: number = 204): HTTPResponse {
+export function noContent(status: number = 204): HTTPResponse {
   return new HTTPResponse(null, {
-    status: sanitizeStatusCode(code),
+    status,
     statusText: "No Content",
   });
 }
@@ -76,13 +74,12 @@ export function writeEarlyHints(
  *
  * For generator (yielding) functions, the returned value is treated the same as yielded values.
  *
- * @param event - H3 event
  * @param iterable - Iterator that produces chunks of the response.
  * @param serializer - Function that converts values from the iterable into stream-compatible values.
  * @template Value - Test
  *
  * @example
- * return iterable(event, async function* work() {
+ * return iterable(async function* work() {
  *   // Open document body
  *   yield "<!DOCTYPE html>\n<html><body><h1>Executing...</h1><ol>\n";
  *   // Do work ...

--- a/src/utils/static.ts
+++ b/src/utils/static.ts
@@ -2,6 +2,7 @@ import type { H3Event } from "../event.ts";
 import { HTTPError } from "../error.ts";
 import { withLeadingSlash, withoutTrailingSlash } from "./internal/path.ts";
 import { getType, getExtension } from "./internal/mime.ts";
+import { PseudoResponse } from "../response.ts";
 
 export interface StaticAssetMeta {
   type?: string;
@@ -66,7 +67,7 @@ export interface ServeStaticOptions {
 export async function serveStatic(
   event: H3Event,
   options: ServeStaticOptions,
-): Promise<false | undefined | null | BodyInit> {
+): Promise<PseudoResponse | undefined> {
   if (options.headers) {
     const entries = Array.isArray(options.headers)
       ? options.headers
@@ -129,9 +130,10 @@ export async function serveStatic(
 
     const ifModifiedSinceH = event.req.headers.get("if-modified-since");
     if (ifModifiedSinceH && new Date(ifModifiedSinceH) >= mtimeDate) {
-      event.res.status = 304;
-      event.res.statusText = "Not Modified";
-      return "";
+      return new PseudoResponse(null, {
+        status: 304,
+        statusText: "Not Modified",
+      });
     }
 
     if (!event.res.headers.get("last-modified")) {
@@ -146,9 +148,10 @@ export async function serveStatic(
   const ifNotMatch =
     meta.etag && event.req.headers.get("if-none-match") === meta.etag;
   if (ifNotMatch) {
-    event.res.status = 304;
-    event.res.statusText = "Not Modified";
-    return "";
+    return new PseudoResponse(null, {
+      status: 304,
+      statusText: "Not Modified",
+    });
   }
 
   if (!event.res.headers.get("content-type")) {
@@ -176,11 +179,11 @@ export async function serveStatic(
   }
 
   if (event.req.method === "HEAD") {
-    return "";
+    return new PseudoResponse(null, { status: 200 });
   }
 
   const contents = await options.getContents(id);
-  return contents;
+  return new PseudoResponse(contents || null, { status: 200 });
 }
 
 // --- Internal Utils ---

--- a/src/utils/static.ts
+++ b/src/utils/static.ts
@@ -2,7 +2,7 @@ import type { H3Event } from "../event.ts";
 import { HTTPError } from "../error.ts";
 import { withLeadingSlash, withoutTrailingSlash } from "./internal/path.ts";
 import { getType, getExtension } from "./internal/mime.ts";
-import { PseudoResponse } from "../response.ts";
+import { HTTPResponse } from "../response.ts";
 
 export interface StaticAssetMeta {
   type?: string;
@@ -67,7 +67,7 @@ export interface ServeStaticOptions {
 export async function serveStatic(
   event: H3Event,
   options: ServeStaticOptions,
-): Promise<PseudoResponse | undefined> {
+): Promise<HTTPResponse | undefined> {
   if (options.headers) {
     const entries = Array.isArray(options.headers)
       ? options.headers
@@ -130,7 +130,7 @@ export async function serveStatic(
 
     const ifModifiedSinceH = event.req.headers.get("if-modified-since");
     if (ifModifiedSinceH && new Date(ifModifiedSinceH) >= mtimeDate) {
-      return new PseudoResponse(null, {
+      return new HTTPResponse(null, {
         status: 304,
         statusText: "Not Modified",
       });
@@ -148,7 +148,7 @@ export async function serveStatic(
   const ifNotMatch =
     meta.etag && event.req.headers.get("if-none-match") === meta.etag;
   if (ifNotMatch) {
-    return new PseudoResponse(null, {
+    return new HTTPResponse(null, {
       status: 304,
       statusText: "Not Modified",
     });
@@ -179,11 +179,11 @@ export async function serveStatic(
   }
 
   if (event.req.method === "HEAD") {
-    return new PseudoResponse(null, { status: 200 });
+    return new HTTPResponse(null, { status: 200 });
   }
 
   const contents = await options.getContents(id);
-  return new PseudoResponse(contents || null, { status: 200 });
+  return new HTTPResponse(contents || null, { status: 200 });
 }
 
 // --- Internal Utils ---

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -56,8 +56,8 @@ describe("benchmark", () => {
         `Bundle size (defineHandler): ${bundle.bytes} (gzip: ${bundle.gzipSize})`,
       );
     }
-    expect(bundle.bytes).toBeLessThanOrEqual(5300); // <5.3kb
-    expect(bundle.gzipSize).toBeLessThanOrEqual(2200); // <2.2kb
+    expect(bundle.bytes).toBeLessThanOrEqual(5700); // <5.7kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(2300); // <2.3kb
   });
 });
 

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -38,7 +38,7 @@ describe("benchmark", () => {
         `Bundle size (H3Core): ${bundle.bytes} (gzip: ${bundle.gzipSize})`,
       );
     }
-    expect(bundle.bytes).toBeLessThanOrEqual(7500); // <7.5kb
+    expect(bundle.bytes).toBeLessThanOrEqual(7600); // <7.6kb
     expect(bundle.gzipSize).toBeLessThanOrEqual(3000); // <3kb
   });
 

--- a/test/iterable.test.ts
+++ b/test/iterable.test.ts
@@ -6,14 +6,14 @@ import { describeMatrix } from "./_setup.ts";
 describeMatrix("iterable", (t, { it, expect, describe }) => {
   describe("iterable", () => {
     it("sends empty body for an empty iterator", async () => {
-      t.app.use((event) => iterable(event, []));
+      t.app.use(() => iterable([]));
       const result = await t.fetch("/");
       expect(result.headers.get("content-length")).toBe(null);
       expect(await result.text()).toBe("");
     });
 
     it("concatenates iterated values", async () => {
-      t.app.use((event) => iterable(event, ["a", "b", "c"]));
+      t.app.use(() => iterable(["a", "b", "c"]));
       const result = await t.fetch("/");
       expect(await result.text()).toBe("abc");
     });
@@ -86,7 +86,7 @@ describeMatrix("iterable", (t, { it, expect, describe }) => {
           }),
         },
       ])("$type", async (c) => {
-        t.app.use((event) => iterable(event, c.iterable as any));
+        t.app.use(() => iterable(c.iterable as any));
         const response = await t.fetch("/");
         expect(await response.text()).toBe("the-value");
       });
@@ -97,7 +97,7 @@ describeMatrix("iterable", (t, { it, expect, describe }) => {
         const testIterable = [1, "2", { field: 3 }, null];
         const textEncoder = new TextEncoder();
         const serializer = vi.fn(() => textEncoder.encode("x"));
-        t.app.use((event) => iterable(event, testIterable, { serializer }));
+        t.app.use(() => iterable(testIterable, { serializer }));
         const response = await t.fetch("/");
         expect(await response.text()).toBe("x".repeat(testIterable.length));
         expect(serializer).toBeCalledTimes(4);

--- a/test/status.test.ts
+++ b/test/status.test.ts
@@ -66,8 +66,8 @@ describeMatrix("event response", (t, { it, describe, expect }) => {
 
   describe("no content response", () => {
     it("sets status 204 as default", async () => {
-      t.app.all("/test", (event) => {
-        return noContent(event);
+      t.app.all("/test", () => {
+        return noContent();
       });
 
       const res = await t.fetch("/test", {

--- a/test/unit/package.test.ts
+++ b/test/unit/package.test.ts
@@ -12,7 +12,7 @@ describe("h3 package", () => {
         "H3Error",
         "H3Event",
         "HTTPError",
-        "PseudoResponse",
+        "HTTPResponse",
         "appendCorsHeaders",
         "appendCorsPreflightHeaders",
         "appendHeader",

--- a/test/unit/package.test.ts
+++ b/test/unit/package.test.ts
@@ -12,6 +12,7 @@ describe("h3 package", () => {
         "H3Error",
         "H3Event",
         "HTTPError",
+        "PseudoResponse",
         "appendCorsHeaders",
         "appendCorsPreflightHeaders",
         "appendHeader",

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -8,10 +8,25 @@ import {
   getRequestIP,
   getRequestFingerprint,
   handleCacheHeaders,
+  html,
 } from "../src/index.ts";
 import { describeMatrix } from "./_setup.ts";
 
 describeMatrix("utils", (t, { it, describe, expect }) => {
+  describe("html", () => {
+    it("can return html response", async () => {
+      t.app.get("/test", () => html("<h1>Hello</h1>"));
+      const res1 = await t.fetch("/test");
+      expect(res1.headers.get("content-type")).toBe("text/html; charset=utf-8");
+      expect(await res1.text()).toBe("<h1>Hello</h1>");
+
+      t.app.get("/test2", () => html`<h1>Hello</h1>`);
+      const res2 = await t.fetch("/test2");
+      expect(res2.headers.get("content-type")).toBe("text/html; charset=utf-8");
+      expect(await res2.text()).toBe("<h1>Hello</h1>");
+    });
+  });
+
   describe("redirect", () => {
     it("can redirect URLs", async () => {
       t.app.use(() => redirect("https://google.com"));

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -14,7 +14,7 @@ import { describeMatrix } from "./_setup.ts";
 describeMatrix("utils", (t, { it, describe, expect }) => {
   describe("redirect", () => {
     it("can redirect URLs", async () => {
-      t.app.use((event) => redirect(event, "https://google.com"));
+      t.app.use(() => redirect("https://google.com"));
       const result = await t.fetch("/");
       expect(result.headers.get("location")).toBe("https://google.com");
       expect(result.headers.get("content-type")).toBe(


### PR DESCRIPTION
Constructing and returning a new `Response` can be costly and unnecessary. 

This PR introduces a new partial/pesudo response `HTTPResponse` (type-compat with `Response`) that is both exposed and used in internal utils. 

Breaking change: Utils below updated return a `HTTPResponse` also some won't (need to) have `event` as first param anymore*

- `html`*
- `iteratable`*
- `noContent`*
- `redirect`*
- `handleCors` 
- `proxy`