### PR TITLE
docs: add `QUERY` method docs

### DIFF
--- a/docs/1.guide/1.basics/2.routing.md
+++ b/docs/1.guide/1.basics/2.routing.md
@@ -67,6 +67,10 @@ Two utilities help implement the RFC:
 > [!NOTE]
 > `QUERY` is treated like `GET` for [conditional caching](/utils/request#handlecacheheadersevent-opts) (`304` responses via `handleCacheHeaders`), and [`proxy`](/utils/proxy) forwards it **with** its body. Unlike `GET`, `QUERY` is **not** CORS-safelisted, so browsers send a preflight — if you pass an explicit `methods` allowlist to [`handleCors`](/utils/security#handlecorsevent-options), include `"QUERY"`.
 
+::read-more{to="/examples/handle-query"}
+See the [HTTP `QUERY` method example](/examples/handle-query) for a runnable `/books` resource that validates the `Content-Type` and advertises a cacheable `GET` alternative.
+::
+
 ## Dynamic Routes
 
 You can define dynamic route parameters using `:` prefix:

--- a/docs/1.guide/1.basics/2.routing.md
+++ b/docs/1.guide/1.basics/2.routing.md
@@ -42,6 +42,31 @@ You can also use [`H3.all`](/guide/api/h3#h3all) method to register a route acce
 app.all("/hello", (event) => `This is a ${event.req.method} request!`);
 ```
 
+## HTTP `QUERY` Method
+
+H3 supports the [HTTP `QUERY` method (RFC 10008)](https://www.rfc-editor.org/rfc/rfc10008) as a first-class method. `QUERY` is like `GET` — **safe, idempotent, and cacheable** — but carries a request body (with a `Content-Type`), closing the long-standing "GET with a body" gap. It's ideal for complex read operations where filters don't fit in a URL.
+
+Register a `QUERY` handler with `app.query()` (or `app.on("QUERY", …)`) and read the request body as usual:
+
+```js
+import { readBody } from "h3";
+
+app.query("/search", async (event) => {
+  const criteria = await readBody(event); // read the query body
+  return runSearch(criteria);
+});
+```
+
+Because `QUERY` carries an attacker-controllable body, [body-size limits](/utils/request#assertbodysizeevent-limit) apply just like `POST`.
+
+Two utilities help implement the RFC:
+
+- [`requireContentType(event, acceptedTypes)`](/utils/request#requirecontenttypeevent-acceptedtypes) — assert the request `Content-Type` (`400`/`415`/`422`).
+- [`appendAcceptQuery(event, mediaTypes)`](/utils/request#appendacceptqueryevent-mediatypes) — advertise accepted query formats via the `Accept-Query` response header.
+
+> [!NOTE]
+> `QUERY` is treated like `GET` for [conditional caching](/utils/request#handlecacheheadersevent-opts) (`304` responses via `handleCacheHeaders`), and [`proxy`](/utils/proxy) forwards it **with** its body. Unlike `GET`, `QUERY` is **not** CORS-safelisted, so browsers send a preflight — if you pass an explicit `methods` allowlist to [`handleCors`](/utils/security#handlecorsevent-options), include `"QUERY"`.
+
 ## Dynamic Routes
 
 You can define dynamic route parameters using `:` prefix:

--- a/docs/4.examples/0.index.md
+++ b/docs/4.examples/0.index.md
@@ -13,6 +13,7 @@ Check [`examples/` dir](https://github.com/h3js/h3/tree/main/examples) for more 
 **Examples:**
 
 - [Cookies](/examples/handle-cookie)
+- [HTTP QUERY Method](/examples/handle-query)
 - [Session](/examples/handle-session)
 - [Static Assets](/examples/serve-static-assets)
 - [Streaming Response](/examples/stream-response)

--- a/docs/4.examples/handle-query.md
+++ b/docs/4.examples/handle-query.md
@@ -1,0 +1,79 @@
+---
+icon: ph:arrow-right
+---
+
+# HTTP `QUERY` Method
+
+> Accept safe, cacheable requests that carry a query in the body.
+
+The [HTTP `QUERY` method (RFC 10008)](https://www.rfc-editor.org/rfc/rfc10008) is like `GET` — **safe, idempotent, and cacheable** — but carries a query in the request **body** with a `Content-Type`. It's the standard answer to "I need a GET, but my query is too large or too structured for the URL".
+
+H3 supports `QUERY` as a first-class method via [`app.query()`](/guide/basics/routing#http-query-method), plus two helper utilities.
+
+## Register a `QUERY` Handler
+
+Read the request body just like you would for a `POST`:
+
+```ts
+import { readBody } from "h3";
+
+app.query("/books", async (event) => {
+  const query = await readBody(event, { type: "text" });
+  return runSearch(query);
+});
+```
+
+Because `QUERY` carries an attacker-controllable body, [body-size limits](/utils/request#assertbodysizeevent-limit) apply just like `POST`.
+
+## Advertise Accepted Formats
+
+Use [`appendAcceptQuery`](/utils/request#appendacceptqueryevent-mediatypes) to tell clients which query formats a resource understands. It sets the `Accept-Query` response header (a [Structured Fields](https://www.rfc-editor.org/rfc/rfc8941) List), and can be set on a plain `GET` too so clients can discover formats before sending a `QUERY`:
+
+```ts
+import { appendAcceptQuery } from "h3";
+
+app.get("/books", (event) => {
+  appendAcceptQuery(event, ["application/sql", "application/jsonpath"]);
+  // Accept-Query: application/sql, application/jsonpath
+  return "Send a QUERY request with a SQL or JSONPath body.";
+});
+```
+
+## Validate the `Content-Type`
+
+Use [`requireContentType`](/utils/request#requirecontenttypeevent-acceptedtypes) to enforce the RFC's error semantics. It returns the matched media type, or throws `400` (missing), `415` (unsupported), or `422` (malformed):
+
+```ts
+import { requireContentType, readBody } from "h3";
+
+app.query("/books", async (event) => {
+  const type = requireContentType(event, ["application/sql", "application/jsonpath"]);
+  const query = await readBody(event, { type: "text" });
+  return runQuery(type, query);
+});
+```
+
+## Offer a Cacheable `GET` Alternative
+
+A `QUERY` response is not addressable by URL, so browsers and CDNs can't cache it. RFC 10008 suggests pointing clients at an equivalent, cacheable `GET` via the `Content-Location` header. Stash the result under a stable id and let a client repeat the query with an ordinary, HTTP-cacheable `GET`:
+
+```ts
+app.query("/books", async (event) => {
+  const result = runQuery(type, query);
+  const id = queryId(type, query); // stable hash of the query
+  cache.set(id, result);
+  event.res.headers.set("content-location", `/books/${id}`);
+  return result;
+});
+```
+
+## Full Example
+
+A self-contained, runnable demo — a `/books` resource that accepts SQL-ish and JSONPath queries, validates the `Content-Type`, and advertises a cacheable `GET` alternative. It also serves a small interactive page at `/`.
+
+::read-more{to="https://github.com/h3js/h3/tree/main/examples/query.mjs"}
+See the full [`examples/query.mjs`](https://github.com/h3js/h3/tree/main/examples/query.mjs) source, or run it locally with `node examples/query.mjs`.
+::
+
+> [!NOTE]
+> Unlike `GET`, `QUERY` is **not** CORS-safelisted, so browsers send a preflight. If you pass an explicit `methods` allowlist to [`handleCors`](/utils/security#handlecorsevent-options), include `"QUERY"`.

--- a/examples/query.mjs
+++ b/examples/query.mjs
@@ -3,7 +3,7 @@ import {
   serve,
   html,
   getRouterParam,
-  setAcceptQuery,
+  appendAcceptQuery,
   requireContentType,
   readBody,
   HTTPError,
@@ -103,7 +103,7 @@ app
   .get("/books", (event) => {
     // Advertise the accepted query formats on a plain GET too, so clients can
     // discover them before sending a QUERY request.
-    setAcceptQuery(event, ACCEPTED);
+    appendAcceptQuery(event, ACCEPTED);
     return "Send a QUERY request to /books with a SQL or JSONPath body.";
   })
   .get("/books/:id", (event) => {
@@ -119,7 +119,7 @@ app
   .query("/books", async (event) => {
     // Echo the accepted formats via the `Accept-Query` response header so a
     // successful response also advertises what this resource understands.
-    setAcceptQuery(event, ACCEPTED);
+    appendAcceptQuery(event, ACCEPTED);
 
     // Validate the request `Content-Type`. Throws 400 (missing),
     // 422 (malformed), or 415 (unsupported) — and returns the matched type.

--- a/src/utils/cors.ts
+++ b/src/utils/cors.ts
@@ -28,9 +28,13 @@ export interface CorsOptions {
   /**
    * This determines the value of the "access-control-allow-methods" response header of a preflight request.
    *
+   * The default `"*"` permits any method (including non-safelisted ones like `QUERY`).
+   * When using an explicit allowlist, remember that `QUERY` is **not** a CORS-safelisted
+   * method, so browsers preflight it — include `"QUERY"` in the array to allow it.
+   *
    * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods
    * @default "*"
-   * @example ["GET", "HEAD", "PUT", "POST"]
+   * @example ["GET", "HEAD", "PUT", "POST", "QUERY"]
    */
   methods?: "*" | string[];
 

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -1,4 +1,9 @@
-import { appendAcceptQuery, requireContentType } from "../src/index.ts";
+import {
+  appendAcceptQuery,
+  handleCacheHeaders,
+  handleCors,
+  requireContentType,
+} from "../src/index.ts";
 import { describeMatrix } from "./_setup.ts";
 
 describeMatrix("query utils", (t, { it, expect, describe }) => {
@@ -150,6 +155,77 @@ describeMatrix("query utils", (t, { it, expect, describe }) => {
         headers: { "content-type": "text/plain" },
       });
       expect(res.status).toBe(200);
+    });
+  });
+
+  // QUERY is not a CORS-safelisted method, so browsers preflight it.
+  // h3's CORS is method-agnostic, so no special handling is needed — these
+  // tests guard that a QUERY preflight keeps working like any other method.
+  describe("CORS preflight", () => {
+    it("allows a QUERY preflight with the default wildcard methods", async () => {
+      t.app.all("/search", (event) => {
+        const cors = handleCors(event, { origin: "*" });
+        if (cors !== false) return cors;
+        return "ok";
+      });
+      const res = await t.fetch("/search", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://example.com",
+          "access-control-request-method": "QUERY",
+        },
+      });
+      expect(res.status).toBe(204);
+      expect(res.headers.get("access-control-allow-methods")).toBe("*");
+    });
+
+    it("echoes QUERY in an explicit methods allowlist", async () => {
+      t.app.all("/search", (event) => {
+        const cors = handleCors(event, {
+          origin: ["https://example.com"],
+          methods: ["GET", "QUERY"],
+        });
+        if (cors !== false) return cors;
+        return "ok";
+      });
+      const res = await t.fetch("/search", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://example.com",
+          "access-control-request-method": "QUERY",
+        },
+      });
+      expect(res.status).toBe(204);
+      expect(res.headers.get("access-control-allow-methods")).toBe("GET,QUERY");
+    });
+  });
+
+  // QUERY is safe, idempotent, and cacheable like GET (RFC 10008 §2), so
+  // conditional-request handling must apply to it. handleCacheHeaders is not
+  // method-gated — these tests guard that it stays that way for QUERY.
+  describe("conditional caching", () => {
+    it("returns 304 for a QUERY request matching If-None-Match", async () => {
+      t.app.query("/search", (event) => {
+        if (handleCacheHeaders(event, { etag: '"v1"' })) return null;
+        return "results";
+      });
+      const res = await t.fetch("/search", {
+        method: "QUERY",
+        headers: { "if-none-match": '"v1"' },
+      });
+      expect(res.status).toBe(304);
+    });
+
+    it("returns 304 for a QUERY request matching If-Modified-Since", async () => {
+      t.app.query("/search", (event) => {
+        if (handleCacheHeaders(event, { modifiedTime: new Date("2021-01-01") })) return null;
+        return "results";
+      });
+      const res = await t.fetch("/search", {
+        method: "QUERY",
+        headers: { "if-modified-since": "Fri, 01 Jan 2021 00:00:00 GMT" },
+      });
+      expect(res.status).toBe(304);
     });
   });
 });


### PR DESCRIPTION
## Summary

**PR 4 — Cross-cutting audits + docs** from the HTTP `QUERY` method proposal (#1441). Completes the checklist now that core support (#1445) and the `Accept-Query` / `requireContentType` utils (#1446) have landed.

The audit finding is that **no core logic change is needed** — CORS and cache handling are already method-agnostic. This PR locks that behavior in with regression tests, documents the one real gotcha (CORS preflight), fixes a broken example, and adds an example doc page.

## Audit results

| Area | Finding | Action |
| --- | --- | --- |
| **CORS** | `handleCors` / `isPreflightRequest` never inspect the *specific* requested method; `access-control-allow-methods` just echoes `methods`. Default `"*"` already permits `QUERY`. | Doc note + regression tests. `QUERY` is **not** CORS-safelisted, so explicit `methods` allowlists must include `"QUERY"`. |
| **Cache** | `handleCacheHeaders` has no method guard — keys off `If-None-Match` / `If-Modified-Since` regardless of method. `QUERY` already gets `304`. | Regression tests. |
| **Proxy** | Already handled in #1445 (`QUERY` in `PayloadMethods`, forwarded with body). | — |

## Changes

- **`src/utils/cors.ts`** — clarify the `methods` option jsdoc: include `"QUERY"` in explicit allowlists since browsers preflight it.
- **`test/query.test.ts`** — matrix regression tests: `QUERY` preflight (wildcard + explicit allowlist) and `304` conditional caching (`If-None-Match` / `If-Modified-Since`).
- **`examples/query.mjs`** — 🐛 **bug fix**: the example imported `setAcceptQuery`, but the util shipped as `appendAcceptQuery` (#1446), so it failed to run. Corrected and verified end-to-end (`QUERY` → `200` + `Content-Location`, `415` on unsupported type, cacheable `GET` follow-up).
- **`docs/1.guide/1.basics/2.routing.md`** — new "HTTP `QUERY` method" section covering `app.query()`, the read-with-a-body use case, body-size limits, and the CORS/cache/proxy parity notes.
- **`docs/4.examples/handle-query.md`** — new example page walking through `app.query()`, `appendAcceptQuery`, `requireContentType`, and the cacheable-`GET` / `Content-Location` pattern; linked from the routing guide and the examples index.

## Testing

- `pnpm vitest run test/query.test.ts` → 38 passed (19 × web/node matrix)
- `pnpm vitest run test/unit/cors.test.ts test/utils.test.ts test/proxy.test.ts` → all green
- `pnpm lint` → clean
- Manually ran `node examples/query.mjs` and exercised every path with `curl`

Closes the PR 4 checklist in #1441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new guide section for the HTTP `QUERY` method, including handler registration, reading request bodies, and enforcing body-size limits.
  * Documented `QUERY` caching behavior, proxy forwarding expectations, and CORS/preflight implications.
  * Expanded CORS docs to clarify that `QUERY` is not CORS-safelisted and must be explicitly included in allowed methods.
* **Examples**
  * Added an “HTTP QUERY Method” example demonstrating correct header-based format negotiation and handler usage.
* **Tests**
  * Added coverage for `QUERY` CORS preflight and conditional caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->