### PR TITLE
feat: export `resolveDotSegments` as a public path utility

### DIFF
--- a/docs/2.utils/4.security.md
+++ b/docs/2.utils/4.security.md
@@ -127,3 +127,17 @@ Check if the origin is allowed.
 Check if the incoming request is a CORS preflight request.
 
 <!-- /automd -->
+
+## Path
+
+<!-- automd:jsdocs src="../../src/utils/path.ts" -->
+
+### `resolveDotSegments(path, opts?)`
+
+Resolve `.` and `..` segments in a path, without ever escaping above the root `/`. The result is always an absolute path with a single leading `/`, so it can never be protocol-relative (`//host`).
+
+Also decodes percent-encoded dot segments (`%2e`/`%2E`) and normalizes `\` to `/`, so encoded or backslash-based traversal (e.g. `%2e%2e/`, `..\..\`) is caught the same way as a literal `../`.
+
+`%2f`/`%5c` (encoded path separators) are left untouched by default — see {@link ResolveDotSegmentsOptions.decodeSlashes}.
+
+<!-- /automd -->

--- a/docs/2.utils/4.security.md
+++ b/docs/2.utils/4.security.md
@@ -140,4 +140,6 @@ Also decodes percent-encoded dot segments at any `%25`-nesting depth (`%2e`, `%2
 
 `%2f`/`%5c` (encoded path separators) are left untouched by default — see {@link ResolveDotSegmentsOptions.decodeSlashes}.
 
+Only `.`/`..` resolution and the decodes above alter the string; every other percent-encoding (`%20`, non-ASCII, `%3A`, and any `%2e` not forming a whole segment) is left intact, so the result stays in the same representation as an un-decoded `event.url.pathname` and matches routes/rules consistently. Interior empty segments are preserved (`/a//b` stays `/a//b`, per WHATWG URL normalization) — only the leading slash is guaranteed single, so a consumer doing exact prefix matching should normalize its allowlist the same way.
+
 <!-- /automd -->

--- a/docs/2.utils/4.security.md
+++ b/docs/2.utils/4.security.md
@@ -136,7 +136,7 @@ Check if the incoming request is a CORS preflight request.
 
 Resolve `.` and `..` segments in a path, without ever escaping above the root `/`. The result is always an absolute path with a single leading `/`, so it can never be protocol-relative (`//host`).
 
-Also decodes percent-encoded dot segments (`%2e`/`%2E`) and normalizes `\` to `/`, so encoded or backslash-based traversal (e.g. `%2e%2e/`, `..\..\`) is caught the same way as a literal `../`.
+Also decodes percent-encoded dot segments at any `%25`-nesting depth (`%2e`, `%252e`, ...) and normalizes `\` to `/`, so encoded or backslash-based traversal (e.g. `%2e%2e/`, `..\..\`) is caught the same way as a literal `../`.
 
 `%2f`/`%5c` (encoded path separators) are left untouched by default — see {@link ResolveDotSegmentsOptions.decodeSlashes}.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,6 +162,10 @@ export { sanitizeStatusCode, sanitizeStatusMessage } from "./utils/sanitize.ts";
 
 export { type CacheConditions, handleCacheHeaders } from "./utils/cache.ts";
 
+// Path
+
+export { type ResolveDotSegmentsOptions, resolveDotSegments } from "./utils/path.ts";
+
 // Static
 
 export { type ServeStaticOptions, type StaticAssetMeta, serveStatic } from "./utils/static.ts";

--- a/src/utils/internal/path.ts
+++ b/src/utils/internal/path.ts
@@ -51,34 +51,8 @@ export function getPathname(path: string = "/"): string {
 }
 
 /**
- * Resolve dot segments (`.` and `..`) in a path to prevent path traversal.
- * Ensures the resulting path never escapes above the root `/`.
- */
-/**
  * Decode percent-encoded pathname, preserving %25 (literal `%`).
  */
 export function decodePathname(pathname: string): string {
   return decodeURI(pathname.includes("%25") ? pathname.replace(/%25/g, "%2525") : pathname);
-}
-
-export function resolveDotSegments(path: string): string {
-  if (!path.includes(".") && !path.includes("%2")) {
-    return path;
-  }
-  // Normalize backslashes to forward slashes to prevent traversal via `\`
-  const segments = path.replaceAll("\\", "/").split("/");
-  const resolved: string[] = [];
-  for (const segment of segments) {
-    // Decode percent-encoded dots (%2e/%2E) to catch double-encoded traversal
-    const normalized = segment.replace(/%2e/gi, ".");
-    if (normalized === "..") {
-      // Never pop past the root (first empty segment from leading slash)
-      if (resolved.length > 1) {
-        resolved.pop();
-      }
-    } else if (normalized !== ".") {
-      resolved.push(segment);
-    }
-  }
-  return resolved.join("/") || "/";
 }

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -44,6 +44,11 @@ export function resolveDotSegments(path: string, opts?: ResolveDotSegmentsOption
     path = "/" + path.replace(/^[/\\]+/, "");
   }
   const decodeSlashes = opts?.decodeSlashes;
+  // TODO(perf): this guard is coarse — any `.` (every dotted filename) or any
+  // `%2x` escape (e.g. `%20`) takes the slow path even without a real dot
+  // segment. A boundary-aware check (dot adjacent to `/`/edges, and only
+  // `%2e`/`%2f`/`%5c`) would keep the common serveStatic inputs on the fast
+  // path. Needs its own benchmark, so deferred.
   const hasDotSegment = path.includes(".") || path.includes("%2");
   const hasBackslash = path.includes("\\");
   const hasEncodedSlash = decodeSlashes && /%2f|%5c/i.test(path);

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -15,9 +15,10 @@ export interface ResolveDotSegmentsOptions {
    * segment dodge a narrower rule at match time and then escape it once
    * decoded downstream. Never use the result for routing/dispatch.
    *
-   * Only a single decode level is applied: a double-encoded separator like
-   * `%252f` is left intact. If a downstream may decode more than once, run
-   * the result through {@link resolveDotSegments} again until it is stable.
+   * Decoding is pessimistic: nested `%25`-encodings of a separator
+   * (`%252f`, `%25252f`, ...) are collapsed too, so a downstream that
+   * decodes any number of times cannot smuggle a separator past the check.
+   * Other escapes (e.g. `%20`) are never decoded.
    *
    * @default false
    */
@@ -29,9 +30,10 @@ export interface ResolveDotSegmentsOptions {
  * root `/`. The result is always an absolute path with a single leading `/`,
  * so it can never be protocol-relative (`//host`).
  *
