### PR TITLE
docs: remove non-existent sendEventStream from createEventStream example

### DIFF
--- a/docs/2.utils/2.response.md
+++ b/docs/2.utils/2.response.md
@@ -17,7 +17,7 @@ Initialize an EventStream instance for creating [server sent events](https://dev
 **Example:**
 
 ```ts
-import { createEventStream, sendEventStream } from "h3";
+import { createEventStream } from "h3";
 
 app.get("/sse", (event) => {
   const eventStream = createEventStream(event);

--- a/src/utils/event-stream.ts
+++ b/src/utils/event-stream.ts
@@ -28,7 +28,7 @@ export interface EventStreamMessage {
  * @example
  *
  * ```ts
- * import { createEventStream, sendEventStream } from "h3";
+ * import { createEventStream } from "h3";
  *
  * app.get("/sse", (event) => {
  *   const eventStream = createEventStream(event);


### PR DESCRIPTION
The `createEventStream` example imports `sendEventStream`:

```ts
import { createEventStream, sendEventStream } from "h3";
```

But h3 does not export `sendEventStream`, and the example never uses it — it only calls `createEventStream` and `eventStream.push(...)`. Copying the snippet gives an unresolved import.

Dropped the stray name from the JSDoc example in `src/utils/event-stream.ts` and regenerated the mirrored docs with `automd`, so `docs/2.utils/2.response.md` matches.

Checked: `pnpm build` and `pnpm exec vitest --run` both pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated event stream examples to remove an unused import.
  * Ensured documentation snippets show only the required event stream utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->