### PR TITLE
feat(session): support password rotation via Record<string, string>

### DIFF
--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -29,8 +29,13 @@ export interface SessionManager<T extends SessionDataT = SessionDataT> {
 }
 
 export interface SessionConfig {
-  /** Private key used to encrypt session tokens */
-  password: string;
+  /**
+   * Private key used to encrypt session tokens.
+   *
+   * For password rotation, pass a record of `{ id: password }` pairs.
+   * The first key is used for sealing new sessions, all keys are tried for unsealing.
+   */
+  password: string | Record<string, string>;
   /** Session expiration time in seconds */
   maxAge?: number;
   /** default is h3 */
@@ -200,7 +205,12 @@ export async function sealSession<T extends SessionData = SessionData>(
   const session: Session<T> =
     (context.sessions?.[sessionName] as Session<T>) || (await getSession<T>(event, config));
 
-  const sealed = await seal(session, config.password, {
+  const sealPassword =
+    typeof config.password === "string"
+      ? config.password
+      : { id: Object.keys(config.password)[0], secret: Object.values(config.password)[0] };
+
+  const sealed = await seal(session, sealPassword, {
     ...sealDefaults,
     ttl: config.maxAge ? config.maxAge * 1000 : 0,
     ...config.seal,

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -111,4 +111,46 @@ describeMatrix("session", (t, { it, expect }) => {
     const body = await res.json();
     expect(body.session.data.token).toBe(token);
   });
+
+  it("supports password rotation", async () => {
+    const oldPassword = "old_password_that_is_at_least_32_characters_long!";
+    const newPassword = "new_password_that_is_at_least_32_characters_long!";
+
+    // Create session with old password
+    const oldConfig: SessionConfig = {
+      name: "h3-rotation",
+      password: oldPassword,
+      generateId: () => "rotation-test",
+    };
+
+    t.app.post("/rotate/create", async (event) => {
+      const session = await useSession(event, oldConfig);
+      await session.update({ secret: "data" });
+      return { id: session.id };
+    });
+
+    // Read session with rotated passwords (new + old)
+    const rotatedConfig: SessionConfig = {
+      name: "h3-rotation",
+      password: { default: oldPassword, new: newPassword },
+      generateId: () => "rotation-test-2",
+    };
+
+    t.app.get("/rotate/read", async (event) => {
+      const session = await useSession(event, rotatedConfig);
+      return { id: session.id, data: session.data };
+    });
+
+    // Step 1: Create with old password
+    const createRes = await t.fetch("/rotate/create", { method: "POST" });
+    const oldCookie = createRes.headers.getSetCookie()[0];
+    expect((await createRes.json()).id).toBe("rotation-test");
+
+    // Step 2: Read with rotated config — old password should still unseal
+    const readRes = await t.fetch("/rotate/read", {
+      headers: { Cookie: oldCookie },
+    });
+    const readBody = await readRes.json();
+    expect(readBody.data.secret).toBe("data");
+  });
 });


### PR DESCRIPTION
## Summary

Closes #1050

Enables session password rotation by allowing `SessionConfig.password` to accept `Record<string, string>` in addition to a plain string.

```ts
const session = await useSession(event, {
  password: {
    // "default" key matches sessions sealed with plain string password
    default: "old-password-at-least-32-chars-long!!",
    // first key is used for sealing new sessions
    v2: "new-password-at-least-32-chars-long!!",
  },
});
```

### How it works

- **Sealing**: Uses the first key in the record (with its ID embedded in the token)
- **Unsealing**: iron-crypto already supports `PasswordHash` (Record of passwords keyed by ID) — it reads the `passwordId` from the sealed token and looks up the matching password
- **Backward compat**: Sessions sealed with a plain `string` password use passwordId `"default"` internally, so the old password should use `"default"` as its key

### Changes

- `SessionConfig.password`: `string` → `string | Record<string, string>`
- `sealSession`: extracts first key from record as `{ id, secret }` for sealing
- `unsealSession`: passes record directly to `unseal()` (already supported)
- ~10 lines of implementation change

## Test plan

- [x] Password rotation test: seal with old string password, unseal with rotated Record
- [x] All existing session tests pass (14/14)
- [x] Typecheck clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced session password rotation capability. Users can now securely rotate credentials without interrupting service. The system supports multiple passwords and automatically handles unsealing of existing sessions with prior credentials, enabling seamless transitions between old and new passwords for enhanced security management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->