### PR TITLE
fix(adapters): sync raw node req.url with event.url in fromNodeHandler

### DIFF
--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -48,14 +48,21 @@ export function fromNodeHandler(handler: NodeHandler | NodeMiddleware): EventHan
     throw new TypeError(`Invalid handler. It should be a function: ${handler}`);
   }
   return function _nodeHandler(event) {
-    if (!event.runtime?.node?.res) {
+    const node = event.runtime?.node;
+    if (!node?.res) {
       throw new Error("[h3] Executing Node.js middleware is not supported in this server!");
     }
-    return callNodeHandler(
-      handler,
-      event.runtime?.node.req,
-      event.runtime?.node.res,
-    ) as EventHandlerResponse;
+    // Legacy handlers route on the raw req.url — sync it with the h3 view so
+    // rewrites (withBase/mount) and pathname normalization propagate (#1432)
+    const url = event.url.pathname + event.url.search;
+    if (node.req.url === url) {
+      return callNodeHandler(handler, node.req, node.res) as EventHandlerResponse;
+    }
+    const originalUrl = node.req.url;
+    node.req.url = url;
+    return (callNodeHandler(handler, node.req, node.res) as Promise<unknown>).finally(() => {
+      node.req.url = originalUrl;
+    }) as EventHandlerResponse;
   };
 }
 

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -1,6 +1,7 @@
 import { vi } from "vitest";
 import { Readable as NodeStreamReadable, Transform as NodeStreamTransoform } from "node:stream";
 import { fromNodeHandler } from "../src/adapters.ts";
+import { withBase } from "../src/utils/base.ts";
 import { HTTPError } from "../src/error.ts";
 import { onResponse } from "../src/utils/middleware.ts";
 import { describeMatrix } from "./_setup.ts";
@@ -298,6 +299,31 @@ describeMatrix("app", (t, { it, expect }) => {
     );
     const res = await t.fetch("/");
     expect(await res.json()).toEqual({ works: 1 });
+  });
+
+  it.skipIf(t.target !== "node")("fromNodeHandler syncs raw req.url with the h3 view", async () => {
+    let rawUrlAfter: string | undefined;
+    t.app.config.onResponse = (_res, event) => {
+      rawUrlAfter = event.runtime?.node?.req?.url;
+    };
+    t.app.use(
+      "/api/**",
+      withBase(
+        "/api",
+        fromNodeHandler((req, res) => {
+          res.end(req.url || "");
+        }),
+      ),
+    );
+
+    // Legacy handler must see the base-stripped path in raw req.url
+    expect(await t.fetch("/api/hello?q=1").then((r) => r.text())).toBe("/hello?q=1");
+
+    // Rewrites must propagate even when the pathname needed percent-decode
+    // normalization (event.url is a clone detached from the shared _url)
+    expect(await t.fetch("/api/h%65llo").then((r) => r.text())).toBe("/hello");
+    // ...and the raw url is restored once the handler settles
+    expect(rawUrlAfter).toBe("/api/h%65llo");
   });
 
   it.skipIf(t.target !== "node")("fromNodeHandler + piping", async () => {


### PR DESCRIPTION
## Context

Follow-up to #1432 (percent-decode normalization no longer mutates the shared `_url`, fixed in a1cf066).

Legacy Node handlers invoked via `fromNodeHandler` route on the **raw** `req.url`. Until now, h3-level URL rewrites (`withBase`, `mount`) only reached that raw request through srvx's implicit `NodeRequestURL` pathname write-back (srvx#118) — mutation-at-a-distance through the shared parsed URL object.

That channel is now half-dead: since a1cf066, requests whose pathname needs percent-decode normalization get a detached `event.url` clone, so `withBase` mutations never reach the shared `NodeRequestURL`, and legacy handlers saw the original un-stripped URL for such requests (e.g. `withBase("/api", fromNodeHandler(m))` handed `m` a `req.url` of `/api/h%65llo` instead of `/hello`).

## Change

Make the propagation explicit at the adapter boundary instead of relying on the shared-object side effect:

- `fromNodeHandler` computes h3's view (`event.url.pathname + event.url.search`); if it differs from the raw `req.url`, it swaps it in before calling the legacy handler and restores the original once the handler settles.
- When the views already match (no rewrite, no decode — the common case), the raw request is never touched.

Behavior for legacy middleware is unchanged vs. the pre-#1432 node behavior (they already received the decoded pathname, since the constructor write-back fired before any handler ran) — except it now also works for percent-encoded paths, which the implicit channel never covered after the clone fix.

This also unblocks srvx dropping the implicit write-back from srvx#118: h3 no longer depends on it, so the raw `IncomingMessage.url` can stay pristine wire data for every other consumer.

## Tests

New node-target regression test: `withBase("/api", fromNodeHandler(...))` echoing `req.url`:

- `/api/hello?q=1` → legacy handler sees `/hello?q=1`
- `/api/h%65llo` → legacy handler sees `/hello` (failed before this change)
- raw `req.url` is restored to `/api/h%65llo` after the handler settles (asserted via `onResponse`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for legacy Node.js handlers so they now see the same normalized URL as the app route.
  * Preserved the original request URL after handling, reducing the risk of affecting later routing or response behavior.
  * Added coverage for base-path stripping, URL rewrites, and percent-decoding behavior to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->