### PR TITLE
fix(sanitize): reject NaN status code from non-numeric strings

### DIFF
--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -21,8 +21,7 @@ export function sanitizeStatusCode(statusCode?: string | number, defaultStatusCo
   if (typeof statusCode === "string") {
     statusCode = +statusCode;
   }
-  if (statusCode < 100 || statusCode > 599) {
-    return defaultStatusCode;
-  }
-  return statusCode;
+  // A positive range check also rejects NaN (`NaN >= 100` is false); the previous
+  // `< 100 || > 599` form let NaN through for non-numeric strings like "abc".
+  return statusCode >= 100 && statusCode <= 599 ? statusCode : defaultStatusCode;
 }

--- a/test/unit/sanitize.test.ts
+++ b/test/unit/sanitize.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeStatusCode, HTTPError } from "../../src/index.ts";
+
+describe("sanitizeStatusCode", () => {
+  it("passes through valid codes", () => {
+    expect(sanitizeStatusCode(404)).toBe(404);
+    expect(sanitizeStatusCode("404")).toBe(404);
+  });
+
+  it("falls back to the default for out-of-range codes", () => {
+    expect(sanitizeStatusCode(700)).toBe(200);
+    expect(sanitizeStatusCode(99, 500)).toBe(500);
+  });
+
+  it("falls back to the default for non-numeric strings", () => {
+    // regression: "+abc" is NaN, and NaN<100 / NaN>599 are both false,
+    // so the range guard let NaN through as a "sanitized" status code.
+    expect(sanitizeStatusCode("abc")).toBe(200);
+    expect(sanitizeStatusCode("2xx", 500)).toBe(500);
+  });
+});
+
+describe("HTTPError status from a non-numeric cause", () => {
+  it("does not produce a NaN status when cause.statusCode is non-numeric", () => {
+    const cause = Object.assign(new Error("boom"), { statusCode: "ECONNREFUSED" });
+    const err = new HTTPError({ cause });
+    expect(err.status).toBe(500);
+  });
+});


### PR DESCRIPTION
### Problem

`sanitizeStatusCode` can return `NaN`, defeating its own documented purpose ("Make sure the status code is a valid HTTP status code"):

```ts
sanitizeStatusCode("abc") // => NaN
```

`+"abc"` is `NaN`, and both `NaN < 100` and `NaN > 599` evaluate to `false`, so the range guard lets `NaN` through.

This is reachable through `HTTPError`. Its status is derived from an arbitrary `cause`:

```ts
const status = sanitizeStatusCode(
  (details as ErrorBody)?.status ||
    (details as ErrorInput)?.statusCode ||
    (details?.cause as ErrorBody)?.status ||
    (details?.cause as ErrorInput)?.statusCode,
  500,
);
```

`cause` is any caught error, so a non-numeric `statusCode`/`status` on it (e.g. a wrapped library error) yields an `HTTPError` with `status: NaN` — an invalid HTTP response.

### Fix

Rewrite the range guard as a *positive* check. `NaN >= 100` is `false`, so `NaN` now correctly falls back to the default:

```ts
return statusCode >= 100 && statusCode <= 599 ? statusCode : defaultStatusCode;
```

Strictly behaviour-preserving for every numeric input in/out of range; only the previously-undefined `NaN` path changes (now returns the default). The ternary is also smaller than the prior two-statement `if`/return, so the `defineHandler` **bundle-size budget test stays green**.

### Tests

Added `test/unit/sanitize.test.ts` covering valid pass-through, out-of-range fallback, non-numeric-string fallback, and the `HTTPError`-from-non-numeric-`cause` regression. Full suite green (1154 passed), `tsc` 0 errors, oxlint + oxfmt clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status code validation to properly reject non-numeric and out-of-range values, ensuring invalid codes fall back to sensible defaults
  
* **Tests**
  * Added unit test coverage for status code validation and error handling with invalid inputs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/h3js/h3/pull/1397?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->