### PR TITLE
fix(sanitizeStatusCode): return default for non-numeric input instead of NaN

### DIFF
--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -21,7 +21,10 @@ export function sanitizeStatusCode(statusCode?: string | number, defaultStatusCo
   if (typeof statusCode === "string") {
     statusCode = +statusCode;
   }
-  if (statusCode < 100 || statusCode > 599) {
+  // `+statusCode` yields `NaN` for non-numeric strings, and `NaN` passes the
+  // range check below (every comparison with `NaN` is `false`). Guard against
+  // it so an invalid code can never leak through and break `Response`.
+  if (Number.isNaN(statusCode) || statusCode < 100 || statusCode > 599) {
     return defaultStatusCode;
   }
   return statusCode;

--- a/test/unit/sanitize.test.ts
+++ b/test/unit/sanitize.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeStatusCode, sanitizeStatusMessage } from "../../src/utils/sanitize.ts";
+
+describe("sanitizeStatusCode", () => {
+  it("returns valid status codes unchanged", () => {
+    expect(sanitizeStatusCode(200)).toBe(200);
+    expect(sanitizeStatusCode(404)).toBe(404);
+    expect(sanitizeStatusCode(599)).toBe(599);
+    expect(sanitizeStatusCode("301")).toBe(301);
+  });
+
+  it("returns the default for out-of-range codes", () => {
+    expect(sanitizeStatusCode(99)).toBe(200);
+    expect(sanitizeStatusCode(600)).toBe(200);
+    expect(sanitizeStatusCode(99, 500)).toBe(500);
+  });
+
+  it("returns the default for missing input", () => {
+    expect(sanitizeStatusCode(undefined)).toBe(200);
+    expect(sanitizeStatusCode("")).toBe(200);
+    expect(sanitizeStatusCode(0)).toBe(200);
+    expect(sanitizeStatusCode(undefined, 404)).toBe(404);
+  });
+
+  it("returns the default for non-numeric strings (never NaN)", () => {
+    // Regression: `+"abc"` is NaN and NaN passes the range check, so the
+    // function used to return NaN — which then throws `RangeError` when used
+    // to construct a `Response`.
+    expect(sanitizeStatusCode("abc")).toBe(200);
+    expect(sanitizeStatusCode("12x")).toBe(200);
+    expect(sanitizeStatusCode("abc", 500)).toBe(500);
+    expect(sanitizeStatusCode(Number.NaN)).toBe(200);
+  });
+});
+
+describe("sanitizeStatusMessage", () => {
+  it("strips disallowed characters", () => {
+    expect(sanitizeStatusMessage("OK")).toBe("OK");
+    expect(sanitizeStatusMessage("Not\nFound")).toBe("NotFound");
+  });
+});


### PR DESCRIPTION
Coercing a non-numeric string status to a number yields `NaN`, and `NaN` silently passes the range check, so the sanitizer returns `NaN` — defeating its own purpose ("Make sure the status code is a valid HTTP status code").

### Bug

```ts
sanitizeStatusCode("abc"); // NaN  (expected: 200)
sanitizeStatusCode("12x"); // NaN
sanitizeStatusCode(Number.NaN); // NaN
```

Inside `sanitizeStatusCode`, `+statusCode` is `NaN` for non-numeric strings. Because **every** comparison with `NaN` is `false`, the `statusCode < 100 || statusCode > 599` guard does not catch it and `NaN` is returned unchanged.

This is reachable through `HTTPError` (`src/error.ts` reads `status`/`statusCode` from arbitrary error/cause objects) and the deprecated `setResponseStatus(event, code)` (which accepts a string). A `NaN` status then throws when the response is built:

```
RangeError: init["status"] must be in the range of 200 to 599, inclusive.
```

So a value meant to be sanitized into a safe code instead crashes response construction.

### Fix

Reject `NaN` alongside the existing out-of-range check so an invalid code always falls back to `defaultStatusCode`:

```ts
if (Number.isNaN(statusCode) || statusCode < 100 || statusCode > 599) {
  return defaultStatusCode;
}
```

Valid numbers and numeric strings are unaffected. The bug has been present since the original implementation (2023).

### Tests

Added `test/unit/sanitize.test.ts`. The `non-numeric strings (never NaN)` case fails on `main` (`expected NaN to be 200`) and passes with the fix; the other cases pin existing behavior (valid codes, out-of-range, falsy input).

- `vitest run test/unit/sanitize.test.ts` → 5 passed
- Full suite: 48/49 files, 1152 tests pass (the only red is `test/bench/bundle.test.ts`, which needs the native `esbuild` binary and fails identically on a clean checkout — unrelated to this change)
- `oxfmt --check` clean on both files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP status code validation to properly reject invalid values including NaN, preventing potential response construction failures.

* **Tests**
  * Added comprehensive unit tests for status code and message sanitization utilities, ensuring proper handling of valid codes, out-of-range values, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->