### PR TITLE
feat: add QUERY method (core support)

### DIFF
--- a/src/h3.ts
+++ b/src/h3.ts
@@ -227,7 +227,7 @@ export const H3 = /* @__PURE__ */ (() => {
   }
 
   // prettier-ignore
-  for (const method of ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "CONNECT", "TRACE"] as const) {
+  for (const method of ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "CONNECT", "TRACE", "QUERY"] as const) {
     (H3Core as any).prototype[method.toLowerCase()] = function (
       this: H3Type,
       route: string,

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -22,7 +22,7 @@ export type MatchedRoute<T = any> = {
 
 // https://www.rfc-editor.org/rfc/rfc7231#section-4.1
 // prettier-ignore
-export type HTTPMethod =  "GET" | "HEAD" | "PATCH" | "POST" | "PUT" | "DELETE" | "CONNECT" | "OPTIONS" | "TRACE";
+export type HTTPMethod =  "GET" | "HEAD" | "PATCH" | "POST" | "PUT" | "DELETE" | "CONNECT" | "OPTIONS" | "TRACE" | "QUERY";
 
 export interface H3Config {
   /**
@@ -184,4 +184,5 @@ export declare class H3 extends H3Core {
   options(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
   connect(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
   trace(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
+  query(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
 }

--- a/src/utils/internal/proxy.ts
+++ b/src/utils/internal/proxy.ts
@@ -1,4 +1,4 @@
-export const PayloadMethods: Set<string> = new Set(["PATCH", "POST", "PUT", "DELETE"]);
+export const PayloadMethods: Set<string> = new Set(["PATCH", "POST", "PUT", "DELETE", "QUERY"]);
 
 export const ignoredHeaders: Set<string> = new Set([
   "transfer-encoding",

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -18,8 +18,8 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log(`Bundle size (H3): ${bundle.bytes} (gzip: ${bundle.gzipSize})`);
     }
-    expect(bundle.bytes).toBeLessThanOrEqual(17_000); // <17kb
-    expect(bundle.gzipSize).toBeLessThanOrEqual(6_500); // <6.5kb
+    expect(bundle.bytes).toBeLessThanOrEqual(17_200); // <17.2kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(6_600); // <6.6kb
   });
 
   it("bundle size (H3Core)", async () => {

--- a/test/body.test.ts
+++ b/test/body.test.ts
@@ -119,6 +119,22 @@ describeMatrix("body", (t, { it, expect, describe }) => {
     expect(await result.text()).toBe("200");
   });
 
+  it("can parse query method json payload", async () => {
+    t.app.query("/api/query", async (event) => {
+      const body = await readBody(event);
+      expect(body).toMatchObject({ query: true });
+      return "200";
+    });
+
+    const result = await t.fetch("/api/query", {
+      method: "QUERY",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query: true }),
+    });
+
+    expect(await result.text()).toBe("200");
+  });
+
   it("handles non-present body", async () => {
     let _body: string | undefined;
     t.app.all("/api/test", async (event) => {

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -69,6 +69,34 @@ describeMatrix("proxy", (t, { it, expect, describe }) => {
         `);
       });
 
+      it("can proxy query request body", async () => {
+        t.app.all("/debug", async (event) => {
+          return {
+            method: event.req.method,
+            body: await event.req.text(),
+          };
+        });
+
+        t.app.all("/", (event) => {
+          return proxyRequest(event, "/debug");
+        });
+
+        const result = await t
+          .fetch("/", {
+            method: "QUERY",
+            body: "query body",
+            headers: {
+              "content-type": "text/plain",
+            },
+          })
+          .then((r) => r.json());
+
+        expect(result).toMatchObject({
+          method: "QUERY",
+          body: "query body",
+        });
+      });
+
       it("does not forward incoming accept-encoding header", async () => {
         t.app.all("/debug", (event) => {
           return { headers: Object.fromEntries(event.req.headers.entries()) };

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -35,6 +35,17 @@ describeMatrix("router", (t, { it, expect, describe }) => {
     const res2 = await t.fetch("/test", { method: "POST" });
     expect(await res2.text()).toEqual("Test (POST)");
   });
+
+  it("Handle query method", async () => {
+    t.app.get("/query", () => "Test (GET)").query("/query", () => "Test (QUERY)");
+
+    const getRes = await t.fetch("/query");
+    expect(await getRes.text()).toEqual("Test (GET)");
+
+    const queryRes = await t.fetch("/query", { method: "QUERY" });
+    expect(await queryRes.text()).toEqual("Test (QUERY)");
+  });
+
   it("Handle url with query parameters", async () => {
     const res = await t.fetch("/test?title=test");
     expect(res.status).toEqual(200);

--- a/test/unit/body-limit.test.ts
+++ b/test/unit/body-limit.test.ts
@@ -24,6 +24,18 @@ describe("body limit (unit)", () => {
       await expect(assertBodySize(eventMock, BODY.length - 2)).rejects.toThrow(HTTPError);
     });
 
+    it("query method body", async () => {
+      const BODY = "a query request body";
+
+      const eventMock = mockEvent("/", {
+        method: "QUERY",
+        body: BODY,
+      });
+
+      await expect(assertBodySize(eventMock, BODY.length)).resolves.toBeUndefined();
+      await expect(assertBodySize(eventMock, BODY.length - 2)).rejects.toThrow(HTTPError);
+    });
+
     it("streaming body", async () => {
       const BODY_PARTS = ["parts", "of", "the", "body", "that", "are", "streamed", "in"];
 


### PR DESCRIPTION
### Summary

Adds first-class support for the HTTP `QUERY` method from RFC 10008. #1441.

### Changes

- add `QUERY` to the `HTTPMethod` type
- generate `app.query(route, handler, opts)` alongside the existing method helpers
- preserve `QUERY` request bodies when using `proxyRequest()`
- add focused routing, body parsing, body limit, and proxy regression tests
- adjust the H3 bundle-size guard for the added public method helper

### Non-goals

This keeps the first PR small and does not add `Accept-Query` utilities or opt-in content-type validation helpers. Those can be follow-up PRs if wanted.

### Tests

- `corepack pnpm vitest run test/router.test.ts test/body.test.ts test/proxy.test.ts test/unit/body-limit.test.ts`
- `corepack pnpm lint`
- `corepack pnpm vitest run test/router.test.ts test/body.test.ts test/proxy.test.ts test/unit/body-limit.test.ts test/bench/bundle.test.ts`
- `corepack pnpm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new `QUERY` request method, including a matching route handler helper.
  * Requests using this method can now carry and process bodies consistently with other supported methods.

* **Tests**
  * Added coverage for routing, body parsing, proxying, and request size limits with `QUERY` requests.
  * Tightened bundle size checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->