### PR TITLE
feat(proxy): support client aborts

### DIFF
--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -179,54 +179,16 @@ export async function proxy(
     await opts.onResponse(event, response);
   }
 
-  // A client disconnect during response streaming aborts the forwarded
-  // `event.req.signal` and errors the upstream body stream *after* the
-  // try/catch above has returned. By default, swallow that abort quietly (the
-  // bytes are never delivered — the client is already gone) instead of letting
-  // it surface as an unhandled streaming error. When opted in via
-  // `propagateAbortError`, leave the stream untouched so the error propagates.
-  const body =
-    response.body && !opts.propagateAbortError
-      ? quietlyAbortableStream(response.body, event.req.signal)
-      : response.body;
-
-  return new HTTPResponse(body, {
+  // Stream the upstream body through natively so the common case has zero
+  // overhead. A client disconnect during streaming aborts the forwarded
+  // `event.req.signal`, which errors the upstream body; that error is delivered
+  // to whoever consumes the stream — the server runtime, which is already
+  // tearing down the now-closed connection — so it needs no special handling
+  // here and never becomes a gateway (502) error.
+  return new HTTPResponse(response.body, {
     status: response.status,
     statusText: response.statusText,
     headers,
-  });
-}
-
-/**
- * Wrap an upstream body stream so an abort caused by the client disconnecting
- * (the forwarded `signal`) ends the stream quietly instead of surfacing as an
- * unhandled streaming error. Any other stream error is passed through unchanged.
- */
-function quietlyAbortableStream(
-  body: ReadableStream<Uint8Array>,
-  signal: AbortSignal,
-): ReadableStream<Uint8Array> {
-  const reader = body.getReader();
-  return new ReadableStream<Uint8Array>({
-    async pull(controller) {
-      try {
-        const { done, value } = await reader.read();
-        if (done) {
-          controller.close();
-        } else {
-          controller.enqueue(value);
-        }
-      } catch (error) {
-        if (signal.aborted && (error as Error)?.name === "AbortError") {
-          controller.close();
-        } else {
-          controller.error(error);
-        }
-      }
-    },
-    cancel(reason) {
-      return reader.cancel(reason);
-    },
   });
 }
 

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -19,6 +19,15 @@ export interface ProxyOptions {
   cookieDomainRewrite?: string | Record<string, string>;
   cookiePathRewrite?: string | Record<string, string>;
   onResponse?: (event: H3Event, response: Response) => void | Promise<void>;
+  /**
+   * Control how a client disconnect is reported.
+   *
+   * The incoming request's abort signal (`event.req.signal`) is always forwarded
+   * to the proxied request, so a client disconnect aborts the upstream request
+   * and releases its connection. By default the resulting abort is reported as a
+   * `502`. Set this to `true` to instead let the `AbortError` propagate.
+   */
+  propagateAbortError?: boolean;
 }
 
 /**
@@ -97,6 +106,7 @@ export async function proxy(
   opts: ProxyOptions = {},
 ): Promise<HTTPResponse> {
   const fetchOptions: RequestInit = {
+    signal: event.req.signal,
     headers: opts.headers as HeadersInit,
     ...opts.fetchOptions,
   };
@@ -108,6 +118,10 @@ export async function proxy(
         ? await event.app!.fetch(createSubRequest(event, target, fetchOptions))
         : await fetch(target, fetchOptions);
   } catch (error) {
+    // A client disconnect aborts the proxied request; surface it as-is when opted in, else as a gateway error.
+    if (opts.propagateAbortError && event.req.signal.aborted) {
+      throw error;
+    }
     throw new HTTPError({ status: 502, cause: error });
   }
 

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -118,8 +118,11 @@ export async function proxy(
         ? await event.app!.fetch(createSubRequest(event, target, fetchOptions))
         : await fetch(target, fetchOptions);
   } catch (error) {
-    // A client disconnect aborts the proxied request; surface it as-is when opted in, else as a gateway error.
-    if (opts.propagateAbortError && event.req.signal.aborted) {
+    // A client disconnect (or any caller-supplied signal) aborts the proxied
+    // request; surface the abort as-is when opted in, else as a gateway error.
+    // Key off the error itself so it works with a custom `fetchOptions.signal`
+    // and so a real upstream failure is never mistaken for an abort.
+    if (opts.propagateAbortError && (error as Error)?.name === "AbortError") {
       throw error;
     }
     throw new HTTPError({ status: 502, cause: error });

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -109,10 +109,15 @@ export async function proxy(
   target: string,
   opts: ProxyOptions = {},
 ): Promise<HTTPResponse> {
+  // Always forward the client's abort signal so a disconnect aborts the
+  // upstream request and releases its connection. If the caller also supplied
+  // `fetchOptions.signal`, honor both (either aborting aborts the request)
+  // instead of letting the spread silently drop `event.req.signal`.
+  const callerSignal = opts.fetchOptions?.signal;
   const fetchOptions: RequestInit = {
-    signal: event.req.signal,
     headers: opts.headers as HeadersInit,
     ...opts.fetchOptions,
+    signal: callerSignal ? AbortSignal.any([event.req.signal, callerSignal]) : event.req.signal,
   };
 
   let response: Response | undefined;
@@ -174,10 +179,54 @@ export async function proxy(
     await opts.onResponse(event, response);
   }
 
-  return new HTTPResponse(response.body, {
+  // A client disconnect during response streaming aborts the forwarded
+  // `event.req.signal` and errors the upstream body stream *after* the
+  // try/catch above has returned. By default, swallow that abort quietly (the
+  // bytes are never delivered — the client is already gone) instead of letting
+  // it surface as an unhandled streaming error. When opted in via
+  // `propagateAbortError`, leave the stream untouched so the error propagates.
+  const body =
+    response.body && !opts.propagateAbortError
+      ? quietlyAbortableStream(response.body, event.req.signal)
+      : response.body;
+
+  return new HTTPResponse(body, {
     status: response.status,
     statusText: response.statusText,
     headers,
+  });
+}
+
+/**
+ * Wrap an upstream body stream so an abort caused by the client disconnecting
+ * (the forwarded `signal`) ends the stream quietly instead of surfacing as an
+ * unhandled streaming error. Any other stream error is passed through unchanged.
+ */
+function quietlyAbortableStream(
+  body: ReadableStream<Uint8Array>,
+  signal: AbortSignal,
+): ReadableStream<Uint8Array> {
+  const reader = body.getReader();
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          controller.close();
+        } else {
+          controller.enqueue(value);
+        }
+      } catch (error) {
+        if (signal.aborted && (error as Error)?.name === "AbortError") {
+          controller.close();
+        } else {
+          controller.error(error);
+        }
+      }
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
   });
 }
 

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -20,12 +20,16 @@ export interface ProxyOptions {
   cookiePathRewrite?: string | Record<string, string>;
   onResponse?: (event: H3Event, response: Response) => void | Promise<void>;
   /**
-   * Control how a client disconnect is reported.
+   * Control how a client disconnect is handled.
    *
    * The incoming request's abort signal (`event.req.signal`) is always forwarded
    * to the proxied request, so a client disconnect aborts the upstream request
-   * and releases its connection. By default the resulting abort is reported as a
-   * `502`. Set this to `true` to instead let the `AbortError` propagate.
+   * and releases its connection. By default the resulting abort is handled
+   * quietly with a `499 Client Closed Request` response (never delivered, since
+   * the client is already gone) rather than logged as a `502` gateway error.
+   *
+   * Set this to `true` to instead let the `AbortError` propagate to your handler
+   * (e.g. to run cleanup). This also applies to a custom `fetchOptions.signal`.
    */
   propagateAbortError?: boolean;
 }
