### PR TITLE
docs: correct decode function name for getRouterParam helpers

### DIFF
--- a/docs/2.utils/1.request.md
+++ b/docs/2.utils/1.request.md
@@ -201,7 +201,7 @@ app.get("/", (event) => {
 
 Get a matched route param by name.
 
-If `decode` option is `true`, it will decode the matched route param using `decodeURI`.
+If `decode` option is `true`, it will decode the matched route param using `decodeURIComponent`.
 
 **Example:**
 
@@ -279,7 +279,7 @@ app.get("/", async (event) => {
 
 Get matched route params and validate with validate function.
 
-If `decode` option is `true`, it will decode the matched route params using `decodeURI`.
+If `decode` option is `true`, it will decode the matched route params using `decodeURIComponent`.
 
 You can use a simple function to validate the params object or use a Standard-Schema compatible library like `zod` to define a schema.
 

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -204,7 +204,7 @@ export function getValidatedRouterParams<
 /**
  * Get matched route params and validate with validate function.
  *
- * If `decode` option is `true`, it will decode the matched route params using `decodeURI`.
+ * If `decode` option is `true`, it will decode the matched route params using `decodeURIComponent`.
  *
  * You can use a simple function to validate the params object or use a Standard-Schema compatible library like `zod` to define a schema.
  *
@@ -267,7 +267,7 @@ export function getValidatedRouterParams(
 /**
  * Get a matched route param by name.
  *
- * If `decode` option is `true`, it will decode the matched route param using `decodeURI`.
+ * If `decode` option is `true`, it will decode the matched route param using `decodeURIComponent`.
  *
  * @example
  * app.get("/", (event) => {


### PR DESCRIPTION
The JSDoc for `getRouterParam` and `getValidatedRouterParams` says the `decode` option decodes params with `decodeURI`, but both functions delegate to `getRouterParams`, which decodes with `decodeURIComponent`:

```ts
// getRouterParams, src/utils/request.ts:178
params[key] = decodeURIComponent(params[key]);
```

`getRouterParams`' own JSDoc (line 161) already says `decodeURIComponent`, so the two sibling helpers contradicted it. The distinction matters because `decodeURI` leaves reserved characters like `%2F`, `%23` and `%3F` encoded, while `decodeURIComponent` decodes them, so a reader following the docs would expect the wrong result.

Fixed the JSDoc on both helpers and regenerated the `docs/2.utils/1.request.md` automd block that is built from it. Comment-only change, no behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified route parameter decoding behavior when the decode option is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->