### PR TITLE
fix: resolve writeEarlyHints hang with empty hints on Node.js

### DIFF
--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -112,26 +112,40 @@ export function writeEarlyHints(
   event: H3Event,
   hints: Record<string, string | string[]>,
 ): void | Promise<void> {
+  const links = getEarlyHintLinks(hints);
+  if (links.length === 0) {
+    return;
+  }
+
   // Use native early hints if available (Node.js)
   if (event.runtime?.node?.res?.writeEarlyHints) {
     return new Promise((resolve) => {
-      event.runtime?.node?.res?.writeEarlyHints(hints, () => resolve());
+      event.runtime?.node?.res?.writeEarlyHints(
+        { link: links.length === 1 ? links[0]! : links },
+        () => resolve(),
+      );
     });
   }
 
   // Fallback: Set Link headers for CDN support (only Link headers to avoid leaking sensitive headers)
+  for (const link of links) {
+    event.res.headers.append("link", link);
+  }
+}
+
+function getEarlyHintLinks(hints: Record<string, string | string[]>): string[] {
+  const links: string[] = [];
   for (const [name, value] of Object.entries(hints)) {
     if (name.toLowerCase() !== "link") {
       continue;
     }
     if (Array.isArray(value)) {
-      for (const v of value) {
-        event.res.headers.append("link", v);
-      }
+      links.push(...value);
     } else {
-      event.res.headers.append("link", value);
+      links.push(value);
     }
   }
+  return links;
 }
 
 /**

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -470,6 +470,19 @@ describeMatrix("utils", (t, { it, describe, expect }) => {
   });
 
   describe("writeEarlyHints", () => {
+    it.skipIf(t.target !== "node")(
+      "resolves immediately when hints are empty on Node.js",
+      async () => {
+        t.app.get("/", async (event) => {
+          await writeEarlyHints(event, {});
+          return "ok";
+        });
+
+        const res = await t.fetch("/");
+        expect(await res.text()).toBe("ok");
+      },
+    );
+
     // In Node.js, native writeEarlyHints sends 103 Early Hints status,
     // so the Link header fallback is not used. Test fallback in web target only.
     it.skipIf(t.target === "node")(


### PR DESCRIPTION
## Summary

- Fix `writeEarlyHints()` hanging indefinitely on Node.js when called with empty hints (`{}`)
- Normalize `Link` headers to Node's expected lowercase `link` key before calling native `writeEarlyHints`
- Skip native early hints call when there are no link hints to send

Fixes #1383

## Root cause

Node.js `ServerResponse.writeEarlyHints()` only invokes its callback when valid `link` hints are provided. Passing `{}` or `{ Link: ... }` (capital L) never triggers the callback, causing `await writeEarlyHints(event, {})` to hang forever.

## Test plan

- [x] Added Node test: empty hints resolve immediately and handler completes
- [x] Manual repro confirmed fixed (`await writeEarlyHints(event, {})` no longer hangs)
- [x] `pnpm vitest run test/utils.test.ts -t writeEarlyHints` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced early HTTP link hint handling for improved compatibility and reliability across different runtime environments.

* **Tests**
  * Added test coverage for edge cases in early hint processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/h3js/h3/pull/1400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->