### PR TITLE
fix(proxy): ignore incoming accept-encoding header

### DIFF
--- a/src/utils/internal/proxy.ts
+++ b/src/utils/internal/proxy.ts
@@ -2,6 +2,7 @@ export const PayloadMethods: Set<string> = new Set(["PATCH", "POST", "PUT", "DEL
 
 export const ignoredHeaders: Set<string> = new Set([
   "transfer-encoding",
+  "accept-encoding",
   "connection",
   "keep-alive",
   "upgrade",

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -69,6 +69,24 @@ describeMatrix("proxy", (t, { it, expect, describe }) => {
         `);
       });
 
+      it("does not forward incoming accept-encoding header", async () => {
+        t.app.all("/debug", (event) => {
+          return { headers: Object.fromEntries(event.req.headers.entries()) };
+        });
+
+        t.app.all("/", (event) => {
+          return proxyRequest(event, "/debug");
+        });
+
+        const result = await t
+          .fetch("/", {
+            headers: { "accept-encoding": "zstd, br, gzip" },
+          })
+          .then((r) => r.json());
+
+        expect(result.headers["accept-encoding"]).toBeUndefined();
+      });
+
       it("can proxy binary request", async () => {
         t.app.all("/debug", async (event) => {
           const body = await event.req.arrayBuffer();


### PR DESCRIPTION
v1 strips the incoming `accept-encoding` header before proxying (#914). The v2 `ignoredHeaders` set in `src/utils/internal/proxy.ts` added `accept` but dropped `accept-encoding`, so `getProxyRequestHeaders` forwards the client's `accept-encoding` to the target.

`proxy()` removes `content-encoding` from the upstream response, relying on the runtime's fetch having already decoded the body. Forwarding the client's `accept-encoding` lets the target pick an encoding the runtime's fetch may not decode (the zstd-on-undici case from nitrojs/nitro#2880 that #914 addressed); the still-encoded body would then be passed on without a `content-encoding` header. Since h3 v2 runs across runtimes whose fetch clients support different encoding sets, this restores the v1 behavior by adding `accept-encoding` back to the set so the runtime fetch negotiates and decodes the encoding itself.

Added a regression test: proxying a request that sends `accept-encoding: zstd, br, gzip` now asserts the upstream does not receive it. Without the change the header is forwarded (web and node test targets); with it the header is dropped. Full suite passes.

Ref: #914


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated proxy handling so incoming `accept-encoding` headers are no longer forwarded upstream.
  * This helps ensure proxied requests use the expected header behavior.
* **Tests**
  * Added coverage verifying that `accept-encoding` is stripped before reaching the upstream request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->