### PR TITLE
fix(sse): ignore pushes after stream close

### DIFF
--- a/src/utils/internal/event-stream.ts
+++ b/src/utils/internal/event-stream.ts
@@ -18,6 +18,10 @@ export class EventStream {
   private _disposed = false;
   private _handled = false;
 
+  private get _isClosed(): boolean {
+    return this._writerIsClosed || this._disposed;
+  }
+
   constructor(event: H3Event, opts: EventStreamOptions = {}) {
     this._event = event;
     this._writer = this._transformStream.writable.getWriter();
@@ -60,7 +64,7 @@ export class EventStream {
   }
 
   async pushComment(comment: string): Promise<void> {
-    if (this._writerIsClosed) {
+    if (this._isClosed) {
       return;
     }
     if (this._paused && !this._unsentData) {
@@ -77,7 +81,7 @@ export class EventStream {
   }
 
   private async _sendEvent(message: EventStreamMessage) {
-    if (this._writerIsClosed) {
+    if (this._isClosed) {
       return;
     }
     if (this._paused && !this._unsentData) {
@@ -94,7 +98,7 @@ export class EventStream {
   }
 
   private async _sendEvents(messages: EventStreamMessage[]) {
-    if (this._writerIsClosed) {
+    if (this._isClosed) {
       return;
     }
     const payload = formatEventStreamMessages(messages);
@@ -126,7 +130,7 @@ export class EventStream {
   }
 
   async flush(): Promise<void> {
-    if (this._writerIsClosed) {
+    if (this._isClosed) {
       return;
     }
     if (this._unsentData?.length) {
@@ -144,7 +148,7 @@ export class EventStream {
     if (this._disposed) {
       return;
     }
-    if (!this._writerIsClosed) {
+    if (!this._isClosed) {
       try {
         await this._writer.close();
       } catch {

--- a/test/sse.test.ts
+++ b/test/sse.test.ts
@@ -14,7 +14,7 @@ describeMatrix("sse", (t, { it, expect }) => {
         if (counter++ === 3) {
           clearInterval(clear);
           eventStream.close();
-          return; // TODO: eventStream.push should auto disable after close!
+          return;
         }
         if (sendComment) {
           eventStream.pushComment("hello world");
@@ -56,5 +56,22 @@ describeMatrix("sse", (t, { it, expect }) => {
     expect(messages.length).toBe(3);
     const expected = Array.from({ length: 3 }).fill(": hello world");
     expect(messages).toEqual(expected);
+  });
+
+  it("ignores pushes after close", async () => {
+    t.app.get("/sse-after-close", async (event) => {
+      const eventStream = createEventStream(event);
+      setTimeout(async () => {
+        await eventStream.push("before close");
+        await eventStream.close();
+        await eventStream.push("after close");
+        await eventStream.pushComment("after close");
+      });
+      return eventStream.send();
+    });
+
+    const res = await t.fetch("/sse-after-close");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("data: before close\n\n");
   });
 });


### PR DESCRIPTION
## Summary
- Treat disposed SSE event streams as closed before writing
- Add matrix coverage that later pushes/comments are ignored after close

## Verification
- `pnpm vitest run test/sse.test.ts --coverage=false`
- `pnpm lint` (passes with existing `typescript(await-thenable)` warning in `test/bench/bench.ts`)
- `git diff --check`
- Added-line security scan: 0 findings
- Independent review: passed

Closes #1410

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event stream closure handling to consistently ignore push operations after the stream is closed.

* **Tests**
  * Added test coverage verifying push operations are properly ignored after stream closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->