### PR TITLE
perf(cookie): avoid quadratic chunked cookie parsing and header rebuilds

### DIFF
--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -11,6 +11,18 @@ const CHUNKED_COOKIE = "__chunked__";
 // The limit is approximately 4KB, but may vary by browser and server. We leave some room to be safe.
 const CHUNKS_MAX_LENGTH = 4000;
 
+interface SetCookieState {
+  cookies: string[];
+  keys: Array<string | undefined>;
+  distinctKeys: Set<string>;
+}
+
+const requestCookiesCache = new WeakMap<
+  Headers,
+  { source: string; cookies: Record<string, string | undefined> }
+>();
+const responseCookiesCache = new WeakMap<Headers, SetCookieState>();
+
 /**
  * Parse the request to get HTTP Cookie header string and returning an object of all cookie name-value pairs.
  * @param event {HTTPEvent} H3 event or req passed by h3 handler
@@ -20,7 +32,16 @@ const CHUNKS_MAX_LENGTH = 4000;
  * ```
  */
 export function parseCookies(event: HTTPEvent): Record<string, string | undefined> {
-  return parseCookie(event.req.headers.get("cookie") || "");
+  const headers = event.req.headers;
+  const source = headers.get("cookie") || "";
+  const cached = requestCookiesCache.get(headers);
+  if (cached && cached.source === source) {
+    return cached.cookies;
+  }
+
+  const cookies = parseCookie(source);
+  requestCookiesCache.set(headers, { source, cookies });
+  return cookies;
 }
 
 /**
@@ -87,28 +108,35 @@ export function setCookie(
   // Serialize cookie
   const newCookie = serializeCookie({ name, value, path: "/", ...options });
 
-  // Check and add only not any other set-cookie headers already set
-  const currentCookies = event.res.headers.getSetCookie();
-  if (currentCookies.length === 0) {
-    event.res.headers.set("set-cookie", newCookie);
+  // Merge and deduplicate unique set-cookie headers
+  const headers = event.res.headers;
+  const state = _getSetCookieState(headers);
+  const newCookieKey = _getDistinctCookieKey(name, options || {});
+  if (!state.distinctKeys.has(newCookieKey)) {
+    state.cookies.push(newCookie);
+    state.keys.push(newCookieKey);
+    state.distinctKeys.add(newCookieKey);
+    if (state.cookies.length === 1) {
+      headers.set("set-cookie", newCookie);
+    } else {
+      headers.append("set-cookie", newCookie);
+    }
     return;
   }
 
-  // Merge and deduplicate unique set-cookie headers
-  const newCookieKey = _getDistinctCookieKey(name, options || {});
-  event.res.headers.delete("set-cookie");
-  for (const cookie of currentCookies) {
-    const parsed = parseSetCookie(cookie);
-    if (!parsed) {
+  const dedupedCookies = [];
+  const dedupedKeys = [];
+  for (const [index, cookie] of state.cookies.entries()) {
+    if (state.keys[index] === newCookieKey) {
       continue;
     }
-    const _key = _getDistinctCookieKey(cookie.split("=")?.[0], parsed);
-    if (_key === newCookieKey) {
-      continue;
-    }
-    event.res.headers.append("set-cookie", cookie);
+    dedupedCookies.push(cookie);
+    dedupedKeys.push(state.keys[index]);
   }
-  event.res.headers.append("set-cookie", newCookie);
+  dedupedCookies.push(newCookie);
+  dedupedKeys.push(newCookieKey);
+
+  _writeSetCookieState(headers, state, dedupedCookies, dedupedKeys);
 }
 
 /**
@@ -141,7 +169,8 @@ export function deleteCookie(
  * ```
  */
 export function getChunkedCookie(event: HTTPEvent, name: string): string | undefined {
-  const mainCookie = getCookie(event, name);
+  const cookies = parseCookies(event);
+  const mainCookie = cookies[name];
   if (!mainCookie || !mainCookie.startsWith(CHUNKED_COOKIE)) {
     return mainCookie;
   }
@@ -153,7 +182,7 @@ export function getChunkedCookie(event: HTTPEvent, name: string): string | undef
 
   const chunks = [];
   for (let i = 1; i <= chunksCount; i++) {
-    const chunk = getCookie(event, chunkCookieName(name, i));
+    const chunk = cookies[chunkCookieName(name, i)];
     if (!chunk) {
       return undefined;
     }
@@ -262,4 +291,54 @@ function getChunkedCookieCount(cookie: string | undefined): number {
 
 function chunkCookieName(name: string, chunkNumber: number): string {
   return `${name}.${chunkNumber}`;
+}
+
+function _getSetCookieState(headers: Headers): SetCookieState {
+  let state = responseCookiesCache.get(headers);
+  if (state) {
+    return state;
+  }
+
+  state = {
+    cookies: [],
+    keys: [],
+    distinctKeys: new Set(),
+  };
+  responseCookiesCache.set(headers, state);
+
+  if (!headers.has("set-cookie")) {
+    return state;
+  }
+
+  for (const cookie of headers.getSetCookie()) {
+    state.cookies.push(cookie);
+    const parsed = parseSetCookie(cookie);
+    const key = parsed ? _getDistinctCookieKey(parsed.name, parsed) : undefined;
+    state.keys.push(key);
+    if (key) {
+      state.distinctKeys.add(key);
+    }
+  }
+
+  return state;
+}
+
+function _writeSetCookieState(
+  headers: Headers,
+  state: SetCookieState,
+  cookies: string[],
+  keys: Array<string | undefined>,
+): void {
+  headers.delete("set-cookie");
+  const distinctKeys = new Set<string>();
+  for (const [index, cookie] of cookies.entries()) {
+    headers.append("set-cookie", cookie);
+    const key = keys[index];
+    if (key) {
+      distinctKeys.add(key);
+    }
+  }
+  state.cookies = cookies;
+  state.keys = keys;
+  state.distinctKeys = distinctKeys;
 }

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -35,13 +35,16 @@ export function parseCookies(event: HTTPEvent): Record<string, string | undefine
   const headers = event.req.headers;
   const source = headers.get("cookie") || "";
   const cached = requestCookiesCache.get(headers);
+  // Return a fresh copy so callers can mutate the result without corrupting the
+  // cache (matching the previous parse-per-call behavior), while the expensive
+  // parse itself stays memoized across reads of the same header.
   if (cached && cached.source === source) {
-    return cached.cookies;
+    return { ...cached.cookies };
   }
 
   const cookies = parseCookie(source);
   requestCookiesCache.set(headers, { source, cookies });
-  return cookies;
+  return { ...cookies };
 }
 
 /**
@@ -295,23 +298,24 @@ function chunkCookieName(name: string, chunkNumber: number): string {
 }
 
 function _getSetCookieState(headers: Headers): SetCookieState {
-  let state = responseCookiesCache.get(headers);
-  if (state) {
-    return state;
+  // Live headers are the source of truth. If they still match our cached view
+  // (i.e. every set-cookie was written through setCookie), reuse it without
+  // re-parsing. Otherwise the headers were mutated elsewhere (middleware,
+  // proxy, direct append) and we rebuild — parsing only the unknown cookies.
+  const current = headers.getSetCookie();
+  const cached = responseCookiesCache.get(headers);
+  if (cached && _sameCookies(cached.cookies, current)) {
+    return cached;
   }
 
-  state = {
+  const state: SetCookieState = {
     cookies: [],
     keys: [],
     distinctKeys: new Set(),
   };
   responseCookiesCache.set(headers, state);
 
-  if (!headers.has("set-cookie")) {
-    return state;
-  }
-
-  for (const cookie of headers.getSetCookie()) {
+  for (const cookie of current) {
     state.cookies.push(cookie);
     const parsed = parseSetCookie(cookie);
     const key = parsed ? _getDistinctCookieKey(parsed.name, parsed) : undefined;
@@ -322,6 +326,18 @@ function _getSetCookieState(headers: Headers): SetCookieState {
   }
 
   return state;
+}
+
+function _sameCookies(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function _writeSetCookieState(

--- a/test/cookies.test.ts
+++ b/test/cookies.test.ts
@@ -59,6 +59,22 @@ describeMatrix("cookies", (t, { it, expect, describe }) => {
 
       expect(await result.text()).toBe("200");
     });
+
+    it("returns a fresh object that does not corrupt subsequent reads when mutated", async () => {
+      t.app.get("/", (event) => {
+        const first = parseCookies(event);
+        first.injected = "tampered";
+        delete first.Authorization;
+        // A later read must reflect the real header, not the mutated copy
+        expect(parseCookies(event)).toEqual({ Authorization: "1234567" });
+        return "200";
+      });
+
+      const result = await t.fetch("/", {
+        headers: { Cookie: "Authorization=1234567" },
+      });
+      expect(await result.text()).toBe("200");
+    });
   });
 
   describe("getCookie", () => {
@@ -127,6 +143,20 @@ describeMatrix("cookies", (t, { it, expect, describe }) => {
       });
       const result = await t.fetch("/");
       expect(result.headers.getSetCookie()).toEqual(["token=new; Domain=example.test; Path=/app"]);
+      expect(await result.text()).toBe("200");
+    });
+
+    it("preserves set-cookie headers written directly to res.headers", async () => {
+      t.app.get("/", (event) => {
+        setCookie(event, "token", "old");
+        // A middleware / plugin writes a set-cookie header directly, bypassing setCookie
+        event.res.headers.append("set-cookie", "external=9; Path=/");
+        // Overwriting an h3-managed cookie must not drop the external one
+        setCookie(event, "token", "new");
+        return "200";
+      });
+      const result = await t.fetch("/");
+      expect(result.headers.getSetCookie()).toEqual(["external=9; Path=/", "token=new; Path=/"]);
       expect(await result.text()).toBe("200");
     });
 

--- a/test/unit/cookie-performance.test.ts
+++ b/test/unit/cookie-performance.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const parseCookieSpy = vi.hoisted(() => vi.fn());
+const parseSetCookieSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("cookie-es", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("cookie-es")>();
+  return {
+    ...actual,
+    parseCookie: parseCookieSpy.mockImplementation(actual.parseCookie),
+    parseSetCookie: parseSetCookieSpy.mockImplementation(actual.parseSetCookie),
+  };
+});
+
+const { getChunkedCookie, setChunkedCookie } = await import("../../src/utils/cookie.ts");
+
+describe("cookie performance", () => {
+  beforeEach(() => {
+    parseCookieSpy.mockClear();
+    parseSetCookieSpy.mockClear();
+  });
+
+  it("parses the request cookie header once when reading chunked cookies", () => {
+    const event = {
+      req: {
+        headers: new Headers({
+          cookie: [
+            "session=__chunked__3",
+            "session.1=alpha",
+            "session.2=beta",
+            "session.3=gamma",
+          ].join("; "),
+        }),
+      },
+    };
+
+    expect(getChunkedCookie(event as any, "session")).toBe("alphabetagamma");
+    expect(parseCookieSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reparse existing set-cookie headers when appending unique chunks", () => {
+    const event = {
+      req: {
+        headers: new Headers(),
+      },
+      res: {
+        headers: new Headers(),
+      },
+    };
+
+    setChunkedCookie(event as any, "session", "abcdefghij", {
+      chunkMaxLength: 3,
+    });
+
+    expect(event.res.headers.getSetCookie()).toEqual([
+      "session=__chunked__4; Path=/",
+      "session.1=abc; Path=/",
+      "session.2=def; Path=/",
+      "session.3=ghi; Path=/",
+      "session.4=j; Path=/",
+    ]);
+    expect(parseSetCookieSpy).toHaveBeenCalledTimes(0);
+  });
+});


### PR DESCRIPTION
### Summary

This PR improves cookie performance in the chunked-cookie path used by sessions.

Previously, `setCookie()` rebuilt and reparsed the full `set-cookie` header list on every write. Since `setChunkedCookie()` calls `setCookie()` for the main cookie and for each chunk, large chunked session writes became quadratic in chunk count. The read path had a similar issue: `getChunkedCookie()` repeatedly called `getCookie()`, which reparsed the full request cookie header each time.

### What Changed

* Cache parsed request cookies per `Headers` instance in `src/utils/cookie.ts`
* Update `getChunkedCookie()` to read from a single parsed cookie map instead of reparsing per chunk.
* Keep response-side `set-cookie` state in memory so unique cookie writes can append without reparsing existing headers.
* Preserve deduplication behavior for overwrites by rebuilding headers only when the same logical cookie key is replaced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved cookie handling performance by caching parsed request cookies and response Set-Cookie state to reduce repeated parsing.
  * Optimized chunked cookie reads to parse the request cookie header once.
  * Updated Set-Cookie behavior to update headers incrementally when possible.
* **Tests**
  * Added performance-focused unit tests for chunked cookie utilities (single parse on read; no extra parsing when appending).
  * Extended coverage to ensure parse results aren’t affected by mutations of returned cookie objects and that externally added Set-Cookie values aren’t removed by later calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->