### PR TITLE
fix(event-stream): do not emit unhandled rejection when readable side is canceled

### DIFF
--- a/src/utils/internal/event-stream.ts
+++ b/src/utils/internal/event-stream.ts
@@ -21,9 +21,11 @@ export class EventStream {
   constructor(event: H3Event, opts: EventStreamOptions = {}) {
     this._event = event;
     this._writer = this._transformStream.writable.getWriter();
-    this._writer.closed.then(() => {
-      this._writerIsClosed = true;
-    });
+    this._writer.closed
+      .then(() => {
+        this._writerIsClosed = true;
+      })
+      .catch(_noop);
     if (opts.autoclose !== false) {
       this._event.runtime?.node?.res?.once("close", () => this.close());
     }

--- a/src/utils/internal/event-stream.ts
+++ b/src/utils/internal/event-stream.ts
@@ -22,10 +22,10 @@ export class EventStream {
     this._event = event;
     this._writer = this._transformStream.writable.getWriter();
     this._writer.closed
-      .then(() => {
+      .catch(_noop)
+      .finally(() => {
         this._writerIsClosed = true;
-      })
-      .catch(_noop);
+      });
     if (opts.autoclose !== false) {
       this._event.runtime?.node?.res?.once("close", () => this.close());
     }

--- a/src/utils/internal/event-stream.ts
+++ b/src/utils/internal/event-stream.ts
@@ -21,11 +21,9 @@ export class EventStream {
   constructor(event: H3Event, opts: EventStreamOptions = {}) {
     this._event = event;
     this._writer = this._transformStream.writable.getWriter();
-    this._writer.closed
-      .catch(_noop)
-      .finally(() => {
-        this._writerIsClosed = true;
-      });
+    this._writer.closed.catch(_noop).finally(() => {
+      this._writerIsClosed = true;
+    });
     if (opts.autoclose !== false) {
       this._event.runtime?.node?.res?.once("close", () => this.close());
     }

--- a/test/unit/sse.test.ts
+++ b/test/unit/sse.test.ts
@@ -122,6 +122,24 @@ describe("sse (unit)", () => {
       expect(unhandled).not.toHaveBeenCalled();
     });
 
+    it("does not emit unhandled rejection when readable side is canceled", async () => {
+      const event = mockEvent("/");
+      const stream = new EventStream(event);
+
+      const unhandled = vi.fn();
+      process.on("unhandledRejection", unhandled);
+
+      const readable = (await stream.send()) as ReadableStream<Uint8Array>;
+      const reader = readable.getReader();
+      await reader.cancel(new Error("resource closed"));
+
+      // Give microtasks time to settle
+      await new Promise((r) => setTimeout(r, 10));
+
+      process.off("unhandledRejection", unhandled);
+      expect(unhandled).not.toHaveBeenCalled();
+    });
+
     it("push stops retrying after write failure", async () => {
       const event = mockEvent("/");
       const stream = new EventStream(event);


### PR DESCRIPTION
Per WHATWG Streams, cancelling a TransformStream's readable errors its writable with the same reason. writer.closed therefore rejects with the string 'resource closed'. 

H3's .then(() => { this._writerIsClosed = true }) has no .catch, so the rejection bubbles to a top-level unhandled promise rejection and Deno terminates the process. 

H3 does correctly .catch(...) the per-write rejections (this._writer.write(...).catch(() => { this._writerIsClosed = true })), so the design intent is clearly to swallow these — it just forgot the same .catch on .closed. Adding one to that .then would fix this regardless of runtime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event-stream closure handling so the stream-writer's closed state is recognized whether closure succeeds or fails, reducing unhandled promise rejections.
  * Makes downstream checks for writer closure more reliable, preventing spurious runtime errors when streams close unexpectedly.
  * No changes to public APIs; behavior is more robust without altering interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->