@@ -118,12 +122,20 @@ export async function proxy(
         ? await event.app!.fetch(createSubRequest(event, target, fetchOptions))
         : await fetch(target, fetchOptions);
   } catch (error) {
-    // A client disconnect (or any caller-supplied signal) aborts the proxied
-    // request; surface the abort as-is when opted in, else as a gateway error.
-    // Key off the error itself so it works with a custom `fetchOptions.signal`
-    // and so a real upstream failure is never mistaken for an abort.
-    if (opts.propagateAbortError && (error as Error)?.name === "AbortError") {
-      throw error;
+    // Key off the error itself (not `event.req.signal.aborted`) so an abort is
+    // detected even with a custom `fetchOptions.signal`, and a real upstream
+    // failure is never mistaken for an abort.
+    if ((error as Error)?.name === "AbortError") {
+      // Opted in: surface the abort as-is so the caller can handle it.
+      if (opts.propagateAbortError) {
+        throw error;
+      }
+      // Default: a client disconnect is not a gateway failure. Respond quietly
+      // instead of throwing a 502 for every dropped connection (the response is
+      // never delivered — the client is already gone).
+      if (event.req.signal.aborted) {
+        return new HTTPResponse(null, { status: 499, statusText: "Client Closed Request" });
+      }
     }
     throw new HTTPError({ status: 502, cause: error });
   }

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -314,11 +314,13 @@ describeMatrix("proxy", (t, { it, expect, describe }) => {
       );
 
       it.runIf(t.target === "web")(
-        "swallows a client abort during response streaming",
+        "does not turn a mid-stream client abort into a gateway error",
         async () => {
           // Upstream returns a body stream that errors with an AbortError once
-          // the client is gone (simulating a mid-stream disconnect). The default
-          // must drain quietly instead of surfacing the abort as a stream error.
+          // the client is gone (simulating a mid-stream disconnect). The body is
+          // streamed through natively: the handler must still return the upstream
+          // response (not a 502), and the abort is left to the stream consumer
+          // rather than being turned into a gateway error.
           const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(() => {
             const body = new ReadableStream<Uint8Array>({
               pull(controller) {
@@ -337,7 +339,10 @@ describeMatrix("proxy", (t, { it, expect, describe }) => {
             controller.abort();
 
             const res = await t.fetch("/", { signal: controller.signal });
-            await expect(res.text()).resolves.toBe("");
+            // Not a 502: the handler returned the upstream response normally.
+            expect(res.status).toBe(200);
+            // The abort surfaces to the body consumer, not swallowed silently.
+            await expect(res.text()).rejects.toThrow();
           } finally {
             fetchMock.mockRestore();
           }

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -228,15 +228,19 @@ describeMatrix("proxy", (t, { it, expect, describe }) => {
         },
       );
 
-      it.runIf(t.target === "web")("reports a client abort as 502 by default", async () => {
-        t.app.all("/", (event) => proxyRequest(event, "https://example.test/"));
+      it.runIf(t.target === "web")(
+        "handles a client abort quietly (499) by default without throwing",
+        async () => {
+          t.app.all("/", (event) => proxyRequest(event, "https://example.test/"));
 
-        const controller = new AbortController();
-        controller.abort();
+          const controller = new AbortController();
+          controller.abort();
 
-        const res = await t.fetch("/", { signal: controller.signal });
-        expect(res.status).toBe(502);
-      });
+          const res = await t.fetch("/", { signal: controller.signal });
+          // Client-caused abort is not a gateway error: no 502, no thrown error.
+          expect(res.status).toBe(499);
+        },
+      );
 
       it.runIf(t.target === "web")(
         "propagates the abort error when `propagateAbortError` is enabled",

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -262,6 +262,33 @@ describeMatrix("proxy", (t, { it, expect, describe }) => {
         },
       );
 
+      it.runIf(t.target === "web")(
+        "propagates the abort error from a caller-supplied `fetchOptions.signal`",
+        async () => {
+          // The client signal is never aborted here; only the caller's own
+          // signal is. The abort must still propagate when opted in.
+          let caught: unknown;
+          t.app.all("/", async (event) => {
+            const controller = new AbortController();
+            controller.abort();
+            try {
+              return await proxyRequest(event, "https://example.test/", {
+                propagateAbortError: true,
+                fetchOptions: { signal: controller.signal },
+              });
+            } catch (error) {
+              caught = error;
+              return "caught";
+            }
+          });
+
+          const res = await t.fetch("/");
+          expect(await res.text()).toBe("caught");
+          expect((caught as Error)?.name).toBe("AbortError");
+          expect(res.status).toBe(200);
+        },
+      );
+
       it(
         "can handle failed proxy requests gracefully",
         async () => {

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -214,6 +214,54 @@ describeMatrix("proxy", (t, { it, expect, describe }) => {
         },
       );
 
+      it.runIf(t.target === "web")(
+        "forwards the client abort signal to the proxied request",
+        async () => {
+          t.app.all("/debug", (event) => ({ aborted: event.req.signal.aborted }));
+          t.app.all("/", (event) => proxyRequest(event, "/debug"));
+
+          const controller = new AbortController();
+          controller.abort();
+
+          const res = await t.fetch("/", { signal: controller.signal });
+          expect(await res.json()).toMatchObject({ aborted: true });
+        },
+      );
+
+      it.runIf(t.target === "web")("reports a client abort as 502 by default", async () => {
+        t.app.all("/", (event) => proxyRequest(event, "https://example.test/"));
+
+        const controller = new AbortController();
+        controller.abort();
+
+        const res = await t.fetch("/", { signal: controller.signal });
+        expect(res.status).toBe(502);
+      });
+
+      it.runIf(t.target === "web")(
+        "propagates the abort error when `propagateAbortError` is enabled",
+        async () => {
+          let caught: unknown;
+          t.app.all("/", async (event) => {
+            try {
+              return await proxyRequest(event, "https://example.test/", {
+                propagateAbortError: true,
+              });
+            } catch (error) {
+              caught = error;
+              return "caught";
+            }
+          });
+
+          const controller = new AbortController();
+          controller.abort();
+
+          const res = await t.fetch("/", { signal: controller.signal });
+          expect(await res.text()).toBe("caught");
+          expect((caught as Error)?.name).toBe("AbortError");
+        },
+      );
+
       it(
         "can handle failed proxy requests gracefully",
         async () => {

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -293,6 +293,57 @@ describeMatrix("proxy", (t, { it, expect, describe }) => {
         },
       );
 
+      it.runIf(t.target === "web")(
+        "forwards the client abort even when a custom `fetchOptions.signal` is set",
+        async () => {
+          // The caller supplies its own (never-aborted) signal. The client's
+          // abort must still be forwarded and handled quietly (499) rather than
+          // silently dropped by the spread over `fetchOptions`.
+          t.app.all("/", (event) =>
+            proxyRequest(event, "https://example.test/", {
+              fetchOptions: { signal: new AbortController().signal },
+            }),
+          );
+
+          const controller = new AbortController();
+          controller.abort();
+
+          const res = await t.fetch("/", { signal: controller.signal });
+          expect(res.status).toBe(499);
+        },
+      );
+
+      it.runIf(t.target === "web")(
+        "swallows a client abort during response streaming",
+        async () => {
+          // Upstream returns a body stream that errors with an AbortError once
+          // the client is gone (simulating a mid-stream disconnect). The default
+          // must drain quietly instead of surfacing the abort as a stream error.
+          const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(() => {
+            const body = new ReadableStream<Uint8Array>({
+              pull(controller) {
+                const error = new Error("The operation was aborted.");
+                error.name = "AbortError";
+                controller.error(error);
+              },
+            });
+            return Promise.resolve(new Response(body, { status: 200 }));
+          });
+
+          try {
+            t.app.all("/", (event) => proxyRequest(event, "https://upstream.test/"));
+
+            const controller = new AbortController();
+            controller.abort();
+
+            const res = await t.fetch("/", { signal: controller.signal });
+            await expect(res.text()).resolves.toBe("");
+          } finally {
+            fetchMock.mockRestore();
+          }
+        },
+      );
+
       it(
         "can handle failed proxy requests gracefully",
         async () => {


### PR DESCRIPTION
- client abort signals are propagated upstream
- 502 response on abort remains the default to prevent breaking existing behaviour
- new option `propogateAbortError` to throw client abort error instead of 502 response


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `propagateAbortError` option to control whether client disconnects surface as an `AbortError` or are handled quietly.
  * Proxying now forwards the client abort signal for upstream requests, and combines it with any provided `fetch` signal.
  * Client disconnects now result in HTTP **499** by default; enabling `propagateAbortError` surfaces the `AbortError`. Mid-stream disconnects no longer trigger gateway errors.
* **Tests**
  * Added web-only coverage for default **499** behavior, `propagateAbortError: true`, and mid-stream abort outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->