### PR TITLE
test(app): cover onResponse clone with pipe response body

### DIFF
--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -1,6 +1,6 @@
 import { vi } from "vitest";
 import { Readable as NodeStreamReadable, Transform as NodeStreamTransoform } from "node:stream";
-import { HTTPError, fromNodeHandler } from "../src/index.ts";
+import { HTTPError, fromNodeHandler, onResponse } from "../src/index.ts";
 import { describeMatrix } from "./_setup.ts";
 
 describeMatrix("app", (t, { it, expect }) => {
@@ -124,6 +124,27 @@ describeMatrix("app", (t, { it, expect }) => {
     expect(await res.text()).toBe("<h1>Hello world!</h1>");
     expect(res.headers.get("transfer-encoding")).toBe("chunked");
   });
+
+  it.runIf(t.target === "node")(
+    "onResponse clone does not prevent pipe body from being sent",
+    async () => {
+      t.app.use(
+        onResponse((response) => {
+          response.clone();
+        }),
+      );
+      t.app.use(() => ({
+        pipe(writable: { write: (value: string) => void; end: () => void }) {
+          writable.write("test");
+          writable.end();
+        },
+      }));
+
+      const res = await t.fetch("/");
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("test");
+    },
+  );
 
   it.runIf(t.target === "node")("Node.js Readable Stream with Error", async () => {
     t.app.use(() => {


### PR DESCRIPTION
## Summary
Add a node-runtime regression test for #1278.

## Context
When `onResponse` middleware clones the response, handlers returning Node-style `{ pipe() }` objects should still deliver the body on Node.

## Test plan
- [x] `pnpm test test/app.test.ts` — 54 passed
- [x] New test: `onResponse clone does not prevent pipe body from being sent`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a test case for Node environment to verify response streaming behavior functions correctly in specific scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/h3js/h3/pull/1399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->