### PR TITLE
feat(error): coerce thrown number/string to HTTPError

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -16,7 +16,7 @@ export function toResponse(
   if (typeof (val as PromiseLike<unknown>)?.then === "function") {
     return (val as Promise<unknown>).then(
       (resolvedVal) => toResponse(resolvedVal, event, config),
-      (rejection) => toResponse(coerceThrown(rejection), event, config),
+      (r) => toResponse(typeof r === "number" ? new HTTPError({ status: r }) : r, event, config),
     ) as Promise<Response>;
   }
 
@@ -240,14 +240,6 @@ function nullBody(method: string, status: number | undefined): boolean | 0 | und
     status === 100 || status === 101 || status === 102 ||
     status === 204 || status === 205 || status === 304
   )
-}
-
-function coerceThrown(val: unknown): unknown {
-  if (typeof val === "number") return new HTTPError({ status: val });
-  if (typeof val === "string" && /^\d{3}(\s|$)/.test(val)) {
-    return new HTTPError({ status: +val.slice(0, 3), message: val.slice(3).trim() || undefined });
-  }
-  return val;
 }
 
 function errorResponse(error: HTTPError, debug?: boolean, errHeaders?: Headers): Response {

--- a/src/response.ts
+++ b/src/response.ts
@@ -14,8 +14,9 @@ export function toResponse(
   config: H3Config = {},
 ): Response | Promise<Response> {
   if (typeof (val as PromiseLike<unknown>)?.then === "function") {
-    return ((val as Promise<unknown>).catch?.((error) => error) || Promise.resolve(val)).then(
+    return (val as Promise<unknown>).then(
       (resolvedVal) => toResponse(resolvedVal, event, config),
+      (rejection) => toResponse(coerceThrown(rejection), event, config),
     ) as Promise<Response>;
   }
 
@@ -239,6 +240,14 @@ function nullBody(method: string, status: number | undefined): boolean | 0 | und
     status === 100 || status === 101 || status === 102 ||
     status === 204 || status === 205 || status === 304
   )
+}
+
+function coerceThrown(val: unknown): unknown {
+  if (typeof val === "number") return new HTTPError({ status: val });
+  if (typeof val === "string" && /^\d{3}(\s|$)/.test(val)) {
+    return new HTTPError({ status: +val.slice(0, 3), message: val.slice(3).trim() || undefined });
+  }
+  return val;
 }
 
 function errorResponse(error: HTTPError, debug?: boolean, errHeaders?: Headers): Response {

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -34,8 +34,8 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log(`Bundle size (H3Core): ${bundle.bytes} (gzip: ${bundle.gzipSize})`);
     }
-    expect(bundle.bytes).toBeLessThanOrEqual(6600); // <6.6kb
-    expect(bundle.gzipSize).toBeLessThanOrEqual(2700); // <2.7kb
+    expect(bundle.bytes).toBeLessThanOrEqual(6500); // <6.5kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(2600); // <2.6kb
   });
 
   it("bundle size (defineHandler)", async () => {
@@ -50,8 +50,8 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log(`Bundle size (defineHandler): ${bundle.bytes} (gzip: ${bundle.gzipSize})`);
     }
-    expect(bundle.bytes).toBeLessThanOrEqual(6300); // <6.3kb
-    expect(bundle.gzipSize).toBeLessThanOrEqual(2600); // <2.6kb
+    expect(bundle.bytes).toBeLessThanOrEqual(6100); // <6.1kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(2500); // <2.5kb
   });
 });
 

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -34,8 +34,8 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log(`Bundle size (H3Core): ${bundle.bytes} (gzip: ${bundle.gzipSize})`);
     }
-    expect(bundle.bytes).toBeLessThanOrEqual(6500); // <6.5kb
-    expect(bundle.gzipSize).toBeLessThanOrEqual(2600); // <2.6kb
+    expect(bundle.bytes).toBeLessThanOrEqual(6600); // <6.6kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(2700); // <2.7kb
   });
 
   it("bundle size (defineHandler)", async () => {
@@ -50,8 +50,8 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log(`Bundle size (defineHandler): ${bundle.bytes} (gzip: ${bundle.gzipSize})`);
     }
-    expect(bundle.bytes).toBeLessThanOrEqual(6100); // <6.1kb
-    expect(bundle.gzipSize).toBeLessThanOrEqual(2500); // <2.5kb
+    expect(bundle.bytes).toBeLessThanOrEqual(6300); // <6.3kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(2600); // <2.6kb
   });
 });
 

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -160,4 +160,44 @@ describeMatrix("errors", (t, { it, expect }) => {
 
     t.errors = [];
   });
+
+  it("throw number coerces to status", async () => {
+    t.app.use(() => {
+      throw 404;
+    });
+    const res = await t.fetch("/");
+    expect(res.status).toBe(404);
+  });
+
+  it("throw string status code", async () => {
+    t.app.use(() => {
+      throw "404";
+    });
+    const res = await t.fetch("/");
+    expect(res.status).toBe(404);
+  });
+
+  it("throw string status + message", async () => {
+    t.app.use(() => {
+      throw "404 Lesson not found";
+    });
+    const res = await t.fetch("/");
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ status: 404, message: "Lesson not found" });
+  });
+
+  it("throw async number coerces to status", async () => {
+    t.app.use(async () => {
+      throw 500;
+    });
+    const res = await t.fetch("/");
+    expect(res.status).toBe(500);
+  });
+
+  it("return number is unchanged", async () => {
+    t.app.use(() => 404);
+    const res = await t.fetch("/");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toBe(404);
+  });
 });

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -169,23 +169,6 @@ describeMatrix("errors", (t, { it, expect }) => {
     expect(res.status).toBe(404);
   });
 
-  it("throw string status code", async () => {
-    t.app.use(() => {
-      throw "404";
-    });
-    const res = await t.fetch("/");
-    expect(res.status).toBe(404);
-  });
-
-  it("throw string status + message", async () => {
-    t.app.use(() => {
-      throw "404 Lesson not found";
-    });
-    const res = await t.fetch("/");
-    expect(res.status).toBe(404);
-    expect(await res.json()).toMatchObject({ status: 404, message: "Lesson not found" });
-  });
-
   it("throw async number coerces to status", async () => {
     t.app.use(async () => {
       throw 500;


### PR DESCRIPTION
Before, throwing a 404 needed `throw new HTTPError({ status: 404 })` or the deprecated `createError`. This coerces thrown numbers at the rejection boundary in `toResponse`, so this now works:

```ts
throw 404
```

`throw new HTTPError({...})` / `throw new Error()` keep working unchanged. Returning a number from a handler is unchanged (still JSON-serialized).

Net bundle impact: ~0 (stays under existing limits).

Addresses #1371.

I know the likelihood of getting this merged is low, but fun to explore :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of numeric values in promise rejections to properly set HTTP error status codes in asynchronous operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->