### PR TITLE
perf: try avoid cloning response for meriging headers

### DIFF
--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -289,4 +289,33 @@ describeMatrix("app", (t, { it, expect }) => {
       expect(await res.json()).toEqual({ works: 1 });
     },
   );
+
+  it("set headers via event.res + Response", async () => {
+    t.app.use((event) => {
+      event.res.headers.set("x-from-event", "1");
+      return new Response("hello", {
+        headers: { "x-from-response": "1" },
+      });
+    });
+    const res = await t.fetch("/");
+    expect(res.headers.get("x-from-event")).toBe("1");
+    expect(res.headers.get("x-from-response")).toBe("1");
+  });
+
+  it("set headers via event.res + Response (slowpath)", async () => {
+    t.app.use((event) => {
+      event.res.headers.set("x-from-event", "1");
+      const res = new Response("hello", {
+        headers: { "x-from-response": "1" },
+      });
+      Object.defineProperty(res, "headers", {
+        writable: false,
+        value: res.headers,
+      });
+      return res;
+    });
+    const res = await t.fetch("/");
+    expect(res.headers.get("x-from-event")).toBe("1");
+    expect(res.headers.get("x-from-response")).toBe("1");
+  });
 });

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -21,7 +21,7 @@ describe("benchmark", () => {
       );
     }
     expect(bundle.bytes).toBeLessThanOrEqual(11_000); // <11kb
-    expect(bundle.gzipSize).toBeLessThanOrEqual(4100); // <4.1kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(4200); // <4.2kb
   });
 
   it("bundle size (H3Core)", async () => {
@@ -38,13 +38,13 @@ describe("benchmark", () => {
         `Bundle size (H3Core): ${bundle.bytes} (gzip: ${bundle.gzipSize})`,
       );
     }
-    expect(bundle.bytes).toBeLessThanOrEqual(7600); // <7.6kb
-    expect(bundle.gzipSize).toBeLessThanOrEqual(3000); // <3kb
+    expect(bundle.bytes).toBeLessThanOrEqual(7800); // <7.8kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(3100); // <3.1kb
   });
 
   it("bundle size (defineHandler)", async () => {
     const code = /* js */ `
-      import { defineHandler } from "h3";
+      import { defineHandler } from "../../src/index.ts";
       const handler = defineHandler({});
     `;
     const bundle = await getBundleSize(code);
@@ -56,7 +56,7 @@ describe("benchmark", () => {
         `Bundle size (defineHandler): ${bundle.bytes} (gzip: ${bundle.gzipSize})`,
       );
     }
-    expect(bundle.bytes).toBeLessThanOrEqual(5700); // <5.7kb
+    expect(bundle.bytes).toBeLessThanOrEqual(5800); // <5.8kb
     expect(bundle.gzipSize).toBeLessThanOrEqual(2300); // <2.3kb
   });
 });


### PR DESCRIPTION
When there are both prepared headers (`event.res.headers.set`) and returning a new Response, we can override `res.headers` instead of cloning full request.
