### PR TITLE
fix: support plain object request headers

### DIFF
--- a/src/_deprecated.ts
+++ b/src/_deprecated.ts
@@ -54,7 +54,10 @@ export const getHeader: (event: H3Event, name: string) => string | undefined = g
 
 /** @deprecated Please use `Object.fromEntries(event.req.headers.entries())` */
 export function getRequestHeaders(event: H3Event): Record<string, string> {
-  return Object.fromEntries(event.req.headers.entries());
+  const { headers } = event.req;
+  return Object.fromEntries(
+    typeof headers.entries === "function" ? headers.entries() : Object.entries(headers),
+  );
 }
 
 /** @deprecated Please use `Object.fromEntries(event.req.headers.entries())` */

--- a/test/unit/request.test.ts
+++ b/test/unit/request.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { requestWithURL, requestWithBaseURL } from "../../src/utils/request.ts";
-import { getRequestProtocol } from "../../src/index.ts";
+import { getRequestHeaders, getRequestProtocol } from "../../src/index.ts";
 
 // Minimal fake HTTPEvent for unit-testing getRequestProtocol without a live server
 function makeEvent(headers: Record<string, string>, url = "http://localhost/test") {
@@ -87,6 +87,13 @@ describe("requestWithBaseURL", () => {
   it("is instanceof Request", () => {
     const proxied = requestWithBaseURL(original, "/base");
     expect(proxied instanceof Request).toBe(true);
+  });
+});
+
+describe("getRequestHeaders", () => {
+  it("supports plain object request headers", () => {
+    const event = { req: { headers: { "x-test": "works" } } } as any;
+    expect(getRequestHeaders(event)).toEqual({ "x-test": "works" });
   });
 });
 


### PR DESCRIPTION
Keeps deprecated `getRequestHeaders()` tolerant of plain object header bags while preserving the normal `Headers.entries()` path. This does not change the primary h3 request-header contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request header handling so headers are read more reliably across different request shapes.
  * Added a safer fallback when header entries aren’t available, reducing errors in edge cases.

* **Tests**
  * Added coverage for header extraction from plain request objects to verify consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
