### PR TITLE
fix: parse forwarded proto chains

### DIFF
--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -388,7 +388,11 @@ export function getRequestProtocol(
   opts: { xForwardedProto?: boolean } = {},
 ): "http" | "https" | (string & {}) {
   if (opts.xForwardedProto !== false) {
-    const forwardedProto = event.req.headers.get("x-forwarded-proto");
+    const forwardedProto = event.req.headers
+      .get("x-forwarded-proto")
+      ?.split(",")
+      .shift()
+      ?.trim();
     if (forwardedProto === "https") {
       return "https";
     }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -267,6 +267,16 @@ describeMatrix("utils", (t, { it, describe, expect }) => {
           .then((r) => r.text()),
       ).toMatch("https://localhost");
 
+      expect(
+        await t
+          .fetch("/", {
+            headers: {
+              "x-forwarded-proto": "https, http",
+            },
+          })
+          .then((r) => r.text()),
+      ).toMatch("https://localhost");
+
       // TODO
       // expect(
       //   await t


### PR DESCRIPTION

**Repo:** unjs/h3 (⭐ 8000)
**Type:** bugfix
**Files changed:** 2
**Lines:** +15/-1

## What
Normalize `x-forwarded-proto` handling in `getRequestProtocol()` by reading only the first forwarded value and trimming whitespace before protocol matching. Add a regression test covering a comma-separated header chain such as `https, http`, which is a common proxy format.

## Why
`getRequestHost()` already treats forwarded headers as chains and uses the first hop, but `getRequestProtocol()` only accepted an exact header value of `https` or `http`. In deployments behind multiple proxies, `x-forwarded-proto` may arrive as a comma-separated list, causing protocol detection to fall back to the request URL instead of the trusted forwarded value. This patch makes forwarded host and protocol parsing consistent and prevents incorrect URL reconstruction.

## Testing
Intended verification: run `pnpm vitest --run test/utils.test.ts`.
Result in this environment: not completed. `pnpm` was blocked by a sandbox permission error when creating a temp directory under `/Users/bojun/Library/pnpm`, and repo-local dependencies were not present, so the new regression test was validated by code inspection only.

## Risk
Low - the change is limited to forwarded protocol parsing and preserves existing behavior for single-value headers.
