### PR TITLE
docs: fix typos in response and handler guides

### DIFF
--- a/docs/1.guide/1.basics/4.handler.md
+++ b/docs/1.guide/1.basics/4.handler.md
@@ -135,7 +135,7 @@ export const app = new H3();
 
 const webHandler = (request) => new Response("👋 Hello!");
 
-// Using fromWebHandler utiliy
+// Using fromWebHandler utility
 app.all("/web", fromWebHandler(webHandler));
 
 // Using simple wrapper

--- a/docs/1.guide/1.basics/5.response.md
+++ b/docs/1.guide/1.basics/5.response.md
@@ -48,7 +48,7 @@ defineHandler((event) => {
 ```
 
 > [!NOTE]
-> If a full [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response/Response) value is returned, prepared status is discarded and headers will be merged/overriden. For performance reasons, it is best to only set headers only from final Response in this case.
+> If a full [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response/Response) value is returned, prepared status is discarded and headers will be merged/overridden. For performance reasons, it is best to only set headers only from final Response in this case.
 
 > [!NOTE]
 > If an Error happens, prepared status and headers will be discarded. The recommended way to include headers in error responses is via `new HTTPError({ headers })`. As a last resort for headers that need to be set implicitly before the error is known (e.g., CORS), you can use `event.res.errHeaders` — these will be merged into error responses automatically.
@@ -96,7 +96,7 @@ app.get("/", () => html("<h1>hello world</h1>"));
 
 ### `Response`
 
-Returning a web [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response/Response), sends-it as final reponse.
+Returning a web [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response/Response), sends-it as final response.
 
 **Example:**
 


### PR DESCRIPTION
Fixes three spelling typos in the documentation prose/comments.

| File | Before | After |
| --- | --- | --- |
| `docs/1.guide/1.basics/4.handler.md` | `utiliy` | `utility` |
| `docs/1.guide/1.basics/5.response.md` | `overriden` | `overridden` |
| `docs/1.guide/1.basics/5.response.md` | `reponse` | `response` |

Documentation only; no code or behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected several spelling and grammar issues in the developer guide.
  * Clarified guidance around returning a final web `Response` and how prepared status/headers are handled.
  * Fixed example text in handler documentation for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->