### PR TITLE
fix(setCookie): handle `encode` and `stringify` serialize options

### DIFF
--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -85,7 +85,8 @@ export function setCookie(
   options?: CookieSerializeOptions,
 ): void {
   // Serialize cookie
-  const newCookie = serializeCookie({ name, value, path: "/", ...options });
+  const { encode, stringify, ...attrs } = options ?? {};
+  const newCookie = serializeCookie({ name, value, path: "/", ...attrs }, { encode, stringify });
 
   // Check and add only not any other set-cookie headers already set
   const currentCookies = event.res.headers.getSetCookie();

--- a/test/cookies.test.ts
+++ b/test/cookies.test.ts
@@ -142,6 +142,15 @@ describeMatrix("cookies", (t, { it, expect, describe }) => {
       expect(await result.text()).toBe("200");
     });
 
+    it("respects custom encode option", async () => {
+      t.app.get("/", (event) => {
+        setCookie(event, "x", "%22true%22", { encode: (v) => v });
+        return "200";
+      });
+      const result = await t.fetch("/");
+      expect(result.headers.getSetCookie()).toEqual(["x=%22true%22; Path=/"]);
+    });
+
     it("can set cookie with all options", async () => {
       t.app.get("/", (event) => {
         setCookie(event, "session", "xyz", {


### PR DESCRIPTION
related to https://github.com/h3js/h3/commit/a0761e92a8910213804c7f60d1a949bedc231373

this respects encode/stringify options - these do not seem to be used in the first argument (`SetCookie`).

(spreading defeats type safety (a ts limitation), but we could update the function signature in `cookie-es` to disallow accidental spreading if you're interested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cookie serialization to properly respect user-supplied encoding functions, ensuring custom encoders are applied correctly without additional re-encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->