### PR TITLE
feat: add requestId middleware for tracing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -200,6 +200,8 @@ export {
 
 export { type BasicAuthOptions, requireBasicAuth, basicAuth } from "./utils/auth.ts";
 
+export { type RequestIdOptions, getRequestId, requestId } from "./utils/request-id.ts";
+
 // Fingerprint
 
 export { type RequestFingerprintOptions, getRequestFingerprint } from "./utils/fingerprint.ts";

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -29,6 +29,9 @@ export interface H3EventContext extends ServerRequestContext {
     realm?: string;
   };
 
+  /* Request ID for tracing */
+  requestId?: string;
+
   /* Server-Timing entries collected via setServerTiming / withServerTiming */
   timing?: Array<{ name: string } & Record<string, unknown>>;
 }

--- a/src/utils/request-id.ts
+++ b/src/utils/request-id.ts
@@ -1,0 +1,62 @@
+import { getEventContext } from "./event.ts";
+import { onRequest } from "./middleware.ts";
+
+import type { HTTPEvent } from "../event.ts";
+import type { H3EventContext } from "../types/context.ts";
+import type { Middleware } from "../types/handler.ts";
+
+export interface RequestIdOptions {
+  /**
+   * Response header name used to propagate the request ID.
+   * @default "x-request-id"
+   */
+  header?: string;
+
+  /**
+   * Generate a new request ID when none is present on the incoming request.
+   * @default crypto.randomUUID()
+   */
+  generate?: () => string;
+
+  /**
+   * Reuse the incoming request ID header when present.
+   * @default true
+   */
+  trustIncoming?: boolean;
+}
+
+const DEFAULT_HEADER = "x-request-id";
+
+/**
+ * Get the request ID attached to the current event.
+ */
+export function getRequestId(event: HTTPEvent): string | undefined {
+  return getEventContext<H3EventContext>(event).requestId;
+}
+
+/**
+ * Create middleware that generates or propagates a request ID.
+ *
+ * @example
+ * import { H3, requestId } from "h3";
+ *
+ * const app = new H3();
+ * app.use(requestId());
+ */
+export function requestId(opts: RequestIdOptions = {}): Middleware {
+  const header = (opts.header ?? DEFAULT_HEADER).toLowerCase();
+  const generate = opts.generate ?? (() => crypto.randomUUID());
+  const trustIncoming = opts.trustIncoming ?? true;
+
+  return onRequest((event) => {
+    let id = trustIncoming ? event.req.headers.get(header) : null;
+    if (!id) {
+      id = generate();
+    }
+
+    const context = getEventContext<H3EventContext>(event);
+    context.requestId = id;
+    event.res.headers.set(header, id);
+    event.res.errHeaders.set(header, id);
+  });
+}

--- a/test/request-id.test.ts
+++ b/test/request-id.test.ts
@@ -1,0 +1,57 @@
+import { getRequestId, HTTPError, requestId } from "../src/index.ts";
+import { describeMatrix } from "./_setup.ts";
+
+describeMatrix("requestId", (t, { it, expect }) => {
+  it("generates and propagates a request id", async () => {
+    t.app.use(requestId());
+    t.app.get("/test", (event) => ({
+      requestId: getRequestId(event),
+    }));
+
+    const result = await t.fetch("/test");
+    const body = await result.json();
+
+    expect(result.headers.get("x-request-id")).toBeTruthy();
+    expect(body.requestId).toBe(result.headers.get("x-request-id"));
+  });
+
+  it("reuses incoming request id header", async () => {
+    t.app.use(requestId());
+    t.app.get("/test", (event) => getRequestId(event));
+
+    const result = await t.fetch("/test", {
+      headers: {
+        "x-request-id": "incoming-id",
+      },
+    });
+
+    expect(await result.text()).toBe("incoming-id");
+    expect(result.headers.get("x-request-id")).toBe("incoming-id");
+  });
+
+  it("generates a new id when trustIncoming is disabled", async () => {
+    t.app.use(requestId({ trustIncoming: false, generate: () => "generated-id" }));
+    t.app.get("/test", (event) => getRequestId(event));
+
+    const result = await t.fetch("/test", {
+      headers: {
+        "x-request-id": "incoming-id",
+      },
+    });
+
+    expect(await result.text()).toBe("generated-id");
+    expect(result.headers.get("x-request-id")).toBe("generated-id");
+  });
+
+  it("propagates request id on error responses", async () => {
+    t.app.use(requestId({ generate: () => "error-id" }));
+    t.app.get("/test", () => {
+      throw new HTTPError({ status: 400, message: "boom" });
+    });
+
+    const result = await t.fetch("/test");
+
+    expect(result.status).toBe(400);
+    expect(result.headers.get("x-request-id")).toBe("error-id");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `requestId()` middleware to generate or propagate request IDs
- Adds `getRequestId()` helper and `event.context.requestId`
- Sets response header on success and error responses

Closes #1389

## Usage
```ts
import { H3, requestId } from "h3";

const app = new H3();
app.use(requestId());
```

## Test plan
- [x] Added tests for generation, incoming header reuse, trustIncoming, and error responses
- [x] `pnpm vitest run test/request-id.test.ts` (8/8)
- [x] `pnpm lint`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request ID middleware for automatic generation and propagation to response and error headers
  * Configurable header names, custom ID generators, and incoming header trust settings for flexible request tracking

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/h3js/h3/pull/1401?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->