### PR TITLE
docs(ws): use zero-config crossws server plugin

### DIFF
--- a/docs/1.guide/901.advanced/2.websocket.md
+++ b/docs/1.guide/901.advanced/2.websocket.md
@@ -8,14 +8,11 @@ icon: hugeicons:live-streaming-02
 
 You can add cross platform WebSocket support to H3 servers using [🔌 CrossWS](https://crossws.h3.dev/).
 
-> [!IMPORTANT]
-> Built-in support of WebSockets in h3 version is WIP.
-
 ## Usage
 
 WebSocket handlers can be defined using the `defineWebSocketHandler()` utility and registered to any route like event handlers.
 
-You need to register CrossWS as a server plugin in the `serve` function and provide a `resolve` function to resolve the correct hooks from the route.
+You need to register CrossWS as a server plugin in the `serve` function. The plugin resolves the correct hooks from your matched route automatically.
 
 ```js
 import { H3, serve, defineWebSocketHandler } from "h3";
@@ -27,9 +24,12 @@ const app = new H3();
 app.get("/_ws", defineWebSocketHandler({ message: console.log }));
 
 serve(app, {
-  plugins: [ws({ resolve: async (req) => (await app.fetch(req)).crossws })],
+  plugins: [ws()],
 });
 ```
+
+> [!NOTE]
+> Passing a custom `resolve` to `ws()` is only needed to resolve hooks yourself (for example without invoking the app). By default, CrossWS calls the app's `fetch` handler and reads the hooks attached by `defineWebSocketHandler()`.
 
 **Full example:**
 
@@ -116,7 +116,7 @@ app.get(
 );
 
 serve(app, {
-  plugins: [ws({ resolve: async (req) => (await app.fetch(req)).crossws })],
+  plugins: [ws()],
 });
 ```
 

--- a/examples/websocket.mjs
+++ b/examples/websocket.mjs
@@ -78,5 +78,5 @@ app.get(
 );
 
 serve(app, {
-  plugins: [ws({ resolve: async (req) => (await app.fetch(req)).crossws })],
+  plugins: [ws()],
 });


### PR DESCRIPTION
## Summary

[crossws#200](https://github.com/h3js/crossws/pull/200) makes the server plugin's `resolve` optional — it now defaults to calling the app's `fetch` handler and reading the hooks that `defineWebSocketHandler()` attaches as `.crossws`. That makes the `resolve: (req) => (await app.fetch(req)).crossws` boilerplate in our docs redundant (it was h3 wiring itself back into itself).

This PR updates the WebSocket guide + example to the zero-config form:

```diff
 serve(app, {
-  plugins: [ws({ resolve: async (req) => (await app.fetch(req)).crossws })],
+  plugins: [ws()],
 });
```

Docs-only — no `src/` changes. `serve()` already passes `fetch: app.fetch` to srvx and `defineWebSocketHandler` already attaches `.crossws`, so nothing in the framework needs to change.

## Changes

- `docs/1.guide/901.advanced/2.websocket.md` — use `ws()`, update prose, add a NOTE explaining `resolve` is now only for custom hook resolution, and drop the outdated "WIP" callout.
- `examples/websocket.mjs` — drop the `resolve` argument.

## Follow-up (not in this PR)

- Bump the `crossws` peer/dev range once the release carrying crossws#200 is published (currently `^0.4.8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified WebSocket setup instructions for H3 with CrossWS.
  * Updated examples to use a simpler plugin setup and noted when custom route resolution is needed.
* **Bug Fixes**
  * Removed outdated wording about WebSocket support status, making the guidance clearer and more accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->