### PR TITLE
feat: improve param type inference

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -56,7 +56,12 @@ export class H3Event<
   /**
    * Event context.
    */
-  readonly context: H3EventContext;
+  readonly context: _RequestT["routerParams"] extends infer P extends Record<
+    string,
+    string
+  >
+    ? Omit<H3EventContext<P>, "params"> & { params: P }
+    : H3EventContext<Record<string, string>>;
 
   /**
    * @internal

--- a/src/event.ts
+++ b/src/event.ts
@@ -56,10 +56,11 @@ export class H3Event<
   /**
    * Event context.
    */
-  readonly context: _RequestT["routerParams"] extends infer _RouteParams extends
-    Record<string, string>
-    ? Omit<H3EventContext<_RouteParams>, "params"> & { params: _RouteParams }
-    : H3EventContext;
+  readonly context: H3EventContext<_RequestT["routerParams"]> & {
+    params: _RequestT["routerParams"] extends undefined
+      ? undefined
+      : _RequestT["routerParams"];
+  };
 
   /**
    * @internal

--- a/src/event.ts
+++ b/src/event.ts
@@ -56,7 +56,10 @@ export class H3Event<
   /**
    * Event context.
    */
-  readonly context: H3EventContext<_RequestT["routerParams"]>;
+  readonly context: _RequestT["routerParams"] extends infer _RouteParams extends
+    Record<string, string>
+    ? Omit<H3EventContext<_RouteParams>, "params"> & { params: _RouteParams }
+    : H3EventContext;
 
   /**
    * @internal

--- a/src/event.ts
+++ b/src/event.ts
@@ -56,12 +56,7 @@ export class H3Event<
   /**
    * Event context.
    */
