### PR TITLE
feat(context): Added typed context to h3

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -27,6 +27,7 @@ export interface HTTPEvent<_RequestT extends EventHandlerRequest = EventHandlerR
 
 export class H3Event<
   _RequestT extends EventHandlerRequest = EventHandlerRequest,
+  _ContextT extends H3EventContext = H3EventContext,
 > implements HTTPEvent<_RequestT> {
   /**
    * Access to the H3 application instance.
@@ -50,14 +51,14 @@ export class H3Event<
   /**
    * Event context.
    */
-  readonly context: H3EventContext;
+  readonly context: _ContextT;
 
   /**
    * @internal
    */
   static __is_event__ = true;
 
-  constructor(req: ServerRequest, context?: H3EventContext, app?: H3Core) {
+  constructor(req: ServerRequest, context?: _ContextT, app?: H3Core) {
     this.context = context || req.context || new EmptyObject();
     this.req = req;
     this.app = app;

--- a/src/h3.ts
+++ b/src/h3.ts
@@ -99,7 +99,7 @@ export class H3Core implements H3CoreType {
 }
 
 export const H3 = /* @__PURE__ */ (() => {
-  class H3 extends H3Core {
+  class H3<_ContextT extends H3EventContext = H3EventContext> extends H3Core {
     "~rou3": RouterContext;
 
     constructor(config: H3Config = {}) {
@@ -117,7 +117,7 @@ export const H3 = /* @__PURE__ */ (() => {
     request(
       _req: ServerRequest | URL | string,
       _init?: RequestInit,
-      context?: H3EventContext,
+      context?: _ContextT,
     ): Response | Promise<Response> {
       return this["~request"](toRequest(_req, _init), context);
     }
@@ -203,6 +203,16 @@ export const H3 = /* @__PURE__ */ (() => {
       }
       this["~middleware"].push(normalizeMiddleware(fn as Middleware, { ...opts, route }));
       return this;
+    }
+
+    addEventContext<K extends string, V>(
+      key: K,
+      valOrFn: unknown,
+    ): H3Type<_ContextT & Record<K, V>> {
+      this.use(((event) => {
+        event.context[key] = typeof valOrFn === "function" ? valOrFn(event) : valOrFn;
+      }) as Middleware);
+      return this as unknown as H3Type<_ContextT & Record<K, V>>;
     }
   }
 

--- a/src/h3.ts
+++ b/src/h3.ts
@@ -205,14 +205,10 @@ export const H3 = /* @__PURE__ */ (() => {
       return this;
     }
 
-    addEventContext<K extends string, V>(
-      key: K,
-      valOrFn: unknown,
-    ): H3Type<_ContextT & Record<K, V>> {
-      this.use(((event) => {
+    extendContext(key: string, valOrFn: unknown): this {
+      return this.use(((event) => {
         event.context[key] = typeof valOrFn === "function" ? valOrFn(event) : valOrFn;
       }) as Middleware);
-      return this as unknown as H3Type<_ContextT & Record<K, V>>;
     }
   }
 

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -60,8 +60,8 @@ export interface H3Route {
 
 // --- H3 App ---
 
-export type RouteOptions = {
-  middleware?: Middleware[];
+export type RouteOptions<_ContextT extends H3EventContext = H3EventContext> = {
+  middleware?: Middleware<_ContextT>[];
   meta?: H3RouteMeta;
 };
 

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -142,13 +142,14 @@ export declare class H3<_ContextT extends H3EventContext = H3EventContext> exten
   use(handler: Middleware<_ContextT> | H3<_ContextT>, opts?: MiddlewareOptions): this;
 
   /**
-   * Register a key in the event context
+   * Extend the event context with a key and a typed value
+   * @returns a new H3 instance with the extended context type
    */
-  addEventContext<K extends string, V>(
+  extendContext<K extends string, V>(
     key: K,
     valFn: (event: H3Event<EventHandlerRequest, _ContextT>) => V,
   ): H3<_ContextT & Record<K, V>>;
-  addEventContext<K extends string, V>(key: K, val: V): H3<_ContextT & Record<K, V>>;
+  extendContext<K extends string, V>(key: K, val: V): H3<_ContextT & Record<K, V>>;
 
   /**
    * Register a route handler for the specified HTTP method and route.

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -1,5 +1,5 @@
 import type { H3EventContext } from "./context.ts";
-import type { HTTPHandler, EventHandler, Middleware } from "./handler.ts";
+import type { HTTPHandler, EventHandler, Middleware, EventHandlerRequest } from "./handler.ts";
 import type { HTTPError } from "../error.ts";
 import type { MaybePromise } from "./_utils.ts";
 import type { FetchHandler, ServerRequest } from "srvx";
@@ -114,7 +114,7 @@ export declare class H3Core {
   "~addRoute"(_route: H3Route): void;
 }
 
-export declare class H3 extends H3Core {
+export declare class H3<_ContextT extends H3EventContext = H3EventContext> extends H3Core {
   /** @internal */
   "~rou3": RouterContext;
 
@@ -128,14 +128,27 @@ export declare class H3 extends H3Core {
   request(
     request: ServerRequest | URL | string,
     options?: RequestInit,
-    context?: H3EventContext,
+    context?: _ContextT,
   ): Response | Promise<Response>;
 
   /**
    * Register a global middleware.
    */
-  use(route: string, handler: Middleware | H3, opts?: MiddlewareOptions): this;
-  use(handler: Middleware | H3, opts?: MiddlewareOptions): this;
+  use(
+    route: string,
+    handler: Middleware<_ContextT> | H3<_ContextT>,
+    opts?: MiddlewareOptions,
+  ): this;
+  use(handler: Middleware<_ContextT> | H3<_ContextT>, opts?: MiddlewareOptions): this;
+
+  /**
+   * Register a key in the event context
+   */
+  addEventContext<K extends string, V>(
+    key: K,
+    valFn: (event: H3Event<EventHandlerRequest, _ContextT>) => V,
+  ): H3<_ContextT & Record<K, V>>;
+  addEventContext<K extends string, V>(key: K, val: V): H3<_ContextT & Record<K, V>>;
 
   /**
    * Register a route handler for the specified HTTP method and route.
@@ -143,7 +156,7 @@ export declare class H3 extends H3Core {
   on(
     method: HTTPMethod | Lowercase<HTTPMethod> | "",
     route: string,
-    handler: HTTPHandler,
+    handler: HTTPHandler<_ContextT>,
     opts?: RouteOptions,
   ): this;
 
@@ -164,15 +177,15 @@ export declare class H3 extends H3Core {
   /**
    * Register a route handler for all HTTP methods.
    */
-  all(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
+  all(route: string, handler: HTTPHandler<_ContextT>, opts?: RouteOptions): this;
 
-  get(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
-  post(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
-  put(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
-  delete(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
-  patch(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
-  head(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
-  options(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
-  connect(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
-  trace(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
+  get(route: string, handler: HTTPHandler<_ContextT>, opts?: RouteOptions): this;
+  post(route: string, handler: HTTPHandler<_ContextT>, opts?: RouteOptions): this;
+  put(route: string, handler: HTTPHandler<_ContextT>, opts?: RouteOptions): this;
+  delete(route: string, handler: HTTPHandler<_ContextT>, opts?: RouteOptions): this;
+  patch(route: string, handler: HTTPHandler<_ContextT>, opts?: RouteOptions): this;
+  head(route: string, handler: HTTPHandler<_ContextT>, opts?: RouteOptions): this;
+  options(route: string, handler: HTTPHandler<_ContextT>, opts?: RouteOptions): this;
+  connect(route: string, handler: HTTPHandler<_ContextT>, opts?: RouteOptions): this;
+  trace(route: string, handler: HTTPHandler<_ContextT>, opts?: RouteOptions): this;
 }

--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -4,24 +4,30 @@ import type { H3Event, HTTPEvent } from "../event.ts";
 import type { MaybePromise } from "./_utils.ts";
 import type { H3RouteMeta } from "./h3.ts";
 import type { H3Core } from "../h3.ts";
+import type { H3EventContext } from "../index.ts";
 
-export type HTTPHandler = EventHandler | FetchableObject | H3Core;
+export type HTTPHandler<_ContextT extends H3EventContext = H3EventContext> =
+  | EventHandler<EventHandlerRequest, EventHandlerResponse, _ContextT>
+  | FetchableObject
+  | H3Core;
 
 //  --- event handler ---
 
 export interface EventHandler<
   _RequestT extends EventHandlerRequest = EventHandlerRequest,
   _ResponseT extends EventHandlerResponse = EventHandlerResponse,
+  _ContextT extends H3EventContext = H3EventContext,
 > {
-  (event: H3Event<_RequestT>): _ResponseT;
+  (event: H3Event<_RequestT, _ContextT>): _ResponseT;
   meta?: H3RouteMeta;
 }
 
 export interface EventHandlerObject<
   _RequestT extends EventHandlerRequest = EventHandlerRequest,
   _ResponseT extends EventHandlerResponse = EventHandlerResponse,
+  _ContextT extends H3EventContext = H3EventContext,
 > {
-  handler?: EventHandler<_RequestT, _ResponseT>;
+  handler?: EventHandler<_RequestT, _ResponseT, _ContextT>;
   fetch?: FetchHandler;
   middleware?: Middleware[];
   meta?: H3RouteMeta;
@@ -62,8 +68,8 @@ export type EventHandlerFetch<T extends Response | TypedResponse = Response> = (
 
 //  --- middleware ---
 
-export type Middleware = (
-  event: H3Event,
+export type Middleware<_ContextT extends H3EventContext = H3EventContext> = (
+  event: H3Event<EventHandlerRequest, _ContextT>,
   next: () => MaybePromise<unknown | undefined>,
 ) => MaybePromise<unknown | undefined>;
 

--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -4,7 +4,7 @@ import type { H3Event, HTTPEvent } from "../event.ts";
 import type { MaybePromise } from "./_utils.ts";
 import type { H3RouteMeta } from "./h3.ts";
 import type { H3Core } from "../h3.ts";
-import type { H3EventContext } from "../index.ts";
+import type { H3EventContext } from "./context.ts";
 
 export type HTTPHandler<_ContextT extends H3EventContext = H3EventContext> =
   | EventHandler<EventHandlerRequest, EventHandlerResponse, _ContextT>
@@ -29,7 +29,7 @@ export interface EventHandlerObject<
 > {
   handler?: EventHandler<_RequestT, _ResponseT, _ContextT>;
   fetch?: FetchHandler;
-  middleware?: Middleware[];
+  middleware?: Middleware<_ContextT>[];
   meta?: H3RouteMeta;
 }
 


### PR DESCRIPTION
Added typed context to h3, so that we can have better type inference for the context object in handlers.
- Type of `context` has been made generic in `H3Event` and `H3`
- A new method `addEventContext` has been added to `H3` for attaching a typed context.
- Necessary context type has been added to other types.

Code like this is type-safe now-
```typescript
import { H3 } from "h3";

let app = new H3()
  .addEventContext("auth", (event) => event.req.headers.get("authorization"))
  .addEventContext("foo", "bar");

app.get("/", (event) => {
  console.log(event.context.auth); // context contains key 'auth' of type 'string | null'
  return 'Hello World';
});

app.use((event) => {
  console.log(event.context.foo); // context contains key 'foo' of type is 'string'
});
```

Feedback is welcome!

resolves #511

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full generic context typing across the framework, enabling strongly-typed custom event context in handlers and middleware.
  * Introduced a new API to augment event context types with additional properties, propagating type information automatically.
  * Route registration and handler APIs now offer enhanced type safety through context-aware typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->