### PR TITLE
fix: do not await writeEarlyHints callback in Node.js

### DIFF
--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -114,9 +114,8 @@ export function writeEarlyHints(
 ): void | Promise<void> {
   // Use native early hints if available (Node.js)
   if (event.runtime?.node?.res?.writeEarlyHints) {
-    return new Promise((resolve) => {
-      event.runtime?.node?.res?.writeEarlyHints(hints, () => resolve());
-    });
+    event.runtime.node.res.writeEarlyHints(hints);
+    return;
   }
 
   // Fallback: Set Link headers for CDN support (only Link headers to avoid leaking sensitive headers)


### PR DESCRIPTION
Fixes #1383

## Problem

In Node.js v24,  does not call the callback when passed an empty hints object (or possibly in other cases). This causes the returned Promise to never resolve, and the request handler hangs indefinitely.

## Root Cause

The original code wrapped  in a Promise:


If the callback is never called, the Promise never resolves.

## Fix

Since early hints are fire-and-forget by nature, we now call  without wrapping it in a Promise:


This prevents the handler from hanging while still sending the early hints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined early hints handling for Node.js runtime.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/h3js/h3/pull/1387)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->