### PR TITLE
fix(sanitizeStatusCode): return default for non-numeric input instead of NaN

### DIFF
--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -24,7 +24,10 @@ export function sanitizeStatusCode(
   if (typeof statusCode === "string") {
     statusCode = Number.parseInt(statusCode, 10);
   }
-  if (statusCode < 100 || statusCode > 999) {
+  // `Number.parseInt` returns `NaN` for non-numeric strings, and `NaN` passes
+  // the range check below (every comparison with `NaN` is `false`), so an
+  // invalid status code would leak through unchanged. Guard against it.
+  if (Number.isNaN(statusCode) || statusCode < 100 || statusCode > 999) {
     return defaultStatusCode;
   }
   return statusCode;

--- a/test/sanitize.test.ts
+++ b/test/sanitize.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeStatusCode } from "../src/utils/sanitize";
+
+describe("sanitizeStatusCode", () => {
+  it("returns valid status codes unchanged", () => {
+    expect(sanitizeStatusCode(200)).toBe(200);
+    expect(sanitizeStatusCode(404)).toBe(404);
+    expect(sanitizeStatusCode("301")).toBe(301);
+  });
+
+  it("returns the default for missing or out-of-range input", () => {
+    expect(sanitizeStatusCode(undefined)).toBe(200);
+    expect(sanitizeStatusCode(0)).toBe(200);
+    expect(sanitizeStatusCode(99)).toBe(200);
+    expect(sanitizeStatusCode(1000)).toBe(200);
+    expect(sanitizeStatusCode(99, 500)).toBe(500);
+  });
+
+  it("returns the default for non-numeric strings instead of NaN", () => {
+    // `Number.parseInt("abc", 10)` is NaN and NaN passes the range check, so
+    // the function used to return NaN here, which breaks downstream consumers
+    // (e.g. setting `res.statusCode` or building a `Response`).
+    expect(sanitizeStatusCode("abc")).toBe(200);
+    expect(sanitizeStatusCode("abc", 500)).toBe(500);
+  });
+});


### PR DESCRIPTION
`sanitizeStatusCode` accepts `string | number` and parses strings with `Number.parseInt`. For a non-numeric string `Number.parseInt` returns `NaN`, and `NaN` slips through the range check because every comparison with `NaN` is `false`:

```ts
sanitizeStatusCode("abc"); // -> NaN  (expected 200)
```

So an invalid code can reach `createError` (`err.statusCode = sanitizeStatusCode(input.statusCode, ...)`) and the response helpers (`event.node.res.statusCode = sanitizeStatusCode(...)`), where a `NaN` status is no longer a valid HTTP status.

This is the same issue that was fixed for v2 on `main` in #1420; this backports the guard to the v1 line. The `Number.parseInt` behaviour and the `100..999` range are unchanged, I only added the `Number.isNaN` check:

```ts
if (Number.isNaN(statusCode) || statusCode < 100 || statusCode > 999) {
  return defaultStatusCode;
}
```

Added a unit test covering valid codes, out-of-range codes and non-numeric strings. It fails before the change (returns `NaN`) and passes after.