-  readonly context: _RequestT["routerParams"] extends infer P extends Record<
-    string,
-    string
-  >
-    ? Omit<H3EventContext<P>, "params"> & { params: P }
-    : H3EventContext<Record<string, string>>;
+  readonly context: H3EventContext<_RequestT["routerParams"]>;
 
   /**
    * @internal

--- a/src/h3.ts
+++ b/src/h3.ts
@@ -159,7 +159,7 @@ export const H3 = /* @__PURE__ */ (() => {
       return this;
     }
 
-    on<const Route extends string>(
+    on<Route extends string>(
       method: HTTPMethod | Lowercase<HTTPMethod> | "",
       route: Route,
       handler: EventHandler<{
@@ -173,7 +173,7 @@ export const H3 = /* @__PURE__ */ (() => {
       handler: HTTPHandler,
       opts?: RouteOptions,
     ): this;
-    on<const Route extends string>(
+    on<Route extends string>(
       method: HTTPMethod | Lowercase<HTTPMethod> | "",
       route: Route | string,
       handler:

--- a/src/h3.ts
+++ b/src/h3.ts
@@ -4,7 +4,7 @@ import { toResponse, kNotFound } from "./response.ts";
 import { callMiddleware, normalizeMiddleware } from "./middleware.ts";
 
 import type { ServerRequest } from "srvx";
-import type { RouterContext, MatchedRoute } from "rou3";
+import type { RouterContext, MatchedRoute, InferRouteParams } from "rou3";
 import type { H3Config, H3CoreConfig, H3Plugin } from "./types/h3.ts";
 import type { H3EventContext } from "./types/context.ts";
 import type {
@@ -25,6 +25,7 @@ import type {
 
 import { toRequest } from "./utils/request.ts";
 import { toEventHandler } from "./handler.ts";
+import type { RouteParams } from "./types/_utils.ts";
 
 export const NoHandler: EventHandler = () => kNotFound;
 
@@ -158,10 +159,28 @@ export const H3 = /* @__PURE__ */ (() => {
       return this;
     }
 
+    on<const Route extends string>(
+      method: HTTPMethod | Lowercase<HTTPMethod> | "",
+      route: Route,
+      handler: EventHandler<{
+        routerParams: RouteParams<InferRouteParams<Route>>;
+      }>,
+      opts?: RouteOptions,
+    ): this;
     on(
       method: HTTPMethod | Lowercase<HTTPMethod> | "",
       route: string,
       handler: HTTPHandler,
+      opts?: RouteOptions,
+    ): this;
+    on<const Route extends string>(
+      method: HTTPMethod | Lowercase<HTTPMethod> | "",
+      route: Route | string,
+      handler:
+        | EventHandler<{
+            routerParams: RouteParams<InferRouteParams<Route>>;
+          }>
+        | HTTPHandler,
       opts?: RouteOptions,
     ): this {
       const _method = (method || "").toUpperCase();
@@ -169,7 +188,7 @@ export const H3 = /* @__PURE__ */ (() => {
       this._addRoute({
         method: _method as HTTPMethod,
         route,
-        handler: toEventHandler(handler)!,
+        handler: toEventHandler(handler as HTTPHandler)!,
         middleware: opts?.middleware,
         meta: { ...(handler as EventHandler).meta, ...opts?.meta },
       });

--- a/src/h3.ts
+++ b/src/h3.ts
@@ -4,7 +4,7 @@ import { toResponse, kNotFound } from "./response.ts";
 import { callMiddleware, normalizeMiddleware } from "./middleware.ts";
 
 import type { ServerRequest } from "srvx";
-import type { RouterContext, MatchedRoute, InferRouteParams } from "rou3";
+import type { RouterContext, MatchedRoute } from "rou3";
 import type { H3Config, H3CoreConfig, H3Plugin } from "./types/h3.ts";
 import type { H3EventContext } from "./types/context.ts";
 import type {
@@ -163,7 +163,7 @@ export const H3 = /* @__PURE__ */ (() => {
       method: HTTPMethod | Lowercase<HTTPMethod> | "",
       route: Route,
       handler: EventHandler<{
-        routerParams: RouteParams<InferRouteParams<Route>>;
+        routerParams: RouteParams<Route>;
       }>,
       opts?: RouteOptions,
     ): this;
@@ -178,7 +178,7 @@ export const H3 = /* @__PURE__ */ (() => {
       route: Route | string,
       handler:
         | EventHandler<{
-            routerParams: RouteParams<InferRouteParams<Route>>;
+            routerParams: RouteParams<Route>;
           }>
         | HTTPHandler,
       opts?: RouteOptions,

--- a/src/types/_utils.ts
+++ b/src/types/_utils.ts
@@ -1,8 +1,10 @@
+import type { InferRouteParams } from "rou3";
+
 export type MaybePromise<T = unknown> = T | Promise<T>;
 
 export type Simplify<T> = { [K in keyof T]: T[K] } & {};
-export type RouteParams<T> =
-  Simplify<T> extends infer _Simplified
+export type RouteParams<T extends string> =
+  Simplify<InferRouteParams<T>> extends infer _Simplified
     ? keyof _Simplified extends never
       ? undefined
       : _Simplified

--- a/src/types/_utils.ts
+++ b/src/types/_utils.ts
@@ -1,1 +1,9 @@
 export type MaybePromise<T = unknown> = T | Promise<T>;
+
+export type Simplify<T> = { [K in keyof T]: T[K] } & {};
+export type RouteParams<T> =
+  Simplify<T> extends infer _Simplified
+    ? keyof _Simplified extends never
+      ? undefined
+      : _Simplified
+    : never;

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -5,9 +5,7 @@ import type { ServerRequestContext } from "srvx";
 export interface H3EventContext<TParams = Record<string, string>>
   extends ServerRequestContext {
   /* Matched router parameters */
-  params: Record<string, string> extends TParams
-    ? TParams | undefined
-    : TParams;
+  params?: TParams;
 
   /* Matched middleware parameters */
   middlewareParams?: Record<string, string>;

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -5,7 +5,9 @@ import type { ServerRequestContext } from "srvx";
 export interface H3EventContext<TParams = Record<string, string>>
   extends ServerRequestContext {
   /* Matched router parameters */
-  params?: TParams;
+  params: Record<string, string> extends TParams
+    ? TParams | undefined
+    : TParams;
 
   /* Matched middleware parameters */
   middlewareParams?: Record<string, string>;

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -4,7 +4,11 @@ import type { ServerRequestContext } from "srvx";
 
 export interface H3EventContext<TParams = Record<string, string>>
   extends ServerRequestContext {
-  /* Matched router parameters */
+  /**
+   * Matched route parameters
+   *
+   * If there are no parameters, this will be `undefined`.
+   */
   params?: TParams;
 
   /* Matched middleware parameters */

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -2,9 +2,10 @@ import type { Session } from "../utils/session.ts";
 import type { H3Route } from "./h3.ts";
 import type { ServerRequestContext } from "srvx";
 
-export interface H3EventContext extends ServerRequestContext {
+export interface H3EventContext<TParams = Record<string, string>>
+  extends ServerRequestContext {
   /* Matched router parameters */
-  params?: Record<string, string>;
+  params?: TParams;
 
   /* Matched middleware parameters */
   middlewareParams?: Record<string, string>;

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -2,8 +2,9 @@ import type { Session } from "../utils/session.ts";
 import type { H3Route } from "./h3.ts";
 import type { ServerRequestContext } from "srvx";
 
-export interface H3EventContext<TParams = Record<string, string>>
-  extends ServerRequestContext {
+export interface H3EventContext<
+  TParams = Record<string, string>,
+> extends ServerRequestContext {
   /**
    * Matched route parameters
    *

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -3,7 +3,7 @@ import type { HTTPHandler, EventHandler, Middleware } from "./handler.ts";
 import type { HTTPError } from "../error.ts";
 import type { MaybePromise, RouteParams } from "./_utils.ts";
 import type { FetchHandler, ServerRequest } from "srvx";
-import type { MatchedRoute, InferRouteParams, RouterContext } from "rou3";
+import type { MatchedRoute, RouterContext } from "rou3";
 import type { H3Event } from "../event.ts";
 
 // --- Misc ---
@@ -148,7 +148,7 @@ export declare class H3 extends H3Core {
     method: HTTPMethod | Lowercase<HTTPMethod> | "",
     route: Route,
     handler: EventHandler<{
-      routerParams: RouteParams<InferRouteParams<Route>>;
+      routerParams: RouteParams<Route>;
     }>,
     opts?: RouteOptions,
   ): this;
@@ -181,7 +181,7 @@ export declare class H3 extends H3Core {
   get<const Route extends string>(
     route: Route,
     handler: EventHandler<{
-      routerParams: RouteParams<InferRouteParams<Route>>;
+      routerParams: RouteParams<Route>;
     }>,
     opts?: RouteOptions,
   ): this;
@@ -190,7 +190,7 @@ export declare class H3 extends H3Core {
   post<const Route extends string>(
     route: Route,
     handler: EventHandler<{
-      routerParams: RouteParams<InferRouteParams<Route>>;
+      routerParams: RouteParams<Route>;
     }>,
     opts?: RouteOptions,
   ): this;
@@ -199,7 +199,7 @@ export declare class H3 extends H3Core {
   put<const Route extends string>(
     route: Route,
     handler: EventHandler<{
-      routerParams: RouteParams<InferRouteParams<Route>>;
+      routerParams: RouteParams<Route>;
     }>,
     opts?: RouteOptions,
   ): this;
@@ -208,7 +208,7 @@ export declare class H3 extends H3Core {
   delete<const Route extends string>(
     route: Route,
     handler: EventHandler<{
-      routerParams: RouteParams<InferRouteParams<Route>>;
+      routerParams: RouteParams<Route>;
     }>,
     opts?: RouteOptions,
   ): this;
@@ -217,7 +217,7 @@ export declare class H3 extends H3Core {
   patch<const Route extends string>(
     route: Route,
     handler: EventHandler<{
-      routerParams: RouteParams<InferRouteParams<Route>>;
+      routerParams: RouteParams<Route>;
     }>,
     opts?: RouteOptions,
   ): this;
@@ -226,7 +226,7 @@ export declare class H3 extends H3Core {
   head<const Route extends string>(
     route: Route,
     handler: EventHandler<{
-      routerParams: RouteParams<InferRouteParams<Route>>;
+      routerParams: RouteParams<Route>;
     }>,
     opts?: RouteOptions,
   ): this;
@@ -235,7 +235,7 @@ export declare class H3 extends H3Core {
   options<const Route extends string>(
     route: Route,
     handler: EventHandler<{
-      routerParams: RouteParams<InferRouteParams<Route>>;
+      routerParams: RouteParams<Route>;
     }>,
     opts?: RouteOptions,
   ): this;
@@ -244,7 +244,7 @@ export declare class H3 extends H3Core {
   connect<const Route extends string>(
     route: Route,
     handler: EventHandler<{
-      routerParams: RouteParams<InferRouteParams<Route>>;
+      routerParams: RouteParams<Route>;
     }>,
     opts?: RouteOptions,
   ): this;
@@ -253,7 +253,7 @@ export declare class H3 extends H3Core {
   trace<const Route extends string>(
     route: Route,
     handler: EventHandler<{
-      routerParams: RouteParams<InferRouteParams<Route>>;
+      routerParams: RouteParams<Route>;
     }>,
     opts?: RouteOptions,
   ): this;

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -10,8 +10,32 @@ import type { H3Event } from "../event.ts";
 
 // https://www.rfc-editor.org/rfc/rfc7231#section-4.1
 // prettier-ignore
-export type HTTPMethod =  "GET" | "HEAD" | "PATCH" | "POST" | "PUT" | "DELETE" | "CONNECT" | "OPTIONS" | "TRACE";
+export type HTTPMethod = "GET" | "HEAD" | "PATCH" | "POST" | "PUT" | "DELETE" | "CONNECT" | "OPTIONS" | "TRACE";
 
+/**
+ * Interface for HTTP method handlers (GET, POST, PUT, DELETE, etc.).
+ *
+ * Automatically infers route parameters from the route pattern and makes them
+ * available in the event handler context.
+ *
+ * @template {H3} This - Passed as `this` to resolve to the declared H3 class type
+ * rather than the runtime H3 class implementation. This ensures TypeScript uses
+ * the correct type signature from this declaration file.
+ *
+ * NOTE:
+ * If we used H3 directly in the return type, the bench implementation would
+ * fail, due to `app._rou3` not being defined on H3.
+ */
+interface H3HandlerInterface<This extends H3> {
+  <Route extends string>(
+    route: Route,
+    handler: EventHandler<{
+      routerParams: RouteParams<Route>;
+    }>,
+    opts?: RouteOptions,
+  ): This;
+  (route: string, handler: HTTPHandler, opts?: RouteOptions): This;
+}
 export interface H3Config {
   /**
    * When enabled, H3 displays debugging stack traces in HTTP responses (potentially dangerous for production!).
@@ -185,84 +209,13 @@ export declare class H3 extends H3Core {
   ): this;
   all(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
 
-  get<Route extends string>(
-    route: Route,
-    handler: EventHandler<{
-      routerParams: RouteParams<Route>;
-    }>,
-    opts?: RouteOptions,
-  ): this;
-  get(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
-
-  post<Route extends string>(
-    route: Route,
-    handler: EventHandler<{
-      routerParams: RouteParams<Route>;
-    }>,
-    opts?: RouteOptions,
-  ): this;
-  post(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
-
-  put<Route extends string>(
-    route: Route,
-    handler: EventHandler<{
-      routerParams: RouteParams<Route>;
-    }>,
-    opts?: RouteOptions,
-  ): this;
-  put(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
-
-  delete<Route extends string>(
-    route: Route,
-    handler: EventHandler<{
-      routerParams: RouteParams<Route>;
-    }>,
-    opts?: RouteOptions,
-  ): this;
-  delete(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
-
-  patch<Route extends string>(
-    route: Route,
-    handler: EventHandler<{
-      routerParams: RouteParams<Route>;
-    }>,
-    opts?: RouteOptions,
-  ): this;
-  patch(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
-
-  head<Route extends string>(
-    route: Route,
-    handler: EventHandler<{
-      routerParams: RouteParams<Route>;
-    }>,
-    opts?: RouteOptions,
-  ): this;
-  head(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
-
-  options<Route extends string>(
-    route: Route,
-    handler: EventHandler<{
-      routerParams: RouteParams<Route>;
-    }>,
-    opts?: RouteOptions,
-  ): this;
-  options(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
-
-  connect<Route extends string>(
-    route: Route,
-    handler: EventHandler<{
-      routerParams: RouteParams<Route>;
-    }>,
-    opts?: RouteOptions,
-  ): this;
-  connect(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
-
-  trace<Route extends string>(
-    route: Route,
-    handler: EventHandler<{
-      routerParams: RouteParams<Route>;
-    }>,
-    opts?: RouteOptions,
-  ): this;
-  trace(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
+  get: H3HandlerInterface<this>;
+  post: H3HandlerInterface<this>;
+  put: H3HandlerInterface<this>;
+  delete: H3HandlerInterface<this>;
+  patch: H3HandlerInterface<this>;
+  head: H3HandlerInterface<this>;
+  options: H3HandlerInterface<this>;
+  connect: H3HandlerInterface<this>;
+  trace: H3HandlerInterface<this>;
 }

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -1,9 +1,9 @@
 import type { H3EventContext } from "./context.ts";
 import type { HTTPHandler, EventHandler, Middleware } from "./handler.ts";
 import type { HTTPError } from "../error.ts";
-import type { MaybePromise } from "./_utils.ts";
+import type { MaybePromise, RouteParams } from "./_utils.ts";
 import type { FetchHandler, ServerRequest } from "srvx";
-import type { MatchedRoute, RouterContext } from "rou3";
+import type { MatchedRoute, InferRouteParams, RouterContext } from "rou3";
 import type { H3Event } from "../event.ts";
 
 // --- Misc ---
@@ -144,6 +144,14 @@ export declare class H3 extends H3Core {
   /**
    * Register a route handler for the specified HTTP method and route.
    */
+  on<const Route extends string>(
+    method: HTTPMethod | Lowercase<HTTPMethod> | "",
+    route: Route,
+    handler: EventHandler<{
+      routerParams: RouteParams<InferRouteParams<Route>>;
+    }>,
+    opts?: RouteOptions,
+  ): this;
   on(
     method: HTTPMethod | Lowercase<HTTPMethod> | "",
     route: string,
@@ -170,13 +178,84 @@ export declare class H3 extends H3Core {
    */
   all(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
 
+  get<const Route extends string>(
+    route: Route,
+    handler: EventHandler<{
+      routerParams: RouteParams<InferRouteParams<Route>>;
+    }>,
+    opts?: RouteOptions,
+  ): this;
   get(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
+
+  post<const Route extends string>(
+    route: Route,
+    handler: EventHandler<{
+      routerParams: RouteParams<InferRouteParams<Route>>;
+    }>,
+    opts?: RouteOptions,
+  ): this;
   post(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
+
+  put<const Route extends string>(
+    route: Route,
+    handler: EventHandler<{
+      routerParams: RouteParams<InferRouteParams<Route>>;
+    }>,
+    opts?: RouteOptions,
+  ): this;
   put(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
+
+  delete<const Route extends string>(
+    route: Route,
+    handler: EventHandler<{
+      routerParams: RouteParams<InferRouteParams<Route>>;
+    }>,
+    opts?: RouteOptions,
+  ): this;
   delete(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
+
+  patch<const Route extends string>(
+    route: Route,
+    handler: EventHandler<{
+      routerParams: RouteParams<InferRouteParams<Route>>;
+    }>,
+    opts?: RouteOptions,
+  ): this;
   patch(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
+
+  head<const Route extends string>(
+    route: Route,
+    handler: EventHandler<{
+      routerParams: RouteParams<InferRouteParams<Route>>;
+    }>,
+    opts?: RouteOptions,
+  ): this;
   head(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
+
+  options<const Route extends string>(
+    route: Route,
+    handler: EventHandler<{
+      routerParams: RouteParams<InferRouteParams<Route>>;
+    }>,
+    opts?: RouteOptions,
+  ): this;
   options(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
+
+  connect<const Route extends string>(
+    route: Route,
+    handler: EventHandler<{
+      routerParams: RouteParams<InferRouteParams<Route>>;
+    }>,
+    opts?: RouteOptions,
+  ): this;
   connect(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
+
+  trace<const Route extends string>(
+    route: Route,
+    handler: EventHandler<{
+      routerParams: RouteParams<InferRouteParams<Route>>;
+    }>,
+    opts?: RouteOptions,
+  ): this;
   trace(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
 }

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -144,7 +144,7 @@ export declare class H3 extends H3Core {
   /**
    * Register a route handler for the specified HTTP method and route.
    */
-  on<const Route extends string>(
+  on<Route extends string>(
     method: HTTPMethod | Lowercase<HTTPMethod> | "",
     route: Route,
     handler: EventHandler<{
@@ -176,9 +176,16 @@ export declare class H3 extends H3Core {
   /**
    * Register a route handler for all HTTP methods.
    */
+  all<Route extends string>(
+    route: Route,
+    handler: EventHandler<{
+      routerParams: RouteParams<Route>;
+    }>,
+    opts?: RouteOptions,
+  ): this;
   all(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
 
-  get<const Route extends string>(
+  get<Route extends string>(
     route: Route,
     handler: EventHandler<{
       routerParams: RouteParams<Route>;
@@ -187,7 +194,7 @@ export declare class H3 extends H3Core {
   ): this;
   get(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
 
-  post<const Route extends string>(
+  post<Route extends string>(
     route: Route,
     handler: EventHandler<{
       routerParams: RouteParams<Route>;
@@ -196,7 +203,7 @@ export declare class H3 extends H3Core {
   ): this;
   post(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
 
-  put<const Route extends string>(
+  put<Route extends string>(
     route: Route,
     handler: EventHandler<{
       routerParams: RouteParams<Route>;
@@ -205,7 +212,7 @@ export declare class H3 extends H3Core {
   ): this;
   put(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
 
-  delete<const Route extends string>(
+  delete<Route extends string>(
     route: Route,
     handler: EventHandler<{
       routerParams: RouteParams<Route>;
@@ -214,7 +221,7 @@ export declare class H3 extends H3Core {
   ): this;
   delete(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
 
-  patch<const Route extends string>(
+  patch<Route extends string>(
     route: Route,
     handler: EventHandler<{
       routerParams: RouteParams<Route>;
@@ -223,7 +230,7 @@ export declare class H3 extends H3Core {
   ): this;
   patch(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
 
-  head<const Route extends string>(
+  head<Route extends string>(
     route: Route,
     handler: EventHandler<{
       routerParams: RouteParams<Route>;
@@ -232,7 +239,7 @@ export declare class H3 extends H3Core {
   ): this;
   head(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
 
-  options<const Route extends string>(
+  options<Route extends string>(
     route: Route,
     handler: EventHandler<{
       routerParams: RouteParams<Route>;
@@ -241,7 +248,7 @@ export declare class H3 extends H3Core {
   ): this;
   options(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
 
-  connect<const Route extends string>(
+  connect<Route extends string>(
     route: Route,
     handler: EventHandler<{
       routerParams: RouteParams<Route>;
@@ -250,7 +257,7 @@ export declare class H3 extends H3Core {
   ): this;
   connect(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
 
-  trace<const Route extends string>(
+  trace<Route extends string>(
     route: Route,
     handler: EventHandler<{
       routerParams: RouteParams<Route>;

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -115,10 +115,18 @@ export function getValidatedQuery(
  *   const params = getRouterParams(event); // { key: "value" }
  * });
  */
+export function getRouterParams<Event extends H3Event>(
+  event: Event,
+  opts?: { decode?: boolean },
+): Event extends H3Event<infer R> ? R["routerParams"] : never;
+export function getRouterParams<Event extends HTTPEvent>(
+  event: Event,
+  opts?: { decode?: boolean },
+): Record<string, string>;
 export function getRouterParams<Event extends HTTPEvent>(
   event: Event,
   opts: { decode?: boolean } = {},
-): Event extends H3Event<infer R> ? R["routerParams"] : Record<string, string> {
+): Record<string, string> {
   // Fallback object needs to be returned in case router is not used (#149)
   const context = getEventContext<H3EventContext>(event);
   let params = (context.params || {}) as NonNullable<
@@ -199,19 +207,23 @@ export function getValidatedRouterParams(
  * });
  */
 export function getRouterParam<
-  Event extends HTTPEvent,
-  Key extends Event extends H3Event<infer R>
-    ? keyof R["routerParams"] & string
-    : string,
+  Event extends H3Event,
+  Key extends Event extends H3Event<infer R> ? keyof R["routerParams"] & string : never,
 >(
   event: Event,
   name: Key,
+  opts?: { decode?: boolean },
+): Event extends H3Event<infer R> ? R["routerParams"][Key] : never;
+export function getRouterParam<Event extends HTTPEvent>(
+  event: Event,
+  name: string,
+  opts?: { decode?: boolean },
+): string | undefined;
+export function getRouterParam<Event extends HTTPEvent>(
+  event: Event,
+  name: string,
   opts: { decode?: boolean } = {},
-): Event extends H3Event<infer R>
-  ? R["routerParams"] extends Record<string, string>
-    ? R["routerParams"][Key]
-    : string | undefined
-  : string | undefined {
+): string | undefined {
   const params = getRouterParams(event, opts);
 
   return params?.[name] as any;

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -122,11 +122,11 @@ export function getRouterParams<Event extends H3Event>(
 export function getRouterParams<Event extends HTTPEvent>(
   event: Event,
   opts?: { decode?: boolean },
-): Record<string, string>;
+): NonNullable<H3Event["context"]["params"]>;
 export function getRouterParams<Event extends HTTPEvent>(
   event: Event,
   opts: { decode?: boolean } = {},
-): Record<string, string> {
+): NonNullable<H3Event["context"]["params"]> {
   // Fallback object needs to be returned in case router is not used (#149)
   const context = getEventContext<H3EventContext>(event);
   let params = (context.params || {}) as NonNullable<
@@ -140,7 +140,7 @@ export function getRouterParams<Event extends HTTPEvent>(
     }
   }
 
-  return params as any;
+  return params;
 }
 
 export function getValidatedRouterParams<
@@ -226,7 +226,7 @@ export function getRouterParam<Event extends HTTPEvent>(
 ): string | undefined {
   const params = getRouterParams(event, opts);
 
-  return params?.[name] as any;
+  return params[name];
 }
 
 /**

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -105,6 +105,14 @@ export function getValidatedQuery(
   return validateData(query, validate);
 }
 
+export function getRouterParams<Event extends H3Event>(
+  event: Event,
+  opts?: { decode?: boolean },
+): Event extends H3Event<infer R> ? R["routerParams"] : never;
+export function getRouterParams<Event extends HTTPEvent>(
+  event: Event,
+  opts?: { decode?: boolean },
+): NonNullable<H3Event["context"]["params"]>;
 /**
  * Get matched route params.
  *
@@ -115,14 +123,6 @@ export function getValidatedQuery(
  *   const params = getRouterParams(event); // { key: "value" }
  * });
  */
-export function getRouterParams<Event extends H3Event>(
-  event: Event,
-  opts?: { decode?: boolean },
-): Event extends H3Event<infer R> ? R["routerParams"] : never;
-export function getRouterParams<Event extends HTTPEvent>(
-  event: Event,
-  opts?: { decode?: boolean },
-): NonNullable<H3Event["context"]["params"]>;
 export function getRouterParams<Event extends HTTPEvent>(
   event: Event,
   opts: { decode?: boolean } = {},
@@ -196,19 +196,11 @@ export function getValidatedRouterParams(
   return validateData(routerParams, validate);
 }
 
-/**
- * Get a matched route param by name.
- *
- * If `decode` option is `true`, it will decode the matched route param using `decodeURI`.
- *
- * @example
- * app.get("/", (event) => {
- *   const param = getRouterParam(event, "key");
- * });
- */
 export function getRouterParam<
   Event extends H3Event,
-  Key extends Event extends H3Event<infer R> ? keyof R["routerParams"] & string : never,
+  Key extends Event extends H3Event<infer R>
+    ? keyof R["routerParams"] & string
+    : never,
 >(
   event: Event,
   name: Key,
@@ -219,6 +211,16 @@ export function getRouterParam<Event extends HTTPEvent>(
   name: string,
   opts?: { decode?: boolean },
 ): string | undefined;
+/**
+ * Get a matched route param by name.
+ *
+ * If `decode` option is `true`, it will decode the matched route param using `decodeURI`.
+ *
+ * @example
+ * app.get("/", (event) => {
+ *   const param = getRouterParam(event, "key");
+ * });
+ */
 export function getRouterParam<Event extends HTTPEvent>(
   event: Event,
   name: string,

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -118,21 +118,21 @@ export function getValidatedQuery(
 export function getRouterParams<Event extends HTTPEvent>(
   event: Event,
   opts: { decode?: boolean } = {},
-): Event extends H3Event<infer R>
-  ? R["routerParams"] extends infer P extends Record<string, string>
-    ? P
-    : Record<string, string>
-  : Record<string, string> {
+): Event extends H3Event<infer R> ? R["routerParams"] : Record<string, string> {
   // Fallback object needs to be returned in case router is not used (#149)
   const context = getEventContext<H3EventContext>(event);
-  let params = (context.params || {}) as any;
+  let params = (context.params || {}) as NonNullable<
+    H3Event["context"]["params"]
+  >;
+
   if (opts.decode) {
     params = { ...params };
     for (const key in params) {
       params[key] = decodeURIComponent(params[key]);
     }
   }
-  return params;
+
+  return params as any;
 }
 
 export function getValidatedRouterParams<
@@ -201,21 +201,20 @@ export function getValidatedRouterParams(
 export function getRouterParam<
   Event extends HTTPEvent,
   Key extends Event extends H3Event<infer R>
-    ? R["routerParams"] extends infer P extends Record<string, string>
-      ? keyof P & string
-      : string
+    ? keyof R["routerParams"] & string
     : string,
 >(
   event: Event,
   name: Key,
   opts: { decode?: boolean } = {},
 ): Event extends H3Event<infer R>
-  ? R["routerParams"] extends infer P extends Record<string, string>
-    ? P[Key]
+  ? R["routerParams"] extends Record<string, string>
+    ? R["routerParams"][Key]
     : string | undefined
   : string | undefined {
   const params = getRouterParams(event, opts);
-  return params[name] as any;
+
+  return params?.[name] as any;
 }
 
 /**

--- a/test/unit/types.test-d.ts
+++ b/test/unit/types.test-d.ts
@@ -305,13 +305,6 @@ describe("types", () => {
           expectTypeOf(id).toEqualTypeOf<string>();
         }),
       );
-
-      app.all("/:userid/:postId", (event) => {
-        expectTypeOf(event.context.params).toEqualTypeOf<{
-          userid: string;
-          postId: string;
-        }>();
-      });
     });
   });
 });

--- a/test/unit/types.test-d.ts
+++ b/test/unit/types.test-d.ts
@@ -305,6 +305,13 @@ describe("types", () => {
           expectTypeOf(id).toEqualTypeOf<string>();
         }),
       );
+
+      app.all("/:userid/:postId", (event) => {
+        expectTypeOf(event.context.params).toEqualTypeOf<{
+          userid: string;
+          postId: string;
+        }>();
+      });
     });
   });
 });

--- a/test/unit/types.test-d.ts
+++ b/test/unit/types.test-d.ts
@@ -124,4 +124,38 @@ describe("types", () => {
       });
     });
   });
+
+  describe("routerParams inference", () => {
+    it("should infer router params from EventHandlerRequest (non-optional)", () => {
+      defineHandler<{
+        routerParams: { id: string; name: string };
+      }>((event) => {
+        expectTypeOf(event.context.params).toEqualTypeOf<{
+          id: string;
+          name: string;
+        }>();
+        expectTypeOf(event.context.params.id).toEqualTypeOf<string>();
+        expectTypeOf(event.context.params.name).toEqualTypeOf<string>();
+      });
+    });
+
+    it("should default to optional Record<string, string> when no routerParams specified", () => {
+      defineHandler((event) => {
+        expectTypeOf(event.context.params).toEqualTypeOf<
+          Record<string, string> | undefined
+        >();
+      });
+    });
+
+    it("should work with specific param types (non-optional)", () => {
+      defineHandler<{
+        routerParams: { userId: string; postId: string };
+      }>((event) => {
+        const userId = event.context.params.userId;
+        const postId = event.context.params.postId;
+        expectTypeOf(userId).toEqualTypeOf<string>();
+        expectTypeOf(postId).toEqualTypeOf<string>();
+      });
+    });
+  });
 });

--- a/test/unit/types.test-d.ts
+++ b/test/unit/types.test-d.ts
@@ -8,6 +8,8 @@ import {
   readValidatedBody,
   getValidatedQuery,
   defineValidatedHandler,
+  getRouterParams,
+  getRouterParam,
 } from "../../src/index.ts";
 import { z } from "zod";
 
@@ -155,6 +157,38 @@ describe("types", () => {
         const postId = event.context.params.postId;
         expectTypeOf(userId).toEqualTypeOf<string>();
         expectTypeOf(postId).toEqualTypeOf<string>();
+      });
+    });
+
+    it("should work with getRouterParams helper", () => {
+      defineHandler<{
+        routerParams: { id: string; slug: string };
+      }>((event) => {
+        const params = getRouterParams(event);
+        expectTypeOf(params).toEqualTypeOf<{ id: string; slug: string }>();
+        expectTypeOf(params.id).toEqualTypeOf<string>();
+        expectTypeOf(params.slug).toEqualTypeOf<string>();
+      });
+    });
+
+    it("should work with getRouterParam helper", () => {
+      defineHandler<{
+        routerParams: { id: string; slug: string };
+      }>((event) => {
+        const id = getRouterParam(event, "id");
+        const slug = getRouterParam(event, "slug");
+        expectTypeOf(id).toEqualTypeOf<string>();
+        expectTypeOf(slug).toEqualTypeOf<string>();
+      });
+    });
+
+    it("getRouterParam should provide autocomplete for param keys", () => {
+      defineHandler<{
+        routerParams: { userId: string; postId: string };
+      }>((event) => {
+        // This should only allow "userId" | "postId" as the second parameter
+        const userId = getRouterParam(event, "userId");
+        expectTypeOf(userId).toEqualTypeOf<string>();
       });
     });
   });


### PR DESCRIPTION
This PR resolves #1053 by adding automatic type inference for route parameters. When you define a route with parameters using `app.get()`, `app.post()`, or any other HTTP method, TypeScript now knows exactly what parameters are available in `event.context.params`.

Previously, `event.context.params` was always typed as `Record<string, string> | undefined`, even when the route pattern clearly defined specific parameters. Now the route pattern is parsed at the type level to extract parameter names and provide full type safety.

Route parameters are now fully typed based on the route pattern you define:

```typescript
// Before: params were loosely typed
app.get("/user/:id", (event) => {
  const id = event.context.params.id; // string | undefined
});

// After: params are inferred from the route
app.get("/user/:id", (event) => {
  const id = event.context.params.id; // string ✨
});
```

This works with multiple parameters too:

```typescript
app.get("/user/:userId/post/:postId", (event) => {
  event.context.params.userId;  // string
  event.context.params.postId;  // string
});
```

The existing helper functions (`getRouterParam` and `getRouterParams`) also benefit from this:

```typescript
app.get("/hello/:name", (event) => {
  const params = getRouterParams(event); // { name: string }
  const name = getRouterParam(event, "name"); // string
});
```

Type inference works across all route registration methods like `app.get()`, `app.post()`, `app.put()`, `app.delete()`, and `app.on()`. Routes without parameters have `params` typed as `undefined`, so you'll know when there are no parameters available.

When you use `defineHandler` directly (outside of a route), the route pattern isn't available yet, so params remain untyped as `Record<string, string> | undefined`. You can still manually type them using the `routerParams` field in `EventHandlerRequest` if needed. However, when you inline `defineHandler` with a route, the params are fully typed automatically:

```typescript
app.get("/hello/:name", defineHandler((event) => {
  event.context.params.name; // string - fully typed!
  
  const params = getRouterParams(event); // { name: string }
  const name = getRouterParam(event, "name"); // string
}));
```

The implementation leverages `InferRouteParams` from rou3 (https://github.com/h3js/rou3/pull/168) for route pattern parsing. I have tried to make the types backward compatible, so if you catch something that doesn't work as before, just tell me and i'll fix it 😅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strongly-typed route parameter support for route handlers with automatic type inference based on dynamic segments.
  * Introduced helper functions for accessing route parameters with IDE autocomplete support.

* **Tests**
  * Added comprehensive type-level tests validating route parameter inference and helper usage across various route patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->