### PR TITLE
docs(utils): add `Request utils` heading to fix request page TOC

### DIFF
--- a/docs/2.utils/1.request.md
+++ b/docs/2.utils/1.request.md
@@ -6,6 +6,8 @@ icon: material-symbols-light:input
 
 > Utilities to access incoming request
 
+## Request utils
+
 <!-- automd:jsdocs src="../../src/utils/request.ts" -->
 
 ### `assertMethod(event, expected, allowHead?)`


### PR DESCRIPTION
The request.md docs page has three automd-generated sections (request, fingerprint, body utils), but only `Body utils` had an h2 wrapper. The orphan h3s in the first two sections broke the TOC: they rendered at the same depth as the Body utils h2, which pushed Body utils' children past the TOC depth limit and hid them.

Adding a `## Request utils` h2 above the first automd block mirrors the existing Body utils pattern and gives the TOC consistent nesting.

Closes #1106