### PR TITLE
feat: re-export header types from fetchdts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,14 @@ export type {
   TypedServerRequest,
 } from "./types/handler.ts";
 
+export type {
+  TypedHeaders,
+  RequestHeaders,
+  ResponseHeaders,
+  RequestHeaderMap,
+  ResponseHeaderMap,
+} from "fetchdts";
+
 export {
   defineHandler,
   defineLazyEventHandler,

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,15 +41,12 @@ export type {
   FetchableObject,
   HTTPHandler,
   TypedServerRequest,
-} from "./types/handler.ts";
-
-export type {
   TypedHeaders,
   RequestHeaders,
   ResponseHeaders,
   RequestHeaderMap,
   ResponseHeaderMap,
-} from "fetchdts";
+} from "./types/handler.ts";
 
 export {
   defineHandler,

--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -1,5 +1,5 @@
 import type { ServerRequest } from "srvx";
-import type { TypedRequest, TypedResponse, ResponseHeaderMap } from "fetchdts";
+import type { TypedRequest, TypedResponse, TypedHeaders, RequestHeaders, ResponseHeaders, RequestHeaderMap, ResponseHeaderMap } from "fetchdts";
 import type { H3Event, HTTPEvent } from "../event.ts";
 import type { MaybePromise } from "./_utils.ts";
 import type { H3RouteMeta } from "./h3.ts";
@@ -85,3 +85,5 @@ export type InferEventInput<
   Event extends HTTPEvent,
   T,
 > = void extends T ? (Event extends HTTPEvent<infer E> ? E[Key] : never) : T;
+
+export type { TypedHeaders, RequestHeaders, ResponseHeaders, RequestHeaderMap, ResponseHeaderMap };


### PR DESCRIPTION
## Summary

Re-export `TypedHeaders`, `RequestHeaders`, `ResponseHeaders`, `RequestHeaderMap`, and `ResponseHeaderMap` from `fetchdts` so consumers can type functions that accept h3 headers without importing `fetchdts` directly.

Currently `TypedServerRequest` is exported but the `TypedHeaders` type used by its `headers` property is not, making it awkward to write typed helper functions.

Also adds the `RequestHeaders` and `ResponseHeaders` exports mentioned in the migration guide ("TypedHeaders: Migrate to RequestHeaders and ResponseHeaders").

Closes #1308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved TypeScript support for HTTP headers by adding/exporting refined header-related types (TypedHeaders, RequestHeaders, ResponseHeaders, RequestHeaderMap, ResponseHeaderMap), enabling stronger typing and better developer experience when working with request/response headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->