### PR TITLE
fix(request): add AbortSignal to toWebRequest for client disconnect detection

### DIFF
--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -352,16 +352,19 @@ export function getRequestURL(
  * **NOTE:** This function is not stable and might have edge cases that are not handled properly.
  */
 export function toWebRequest(event: H3Event) {
-  return (
-    event.web?.request ||
-    new Request(getRequestURL(event), {
-      // @ts-ignore Undici option
-      duplex: "half",
-      method: event.method,
-      headers: event.headers,
-      body: getRequestWebStream(event),
-    })
-  );
+  if (event.web?.request) {
+    return event.web.request;
+  }
+  const controller = new AbortController();
+  event.node.req.on("close", () => controller.abort());
+  return new Request(getRequestURL(event), {
+    // @ts-ignore Undici option
+    duplex: "half",
+    method: event.method,
+    headers: event.headers,
+    body: getRequestWebStream(event),
+    signal: controller.signal,
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #1204

### Problem

`toWebRequest` creates a `new Request()` without an `AbortSignal`. This means downstream code that consumes `request.signal` (e.g. tRPC subscriptions, streaming handlers) can never detect when a client disconnects — the signal stays open forever.

### Fix

When falling through to `new Request(...)`, create an `AbortController`, wire its `.abort()` to `event.node.req.on("close", ...)`, and pass `signal: controller.signal` to the `Request` constructor.

```ts
// Before
export function toWebRequest(event: H3Event) {
  return (
    event.web?.request ||
    new Request(getRequestURL(event), {
      duplex: "half",
      method: event.method,
      headers: event.headers,
      body: getRequestWebStream(event),
    })
  );
}

// After
export function toWebRequest(event: H3Event) {
  if (event.web?.request) {
    return event.web.request;
  }
  const controller = new AbortController();
  event.node.req.on("close", () => controller.abort());
  return new Request(getRequestURL(event), {
    duplex: "half",
    method: event.method,
    headers: event.headers,
    body: getRequestWebStream(event),
    signal: controller.signal,
  });
}
```

When `event.web?.request` is already present (i.e. a native web runtime), it carries its own signal — we return it as-is and skip the `AbortController` entirely.

### Related

- Issue: https://github.com/h3js/h3/issues/1204
- Workaround mentioned in issue: https://github.com/wobsoriano/trpc-nuxt/issues/191