### PR TITLE
fix(response): resolve writeEarlyHints when Node callback is omitted

### DIFF
--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -114,8 +114,28 @@ export function writeEarlyHints(
 ): void | Promise<void> {
   // Use native early hints if available (Node.js)
   if (event.runtime?.node?.res?.writeEarlyHints) {
+    if (Object.keys(hints).length === 0) {
+      return;
+    }
     return new Promise((resolve) => {
-      event.runtime?.node?.res?.writeEarlyHints(hints, () => resolve());
+      let settled = false;
+      const done = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        resolve();
+      };
+
+      try {
+        event.runtime?.node?.res?.writeEarlyHints(hints, done);
+      } catch {
+        done();
+        return;
+      }
+
+      // Node.js does not reliably invoke the writeEarlyHints callback (h3js/h3#1383).
+      queueMicrotask(done);
     });
   }
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -470,6 +470,28 @@ describeMatrix("utils", (t, { it, describe, expect }) => {
   });
 
   describe("writeEarlyHints", () => {
+    it.runIf(t.target === "node")(
+      "resolves when native writeEarlyHints callback is not invoked",
+      async () => {
+        t.app.get("/", async (event) => {
+          await writeEarlyHints(event, {});
+          return "ok";
+        });
+        t.app.get("/with-hints", async (event) => {
+          await writeEarlyHints(event, {
+            Link: "</style.css>; rel=preload; as=style",
+          });
+          return "ok";
+        });
+
+        const res = await t.fetch("/");
+        expect(await res.text()).toBe("ok");
+
+        const res2 = await t.fetch("/with-hints");
+        expect(await res2.text()).toBe("ok");
+      },
+    );
+
     // In Node.js, native writeEarlyHints sends 103 Early Hints status,
     // so the Link header fallback is not used. Test fallback in web target only.
     it.skipIf(t.target === "node")(


### PR DESCRIPTION
## Summary
Prevent `await writeEarlyHints()` from hanging Node.js request handlers when the native callback is never invoked.

## Problem
Fixes #1383. Handlers like:

```js
await writeEarlyHints(event, {});
return "ok";
```

never completed because `ServerResponse.writeEarlyHints()` does not reliably call its callback (reproducible with `{}` and with Link hints on Node 24).

## Fix
- Return early for empty hint objects (no-op)
- Resolve the returned promise via `queueMicrotask` when the native callback is missing
- Guard with a settled flag so a late callback cannot double-resolve

## Test plan
- [x] `pnpm test test/utils.test.ts` — 108 passed
- [x] New node-runtime test covers empty hints and Link hints without hanging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of early hints processing with enhanced error handling and fallback mechanisms.
  * Early hints now properly handles empty configurations.

* **Tests**
  * Added test coverage for early hints functionality in Node.js environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/h3js/h3/pull/1398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->