- * Also decodes percent-encoded dot segments (`%2e`/`%2E`) and normalizes `\`
- * to `/`, so encoded or backslash-based traversal (e.g. `%2e%2e/`, `..\..\`)
- * is caught the same way as a literal `../`.
+ * Also decodes percent-encoded dot segments at any `%25`-nesting depth
+ * (`%2e`, `%252e`, ...) and normalizes `\` to `/`, so encoded or
+ * backslash-based traversal (e.g. `%2e%2e/`, `..\..\`) is caught the same
+ * way as a literal `../`.
  *
  * `%2f`/`%5c` (encoded path separators) are left untouched by default — see
  * {@link ResolveDotSegmentsOptions.decodeSlashes}.
@@ -51,20 +53,21 @@ export function resolveDotSegments(path: string, opts?: ResolveDotSegmentsOption
   // path. Needs its own benchmark, so deferred.
   const hasDotSegment = path.includes(".") || path.includes("%2");
   const hasBackslash = path.includes("\\");
-  const hasEncodedSlash = decodeSlashes && /%2f|%5c/i.test(path);
+  const hasEncodedSlash = decodeSlashes && /%(?:25)*(?:2f|5c)/i.test(path);
   if (!hasDotSegment && !hasBackslash && !hasEncodedSlash) {
     return path;
   }
   // Normalize backslashes to forward slashes to prevent traversal via `\`
   let normalized = hasBackslash ? path.replaceAll("\\", "/") : path;
   if (hasEncodedSlash) {
-    normalized = normalized.replace(/%2f|%5c/gi, "/");
+    normalized = normalized.replace(/%(?:25)*(?:2f|5c)/gi, "/");
   }
   const segments = normalized.split("/");
   const resolved: string[] = [];
   for (const segment of segments) {
-    // Decode percent-encoded dots (%2e/%2E) to catch double-encoded traversal
-    const normalizedSegment = segment.replace(/%2e/gi, ".");
+    // Decode percent-encoded dots at any %25-nesting depth (%2e, %252e, ...)
+    // to catch multi-encoded traversal
+    const normalizedSegment = segment.replace(/%(?:25)*2e/gi, ".");
     if (normalizedSegment === "..") {
       // Never pop past the root (first empty segment from leading slash)
       if (resolved.length > 1) {

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -25,6 +25,21 @@ export interface ResolveDotSegmentsOptions {
   decodeSlashes?: boolean;
 }
 
+// A dot segment — the only `.`-related input that changes the path — is a `.`
+// or `..` occupying a WHOLE segment, where each dot may be a literal `.` or a
+// `%2e` escape at any `%25`-nesting depth. Matching it boundary-aware (bounded
+// by `/` or the string edges) keeps a dotted filename (`app.1a2b.js`) or a
+// non-dot escape (`%20`) on the fast path instead of the split/normalize loop.
+const DOT_SEGMENT_RE = /(?:^|\/)(?:\.|%(?:25)*2e){1,2}(?:\/|$)/i;
+
+// Encoded path separators (`%2f`/`%5c`) at any `%25`-nesting depth. Test form
+// for the fast-path guard; global form to decode every occurrence.
+const ENCODED_SEP_RE = /%(?:25)*(?:2f|5c)/i;
+const ENCODED_SEP_RE_G = /%(?:25)*(?:2f|5c)/gi;
+
+// Percent-encoded dots at any `%25`-nesting depth, for per-segment decoding.
+const ENCODED_DOT_RE_G = /%(?:25)*2e/gi;
+
 /**
  * Resolve `.` and `..` segments in a path, without ever escaping above the
  * root `/`. The result is always an absolute path with a single leading `/`,
@@ -54,28 +69,28 @@ export function resolveDotSegments(path: string, opts?: ResolveDotSegmentsOption
     path = "/" + path.replace(/^[/\\]+/, "");
   }
   const decodeSlashes = opts?.decodeSlashes;
-  // TODO(perf): this guard is coarse — any `.` (every dotted filename) or any
-  // `%2x` escape (e.g. `%20`) takes the slow path even without a real dot
-  // segment. A boundary-aware check (dot adjacent to `/`/edges, and only
-  // `%2e`/`%2f`/`%5c`) would keep the common serveStatic inputs on the fast
-  // path. Needs its own benchmark, so deferred.
-  const hasDotSegment = path.includes(".") || path.includes("%2");
+  // A `\` always needs normalizing, and (with `decodeSlashes`) an encoded
+  // separator always needs decoding — both are cheap `includes`/`test` scans
+  // checked first so a dot-free path skips the dot-segment regex entirely.
   const hasBackslash = path.includes("\\");
-  const hasEncodedSlash = decodeSlashes && /%(?:25)*(?:2f|5c)/i.test(path);
-  if (!hasDotSegment && !hasBackslash && !hasEncodedSlash) {
+  const hasEncodedSep = decodeSlashes && ENCODED_SEP_RE.test(path);
+  if (!hasBackslash && !hasEncodedSep && !DOT_SEGMENT_RE.test(path)) {
     return path;
   }
   // Normalize backslashes to forward slashes to prevent traversal via `\`
   let normalized = hasBackslash ? path.replaceAll("\\", "/") : path;
-  if (hasEncodedSlash) {
-    normalized = normalized.replace(/%(?:25)*(?:2f|5c)/gi, "/");
+  if (hasEncodedSep) {
+    normalized = normalized.replace(ENCODED_SEP_RE_G, "/");
   }
   const segments = normalized.split("/");
   const resolved: string[] = [];
   for (const segment of segments) {
     // Decode percent-encoded dots at any %25-nesting depth (%2e, %252e, ...)
-    // to catch multi-encoded traversal
-    const normalizedSegment = segment.replace(/%(?:25)*2e/gi, ".");
+    // to catch multi-encoded traversal — skipped for the common `%`-free
+    // segment, which cannot contain an encoded dot.
+    const normalizedSegment = segment.includes("%")
+      ? segment.replace(ENCODED_DOT_RE_G, ".")
+      : segment;
     if (normalizedSegment === "..") {
       // Never pop past the root (first empty segment from leading slash)
       if (resolved.length > 1) {

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,0 +1,59 @@
+export interface ResolveDotSegmentsOptions {
+  /**
+   * Also decode percent-encoded path separators (`%2f`, `%5c`) into real `/`
+   * segment boundaries before resolving `.`/`..`.
+   *
+   * `event.url.pathname` never decodes `%2f` on its own, because doing so
+   * would change how many segments a path has and therefore which route
+   * matches — a correctness concern for dispatch, not just a security one
+   * (e.g. `/files/:id` may rely on `%2F` to keep an id with a literal slash
+   * as one opaque segment).
+   *
+   * Enable this only for out-of-band scope/security checks that must
+   * anticipate a downstream decode — e.g. a reverse-proxy target or redirect
+   * that will collapse `%2f` back to `/` on its own, letting an encoded
+   * segment dodge a narrower rule at match time and then escape it once
+   * decoded downstream. Never use the result for routing/dispatch.
+   *
+   * @default false
+   */
+  decodeSlashes?: boolean;
+}
+
+/**
+ * Resolve `.` and `..` segments in a path, without ever escaping above the
+ * root `/`.
+ *
+ * Also decodes percent-encoded dot segments (`%2e`/`%2E`) and normalizes `\`
+ * to `/`, so encoded or backslash-based traversal (e.g. `%2e%2e/`, `..\..\`)
+ * is caught the same way as a literal `../`.
+ *
+ * `%2f`/`%5c` (encoded path separators) are left untouched by default — see
+ * {@link ResolveDotSegmentsOptions.decodeSlashes}.
+ */
+export function resolveDotSegments(path: string, opts?: ResolveDotSegmentsOptions): string {
+  const decodeSlashes = opts?.decodeSlashes;
+  const hasDotSegment = path.includes(".") || path.includes("%2");
+  const hasEncodedSlash = decodeSlashes && /%2f|%5c/i.test(path);
+  if (!hasDotSegment && !hasEncodedSlash) {
+    return path;
+  }
+  let normalized = path.replaceAll("\\", "/");
+  if (decodeSlashes) {
+    normalized = normalized.replace(/%2f/gi, "/").replace(/%5c/gi, "/");
+  }
+  const segments = normalized.split("/");
+  const resolved: string[] = [];
+  for (const segment of segments) {
+    const normalizedSegment = segment.replace(/%2e/gi, ".");
+    if (normalizedSegment === "..") {
+      // Never pop past the root (first empty segment from leading slash)
+      if (resolved.length > 1) {
+        resolved.pop();
+      }
+    } else if (normalizedSegment !== ".") {
+      resolved.push(segment);
+    }
+  }
+  return resolved.join("/") || "/";
+}

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -15,6 +15,10 @@ export interface ResolveDotSegmentsOptions {
    * segment dodge a narrower rule at match time and then escape it once
    * decoded downstream. Never use the result for routing/dispatch.
    *
+   * Only a single decode level is applied: a double-encoded separator like
+   * `%252f` is left intact. If a downstream may decode more than once, run
+   * the result through {@link resolveDotSegments} again until it is stable.
+   *
    * @default false
    */
   decodeSlashes?: boolean;
@@ -22,7 +26,8 @@ export interface ResolveDotSegmentsOptions {
 
 /**
  * Resolve `.` and `..` segments in a path, without ever escaping above the
- * root `/`.
+ * root `/`. The result is always an absolute path with a single leading `/`,
+ * so it can never be protocol-relative (`//host`).
  *
  * Also decodes percent-encoded dot segments (`%2e`/`%2E`) and normalizes `\`
  * to `/`, so encoded or backslash-based traversal (e.g. `%2e%2e/`, `..\..\`)
@@ -32,19 +37,28 @@ export interface ResolveDotSegmentsOptions {
  * {@link ResolveDotSegmentsOptions.decodeSlashes}.
  */
 export function resolveDotSegments(path: string, opts?: ResolveDotSegmentsOptions): string {
+  // Normalize to a single leading slash (treating a leading `\` as a
+  // separator). This keeps the `..` root clamp below well-defined for
+  // otherwise-relative inputs and prevents a protocol-relative result.
+  if (path[0] !== "/" || path[1] === "/" || path[1] === "\\") {
+    path = "/" + path.replace(/^[/\\]+/, "");
+  }
   const decodeSlashes = opts?.decodeSlashes;
   const hasDotSegment = path.includes(".") || path.includes("%2");
+  const hasBackslash = path.includes("\\");
   const hasEncodedSlash = decodeSlashes && /%2f|%5c/i.test(path);
-  if (!hasDotSegment && !hasEncodedSlash) {
+  if (!hasDotSegment && !hasBackslash && !hasEncodedSlash) {
     return path;
   }
-  let normalized = path.replaceAll("\\", "/");
-  if (decodeSlashes) {
-    normalized = normalized.replace(/%2f/gi, "/").replace(/%5c/gi, "/");
+  // Normalize backslashes to forward slashes to prevent traversal via `\`
+  let normalized = hasBackslash ? path.replaceAll("\\", "/") : path;
+  if (hasEncodedSlash) {
+    normalized = normalized.replace(/%2f|%5c/gi, "/");
   }
   const segments = normalized.split("/");
   const resolved: string[] = [];
   for (const segment of segments) {
+    // Decode percent-encoded dots (%2e/%2E) to catch double-encoded traversal
     const normalizedSegment = segment.replace(/%2e/gi, ".");
     if (normalizedSegment === "..") {
       // Never pop past the root (first empty segment from leading slash)
@@ -55,5 +69,8 @@ export function resolveDotSegments(path: string, opts?: ResolveDotSegmentsOption
       resolved.push(segment);
     }
   }
-  return resolved.join("/") || "/";
+  const result = resolved.join("/") || "/";
+  // Decoded/normalized separators can prepend extra empty segments; collapse
+  // them so the result stays a single-rooted, non protocol-relative path.
+  return result[1] === "/" ? result.replace(/^\/+/, "/") : result;
 }

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -37,6 +37,14 @@ export interface ResolveDotSegmentsOptions {
  *
  * `%2f`/`%5c` (encoded path separators) are left untouched by default — see
  * {@link ResolveDotSegmentsOptions.decodeSlashes}.
+ *
+ * Only `.`/`..` resolution and the decodes above alter the string; every other
+ * percent-encoding (`%20`, non-ASCII, `%3A`, and any `%2e` not forming a whole
+ * segment) is left intact, so the result stays in the same representation as an
+ * un-decoded `event.url.pathname` and matches routes/rules consistently.
+ * Interior empty segments are preserved (`/a//b` stays `/a//b`, per WHATWG URL
+ * normalization) — only the leading slash is guaranteed single, so a consumer
+ * doing exact prefix matching should normalize its allowlist the same way.
  */
 export function resolveDotSegments(path: string, opts?: ResolveDotSegmentsOptions): string {
   // Normalize to a single leading slash (treating a leading `\` as a

--- a/src/utils/static.ts
+++ b/src/utils/static.ts
@@ -1,6 +1,6 @@
 import type { H3Event } from "../event.ts";
 import { HTTPError } from "../error.ts";
-import { withLeadingSlash, withoutTrailingSlash } from "./internal/path.ts";
+import { withoutTrailingSlash } from "./internal/path.ts";
 import { resolveDotSegments } from "./path.ts";
 import { getType, getExtension } from "./internal/mime.ts";
 import { HTTPResponse } from "../response.ts";
@@ -84,9 +84,7 @@ export async function serveStatic(
     throw new HTTPError({ status: 405 });
   }
 
-  const originalId = resolveDotSegments(
-    decodeURI(withLeadingSlash(withoutTrailingSlash(event.url.pathname))),
-  );
+  const originalId = resolveDotSegments(decodeURI(withoutTrailingSlash(event.url.pathname)));
 
   const acceptEncodings = parseAcceptEncoding(
     event.req.headers.get("accept-encoding") || "",

--- a/src/utils/static.ts
+++ b/src/utils/static.ts
@@ -1,6 +1,7 @@
 import type { H3Event } from "../event.ts";
 import { HTTPError } from "../error.ts";
-import { withLeadingSlash, withoutTrailingSlash, resolveDotSegments } from "./internal/path.ts";
+import { withLeadingSlash, withoutTrailingSlash } from "./internal/path.ts";
+import { resolveDotSegments } from "./path.ts";
 import { getType, getExtension } from "./internal/mime.ts";
 import { HTTPResponse } from "../response.ts";
 

--- a/src/utils/static.ts
+++ b/src/utils/static.ts
@@ -84,7 +84,14 @@ export async function serveStatic(
     throw new HTTPError({ status: 405 });
   }
 
-  const originalId = resolveDotSegments(decodeURI(withoutTrailingSlash(event.url.pathname)));
+  // `event.url.pathname` is already decoded once by the event layer
+  // (`decodePathname`, a single `decodeURI` that preserves `%25`) — the same
+  // value the rest of h3 routes on. Decoding again here would peel a second
+  // `%25` level, so serveStatic would resolve/serve a different id than was
+  // dispatched (e.g. a double-encoded separator collapsing to `%2f`).
+  // `resolveDotSegments` decodes nested-encoded dot segments itself, so no
+  // extra decode is needed for traversal safety.
+  const originalId = resolveDotSegments(withoutTrailingSlash(event.url.pathname));
 
   const acceptEncodings = parseAcceptEncoding(
     event.req.headers.get("accept-encoding") || "",

--- a/test/bench/path.ts
+++ b/test/bench/path.ts
@@ -4,35 +4,37 @@ import { resolveDotSegments } from "../../src/utils/path.ts";
 // Micro-benchmarks for `resolveDotSegments`, focused on the fast-path vs
 // slow-path overhead.
 //
-// Fairness: every fast/slow pair below is byte-for-byte the SAME length and
-// segment count, and differs only in the character(s) that flip the fast-path
-// guard — a `.`, a `%`, or a `\`. So each summary's relative multiplier is the
-// pure cost of taking the slow path (split → per-segment normalize → join)
-// relative to the early-return fast path, not a string-length or segment-count
-// artifact. The `fast:` case is the floor (guard scans + early return); results
-// are fed to `do_not_optimize` so nothing is eliminated as dead code.
+// The guard is boundary-aware: only a real `.`/`..` segment (literal or
+// `%2e`-encoded), a `\`, or — with `decodeSlashes` — an encoded separator takes
+// the slow path (split → per-segment normalize → join). Inputs that merely
+// contain a `.` (a dotted filename) or a non-dot `%` escape (`%20`) stay on the
+// fast early return. Results are fed to `do_not_optimize` so nothing is
+// eliminated as dead code.
 
+// --- Fast-path inputs: must all hit the early return unchanged ---
+// A dotted filename and `%`-escaped paths are here to prove the boundary-aware
+// guard keeps them cheap; before it, every `.`/`%2` dragged them onto the loop.
+const FAST_PATH = [
+  "/assets/app/f4a2b1c8/main.js", // dotted filename (segment-internal `.`)
+  "/media/photos/albums/tripxxx", // plain path (length-matched to the above)
+  "/search/foo%20bar%20/results1", // `%20` escapes, no dot segment
+  "/files/userx%2fdocs/report12", // opaque `%2f` (no decodeSlashes)
+  "/menu/caf%C3%A9/starters1234", // percent-encoded non-ASCII
+];
+
+// --- Slow-path pairs: genuine resolution work ---
+// Fairness: each `slow` is byte-for-byte the same length and segment count as
+// its `fast` twin, differing only in the char(s) that flip the guard (`.`/`%`/
+// `\`). So each multiplier is the pure slow-path cost, not a length artifact.
 interface Pair {
   label: string;
-  /** Fast-path input: hits the early return. */
   fast: string;
-  /** Slow-path input: same length/shape, one char class flipped. */
   slow: string;
-  /** Expected `resolveDotSegments(slow, opts)` output (correctness guard). */
   slowExpect: string;
   opts?: { decodeSlashes?: boolean };
 }
 
-// Each pair's `fast`/`slow` are equal length; the flipped chars are noted.
 const PAIRS: Pair[] = [
-  {
-    // The TODO(perf) case: a dotted asset filename has a `.` but no real dot
-    // segment, so it is pushed onto the slow path for nothing. `.` <-> `x`.
-    label: "dotted filename (no real segment)",
-    fast: "/assets/app/f4a2b1c8/mainxjs",
-    slow: "/assets/app/f4a2b1c8/main.js",
-    slowExpect: "/assets/app/f4a2b1c8/main.js",
-  },
   {
     // Literal `..` that actually resolves. `bb` <-> `..`.
     label: "literal .. traversal",
@@ -73,7 +75,24 @@ const PAIRS: Pair[] = [
   },
 ];
 
+// Realistic serveStatic-shaped inputs — absolute-cost reference. Most real
+// assets contain a segment-internal `.`, so this shows the boundary-aware guard
+// keeping them on the fast path while genuine traversal still resolves.
+const REALISTIC = [
+  "/index.html",
+  "/assets/app.4f3a2b1c.js",
+  "/assets/chunks/vendor.8e1d.css",
+  "/api/../secret",
+  "/images/logo.svg",
+];
+
 // --- Correctness + fairness guards (fail loud before benching) ---
+for (const p of FAST_PATH) {
+  const out = resolveDotSegments(p);
+  if (out !== p) {
+    throw new Error(`fast-path input took the slow path or changed: ${p} -> ${out}`);
+  }
+}
 for (const p of PAIRS) {
   if (p.fast.length !== p.slow.length) {
     throw new Error(`unfair pair "${p.label}": fast(${p.fast.length}) !== slow(${p.slow.length})`);
@@ -88,18 +107,15 @@ for (const p of PAIRS) {
   }
 }
 
-// Realistic serveStatic-shaped inputs — absolute-cost reference, not matched
-// pairs. Shows the mix a static server actually sees (most real assets contain
-// a `.`, so they currently take the slow path — see the TODO(perf)).
-const REALISTIC = [
-  "/index.html",
-  "/assets/app.4f3a2b1c.js",
-  "/assets/chunks/vendor.8e1d.css",
-  "/api/../secret",
-  "/images/logo.svg",
-];
-
 compact(() => {
+  // All fast-path inputs should land within a hair of each other (any spread is
+  // string length, not path selection) — the boundary-aware guard's payoff.
+  summary(() => {
+    for (const path of FAST_PATH) {
+      bench(`fast: ${path}`, () => do_not_optimize(resolveDotSegments(path))).gc("once");
+    }
+  });
+
   for (const p of PAIRS) {
     summary(() => {
       bench(`fast: ${p.label}`, () => do_not_optimize(resolveDotSegments(p.fast, p.opts))).gc(

--- a/test/bench/path.ts
+++ b/test/bench/path.ts
@@ -1,0 +1,121 @@
+import { bench, summary, compact, do_not_optimize, run } from "mitata";
+import { resolveDotSegments } from "../../src/utils/path.ts";
+
+// Micro-benchmarks for `resolveDotSegments`, focused on the fast-path vs
+// slow-path overhead.
+//
+// Fairness: every fast/slow pair below is byte-for-byte the SAME length and
+// segment count, and differs only in the character(s) that flip the fast-path
+// guard — a `.`, a `%`, or a `\`. So each summary's relative multiplier is the
+// pure cost of taking the slow path (split → per-segment normalize → join)
+// relative to the early-return fast path, not a string-length or segment-count
+// artifact. The `fast:` case is the floor (guard scans + early return); results
+// are fed to `do_not_optimize` so nothing is eliminated as dead code.
+
+interface Pair {
+  label: string;
+  /** Fast-path input: hits the early return. */
+  fast: string;
+  /** Slow-path input: same length/shape, one char class flipped. */
+  slow: string;
+  /** Expected `resolveDotSegments(slow, opts)` output (correctness guard). */
+  slowExpect: string;
+  opts?: { decodeSlashes?: boolean };
+}
+
+// Each pair's `fast`/`slow` are equal length; the flipped chars are noted.
+const PAIRS: Pair[] = [
+  {
+    // The TODO(perf) case: a dotted asset filename has a `.` but no real dot
+    // segment, so it is pushed onto the slow path for nothing. `.` <-> `x`.
+    label: "dotted filename (no real segment)",
+    fast: "/assets/app/f4a2b1c8/mainxjs",
+    slow: "/assets/app/f4a2b1c8/main.js",
+    slowExpect: "/assets/app/f4a2b1c8/main.js",
+  },
+  {
+    // Literal `..` that actually resolves. `bb` <-> `..`.
+    label: "literal .. traversal",
+    fast: "/x/aa/bb/cc/dd/ee/ff",
+    slow: "/x/aa/../cc/dd/ee/ff",
+    slowExpect: "/x/cc/dd/ee/ff",
+  },
+  {
+    // Percent-encoded dot segment. `xxxxxx` <-> `%2e%2e`.
+    label: "encoded %2e%2e traversal",
+    fast: "/x/aa/xxxxxx/cc/dd/ee",
+    slow: "/x/aa/%2e%2e/cc/dd/ee",
+    slowExpect: "/x/cc/dd/ee",
+  },
+  {
+    // Backslash normalization. `/` <-> `\` after the root.
+    label: "backslash normalization",
+    fast: "/a/b/c/d/e/f/g",
+    slow: "/a\\b\\c\\d\\e\\f\\g",
+    slowExpect: "/a/b/c/d/e/f/g",
+  },
+  {
+    // Opt-in encoded separator. `userxxxprofile` <-> `user%2fprofile`.
+    label: "decodeSlashes: single %2f",
+    fast: "/x/aa/userxxxprofile/cc",
+    slow: "/x/aa/user%2fprofile/cc",
+    slowExpect: "/x/aa/user/profile/cc",
+    opts: { decodeSlashes: true },
+  },
+  {
+    // Nested encoded separator (the multi-decode hardening).
+    // `userxxxxxprofile` <-> `user%252fprofile`.
+    label: "decodeSlashes: nested %252f",
+    fast: "/x/aa/userxxxxxprofile/cc",
+    slow: "/x/aa/user%252fprofile/cc",
+    slowExpect: "/x/aa/user/profile/cc",
+    opts: { decodeSlashes: true },
+  },
+];
+
+// --- Correctness + fairness guards (fail loud before benching) ---
+for (const p of PAIRS) {
+  if (p.fast.length !== p.slow.length) {
+    throw new Error(`unfair pair "${p.label}": fast(${p.fast.length}) !== slow(${p.slow.length})`);
+  }
+  const fastOut = resolveDotSegments(p.fast, p.opts);
+  if (fastOut !== p.fast) {
+    throw new Error(`"${p.label}" fast input is not on the fast path: ${p.fast} -> ${fastOut}`);
+  }
+  const slowOut = resolveDotSegments(p.slow, p.opts);
+  if (slowOut !== p.slowExpect) {
+    throw new Error(`"${p.label}" slow output ${slowOut} !== expected ${p.slowExpect}`);
+  }
+}
+
+// Realistic serveStatic-shaped inputs — absolute-cost reference, not matched
+// pairs. Shows the mix a static server actually sees (most real assets contain
+// a `.`, so they currently take the slow path — see the TODO(perf)).
+const REALISTIC = [
+  "/index.html",
+  "/assets/app.4f3a2b1c.js",
+  "/assets/chunks/vendor.8e1d.css",
+  "/api/../secret",
+  "/images/logo.svg",
+];
+
+compact(() => {
+  for (const p of PAIRS) {
+    summary(() => {
+      bench(`fast: ${p.label}`, () => do_not_optimize(resolveDotSegments(p.fast, p.opts))).gc(
+        "once",
+      );
+      bench(`slow: ${p.label}`, () => do_not_optimize(resolveDotSegments(p.slow, p.opts))).gc(
+        "once",
+      );
+    });
+  }
+
+  summary(() => {
+    for (const path of REALISTIC) {
+      bench(`realistic: ${path}`, () => do_not_optimize(resolveDotSegments(path))).gc("once");
+    }
+  });
+});
+
+await run({ throw: true });

--- a/test/static.test.ts
+++ b/test/static.test.ts
@@ -163,6 +163,20 @@ describeMatrix("serve static", (t, { it, expect }) => {
     expect(text).not.toContain("%2E%2E");
   });
 
+  it("does not decode the pathname a second time", async () => {
+    // The event layer already applied the one canonical decode (preserving
+    // `%25`), so a double-encoded separator stays opaque and must reach the
+    // backend as the same id h3 routes on — not the twice-decoded `%2f`.
+    const res = await t.fetch("/files/a%252fb");
+    expect(res.status).toEqual(200);
+    // A trailing encoding suffix (e.g. `.gz`) may be appended by the
+    // accept-encoding search, so match the distinguishing part loosely:
+    // the id keeps the single-decoded `%252f`, not the twice-decoded `%2f`.
+    const text = await res.text();
+    expect(text).toContain("a%252fb");
+    expect(text).not.toContain("a%2fb");
+  });
+
   it("allows legitimate paths with dots", async () => {
     const allowed = [
       "/_...grid_123.js",

--- a/test/unit/package.test.ts
+++ b/test/unit/package.test.ts
@@ -111,6 +111,7 @@ describe("h3 package", () => {
         "requestWithBaseURL",
         "requestWithURL",
         "requireBasicAuth",
+        "resolveDotSegments",
         "sanitizeStatusCode",
         "sanitizeStatusMessage",
         "sealSession",

--- a/test/unit/path.test.ts
+++ b/test/unit/path.test.ts
@@ -89,7 +89,19 @@ describe("resolveDotSegments", () => {
     );
   });
 
-  it("leaves double-encoded separators intact (single decode level)", () => {
-    expect(resolveDotSegments("/a/%252f../b", { decodeSlashes: true })).toBe("/a/%252f../b");
+  it("decodes nested %25-encoded separators at any depth", () => {
+    expect(resolveDotSegments("/a/%252f../b", { decodeSlashes: true })).toBe("/a/b");
+    expect(resolveDotSegments("/allowed/..%252f..%252fadmin", { decodeSlashes: true })).toBe(
+      "/admin",
+    );
+    expect(resolveDotSegments("/a%25252fb", { decodeSlashes: true })).toBe("/a/b");
+    expect(resolveDotSegments("/a%255cb", { decodeSlashes: true })).toBe("/a/b");
+    // Still opaque without the opt-in
+    expect(resolveDotSegments("/a/%252fb")).toBe("/a/%252fb");
+  });
+
+  it("catches nested %25-encoded dot segments", () => {
+    expect(resolveDotSegments("/api/orders/%252e%252e/admin")).toBe("/api/admin");
+    expect(resolveDotSegments("/a/%25252e%25252e/b")).toBe("/b");
   });
 });

--- a/test/unit/path.test.ts
+++ b/test/unit/path.test.ts
@@ -59,4 +59,37 @@ describe("resolveDotSegments", () => {
     expect(resolveDotSegments("/caf%C3%A9/x")).toBe("/caf%C3%A9/x");
     expect(resolveDotSegments("/a%3Ab")).toBe("/a%3Ab");
   });
+
+  it("normalizes backslashes even without a dot segment", () => {
+    // The `\`->`/` normalization must not be skipped by the fast path.
+    expect(resolveDotSegments("/admin\\panel")).toBe("/admin/panel");
+    expect(resolveDotSegments("/a\\b")).toBe("/a/b");
+  });
+
+  it("roots relative inputs so `..` can never escape", () => {
+    expect(resolveDotSegments("a/../b")).toBe("/b");
+    expect(resolveDotSegments("a/../../b")).toBe("/b");
+    expect(resolveDotSegments("assets/app.js")).toBe("/assets/app.js");
+  });
+
+  it("returns the root consistently for empty/consumed inputs", () => {
+    expect(resolveDotSegments("")).toBe("/");
+    expect(resolveDotSegments(".")).toBe("/");
+    expect(resolveDotSegments("a/..")).toBe("/");
+  });
+
+  it("never yields a protocol-relative path", () => {
+    // Multiple leading slashes (literal, backslash, or decoded) collapse to one
+    // so the result can't be used as a `//host` open-redirect/SSRF target.
+    expect(resolveDotSegments("//evil.com")).toBe("/evil.com");
+    expect(resolveDotSegments("/\\evil.com")).toBe("/evil.com");
+    expect(resolveDotSegments("/%2fevil.com", { decodeSlashes: true })).toBe("/evil.com");
+    expect(resolveDotSegments("/app/..%2f..%2f%2fevil.com/steal", { decodeSlashes: true })).toBe(
+      "/evil.com/steal",
+    );
+  });
+
+  it("leaves double-encoded separators intact (single decode level)", () => {
+    expect(resolveDotSegments("/a/%252f../b", { decodeSlashes: true })).toBe("/a/%252f../b");
+  });
 });

--- a/test/unit/path.test.ts
+++ b/test/unit/path.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { resolveDotSegments } from "../../src/utils/path.ts";
+
+describe("resolveDotSegments", () => {
+  it("leaves a plain path untouched", () => {
+    expect(resolveDotSegments("/app/admin/panel")).toBe("/app/admin/panel");
+  });
+
+  it("resolves literal dot segments", () => {
+    expect(resolveDotSegments("/a/./b")).toBe("/a/b");
+    expect(resolveDotSegments("/a/b/../c")).toBe("/a/c");
+  });
+
+  it("never escapes above the root", () => {
+    expect(resolveDotSegments("/a/../../b")).toBe("/b");
+    expect(resolveDotSegments("/../../etc/passwd")).toBe("/etc/passwd");
+  });
+
+  it("decodes percent-encoded dot segments", () => {
+    expect(resolveDotSegments("/api/orders/%2e%2e/admin")).toBe("/api/admin");
+    expect(resolveDotSegments("/api/orders/%2E%2E/admin")).toBe("/api/admin");
+  });
+
+  it("normalizes backslashes to forward slashes", () => {
+    expect(resolveDotSegments("/a\\..\\b")).toBe("/b");
+  });
+
+  it("keeps encoded path separators opaque by default", () => {
+    // %2f/%5c must not be treated as `/` unless explicitly opted in — decoding
+    // them here would change segment count, i.e. which route matches.
+    expect(resolveDotSegments("/admin%2f..%2fsecret")).toBe("/admin%2f..%2fsecret");
+    expect(resolveDotSegments("/files/a%2fb")).toBe("/files/a%2fb");
+  });
+
+  it("decodes encoded path separators when decodeSlashes is enabled", () => {
+    expect(resolveDotSegments("/app/admin%2fpanel", { decodeSlashes: true })).toBe(
+      "/app/admin/panel",
+    );
+    expect(resolveDotSegments("/app/admin%2Fpanel", { decodeSlashes: true })).toBe(
+      "/app/admin/panel",
+    );
+    expect(resolveDotSegments("/app/admin%5cpanel", { decodeSlashes: true })).toBe(
+      "/app/admin/panel",
+    );
+  });
+
+  it("resolves traversal revealed by decoding separators", () => {
+    expect(resolveDotSegments("/api/orders/..%2fadmin", { decodeSlashes: true })).toBe(
+      "/api/admin",
+    );
+  });
+
+  it("keeps a dotted filename on the fast path", () => {
+    expect(resolveDotSegments("/assets/app.1a2b.js")).toBe("/assets/app.1a2b.js");
+  });
+
+  it("keeps non-separator, non-dot encodings untouched", () => {
+    expect(resolveDotSegments("/foo%20bar")).toBe("/foo%20bar");
+    expect(resolveDotSegments("/caf%C3%A9/x")).toBe("/caf%C3%A9/x");
+    expect(resolveDotSegments("/a%3Ab")).toBe("/a%3Ab");
+  });
+});


### PR DESCRIPTION
## Summary
- Moves `resolveDotSegments` out of `src/utils/internal/path.ts` into a new public `src/utils/path.ts`, exported from `src/index.ts` (`serveStatic` already used it internally to resolve `.`/`..` and encoded dot segments before touching disk).
- Adds an opt-in `decodeSlashes` option that also collapses encoded path separators into real `/` boundaries — off by default, since decoding a path separator changes segment count and therefore which route matches, not just security scope.
- Decoding of the three path-special escapes (`%2e`, `%2f`, `%5c`) is **pessimistic**: nested `%25`-encodings (`%252f`, `%25252f`, …) collapse too, so a downstream that decodes any number of times cannot smuggle a separator or dot segment past a scope check. All other escapes (`%20`, `%C3%A9`, …) are never decoded.
- `serveStatic` behavior is unchanged for normal request paths; a few hostile/edge inputs are now hardened (in the fail-closed direction) and can produce a different computed asset id: backslash-only paths (`/a\b` → `/a/b`), extra leading separators (`//foo` → `/foo`), and multi-encoded dot segments now resolve as traversal instead of passing through opaquely. Also drops a now-redundant `withLeadingSlash` wrapper in `serveStatic`.

## Why
Downstream tools that do their own prefix/scope matching against `event.url.pathname` (e.g. nitro's route-rules, which independently matches rules like `/secure/**` against a path and needs to guard against an encoded separator like `%2f` bypassing a narrower rule that a downstream proxy target/redirect would later decode) need the exact same `.`/`..` resolution + encoded-dot-segment handling h3 already has and battle-tested for `serveStatic`. There was previously no way to reuse it since it lived under `utils/internal/`, so nitro had to reimplement the same tricky, security-sensitive logic from scratch (nitrojs/nitro#4396). This exports the single hardened implementation so it can be reused directly instead of re-derived per consumer.

`%2f` decoding stays opt-in and separate from routing/dispatch: it must never be baked into `event.url.pathname` globally, since some apps intentionally rely on `%2F` to keep an id containing a literal slash as one opaque path segment (e.g. `/files/:id`). The `decodeSlashes` option lets a caller ask for the "canonical path a downstream will eventually see" purely for an out-of-band scope check, without affecting what h3 itself routes on.

Nested `%25`-encodings are collapsed (rather than decoding strictly once) because a strict single-level decode makes the scope-check use case unsound: `/allowed/..%252f..%252fadmin` would look safely under `/allowed` while a downstream that decodes twice sees `/admin`. Since `decodeSlashes` exists precisely to anticipate downstream decodes, the resolver handles arbitrary decode depth itself instead of pushing a fixpoint loop onto every security-sensitive caller.

## Test plan
- [x] `pnpm test` — full suite (lint + typecheck + coverage) passes, `src/utils/path.ts` at 100% coverage
- [x] `test/unit/path.test.ts` covers: plain paths, literal `.`/`..`, root-clamping, `%2e` decoding, backslash normalization, default opaque `%2f`/`%5c`, the `decodeSlashes` option (including traversal revealed only after decoding separators), and nested `%25`-encoded separators/dots at multiple depths
- [x] Updated `test/unit/package.test.ts` export snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new public path utility `resolveDotSegments` to safely normalize `.`/`..`, normalize backslashes, and decode percent-encoded dot segments.
  * Added `decodeSlashes` option to also decode percent-encoded path separators when needed.
* **Bug Fixes**
  * Improved static file URL handling by resolving dot segments after URL decoding, preventing traversal above `/` and avoiding protocol-relative outputs.
* **Documentation**
  * Documented `resolveDotSegments` and `decodeSlashes` in the security utilities guide.
* **Tests**
  * Expanded unit tests for normalization, encoded edge cases, and clamping/traversal hardening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->