### PR TITLE
feat: automatically match GET routes for HEAD requests

### DIFF
--- a/docs/1.guide/1.basics/2.routing.md
+++ b/docs/1.guide/1.basics/2.routing.md
@@ -42,6 +42,27 @@ You can also use [`H3.all`](/guide/api/h3#h3all) method to register a route acce
 app.all("/hello", (event) => `This is a ${event.req.method} request!`);
 ```
 
+## HEAD Requests
+
+Following [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-head), `HEAD` requests automatically match the corresponding `GET` route and run its handler, but the response body is omitted (only the headers and status are sent). You don't need to register a separate `HEAD` handler:
+
+```js
+app.get("/hello", () => "Hello world!");
+
+// HEAD /hello → 200 with the same headers as GET, but an empty body
+```
+
+Register an explicit `HEAD` handler when you want to override this — for example, to skip computing the body:
+
+```js
+app.head("/hello", (event) => {
+  event.res.headers.set("content-length", "12");
+  return null;
+});
+```
+
+An explicit `head()` route always takes precedence over the automatic `GET` fallback.
+
 ## HTTP `QUERY` Method
 
 H3 supports the [HTTP `QUERY` method (RFC 10008)](https://www.rfc-editor.org/rfc/rfc10008) as a first-class method. `QUERY` is like `GET` — **safe, idempotent, and cacheable** — but carries a request body (with a `Content-Type`), closing the long-standing "GET with a body" gap. It's ideal for complex read operations where filters don't fit in a URL.

--- a/src/h3.ts
+++ b/src/h3.ts
@@ -198,7 +198,13 @@ export const H3 = /* @__PURE__ */ (() => {
     }
 
     override "~findRoute"(_event: H3Event): MatchedRoute<H3Route> | void {
-      return findRoute(this["~rou3"], _event.req.method, _event.url.pathname);
+      const match = findRoute<H3Route>(this["~rou3"], _event.req.method, _event.url.pathname);
+      if (match === undefined && _event.req.method === "HEAD") {
+        // Fall back to the matching GET route (RFC 9110). The method stays "HEAD"
+        // so the response body is stripped by nullBody() in prepareResponse.
+        return findRoute(this["~rou3"], "GET", _event.url.pathname);
+      }
+      return match;
     }
 
     override "~addRoute"(_route: H3Route): void {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -35,7 +35,10 @@ function createMatcher(opts: MiddlewareOptions & { route?: string }) {
   const method = opts.method?.toUpperCase();
   return function _middlewareMatcher(event: H3Event) {
     if (method && event.req.method !== method) {
-      return false;
+      // HEAD is served by GET handlers (RFC 9110), so GET-scoped middleware also matches HEAD
+      if (!(method === "GET" && event.req.method === "HEAD")) {
+        return false;
+      }
     }
     if (opts.match && !opts.match(event)) {
       return false;

--- a/src/response.ts
+++ b/src/response.ts
@@ -116,6 +116,14 @@ function prepareResponse(
 
   // Avoid merging if no prepared headers are provided or we are rendering an Error
   if (!preparedHeaders || nested || !val.ok) {
+    // Strip the body for HEAD requests (runtimes usually do this, but keep self-consistent)
+    if (event.req.method === "HEAD" && val.body !== null) {
+      return new FastResponse(null, {
+        status: val.status,
+        statusText: val.statusText,
+        headers: val.headers,
+      }) as Response;
+    }
     return val; // Fast path: no headers to merge
   }
   try {

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -18,8 +18,8 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log(`Bundle size (H3): ${bundle.bytes} (gzip: ${bundle.gzipSize})`);
     }
-    expect(bundle.bytes).toBeLessThanOrEqual(17_200); // <17.2kb
-    expect(bundle.gzipSize).toBeLessThanOrEqual(6_600); // <6.6kb
+    expect(bundle.bytes).toBeLessThanOrEqual(17_400); // <17.4kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(6_650); // <6.65kb
   });
 
   it("bundle size (H3Core)", async () => {
@@ -34,8 +34,8 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log(`Bundle size (H3Core): ${bundle.bytes} (gzip: ${bundle.gzipSize})`);
     }
-    expect(bundle.bytes).toBeLessThanOrEqual(6650); // <6.65kb
-    expect(bundle.gzipSize).toBeLessThanOrEqual(2680); // <2.68kb
+    expect(bundle.bytes).toBeLessThanOrEqual(6800); // <6.8kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(2730); // <2.73kb
   });
 
   it("bundle size (defineHandler)", async () => {
@@ -50,8 +50,8 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log(`Bundle size (defineHandler): ${bundle.bytes} (gzip: ${bundle.gzipSize})`);
     }
-    expect(bundle.bytes).toBeLessThanOrEqual(6200); // <6.2kb
-    expect(bundle.gzipSize).toBeLessThanOrEqual(2520); // <2.52kb
+    expect(bundle.bytes).toBeLessThanOrEqual(6350); // <6.35kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(2560); // <2.56kb
   });
 });
 

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -19,7 +19,7 @@ describe("benchmark", () => {
       console.log(`Bundle size (H3): ${bundle.bytes} (gzip: ${bundle.gzipSize})`);
     }
     expect(bundle.bytes).toBeLessThanOrEqual(17_400); // <17.4kb
-    expect(bundle.gzipSize).toBeLessThanOrEqual(6_650); // <6.65kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(6_600); // <6.6kb
   });
 
   it("bundle size (H3Core)", async () => {

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -160,6 +160,27 @@ describeMatrix("middleware", (t, { it, expect }) => {
     expect(await res2.text()).toBe("hi!");
   });
 
+  it("GET-scoped global middleware also runs for HEAD requests", async () => {
+    const app = new H3();
+    const seen: string[] = [];
+    app.use(
+      (event) => {
+        seen.push(event.req.method);
+      },
+      { method: "GET" },
+    );
+    app.get("/foo", () => "hello");
+
+    const headRes = await app.request("/foo", { method: "HEAD" });
+    expect(headRes.status).toBe(200);
+    expect(await headRes.text()).toBe("");
+
+    const postRes = await app.request("/foo", { method: "POST" });
+    expect(postRes.status).toBe(404); // no POST route; POST-scoped exclusion still holds
+
+    expect(seen).toEqual(["HEAD"]); // ran for HEAD, not for POST
+  });
+
   it('onResponse() does not duplicate "Set-Cookie" headers', async () => {
     // onResponse uses toResponse() internally (#1259)
     t.app.use(onResponse(() => {}));

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -355,6 +355,32 @@ describeMatrix("router", (t, { it, expect, describe }) => {
       expect(await res.text()).toBe("");
     });
 
+    it("preserves a content-length header set by the GET handler", async () => {
+      t.app.get("/head-cl", (event) => {
+        event.res.headers.set("content-length", "13");
+        return { hello: "world" };
+      });
+      const res = await t.fetch("/head-cl", { method: "HEAD" });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-length")).toBe("13");
+      expect(await res.text()).toBe("");
+    });
+
+    it("preserves content-length on a raw Response for HEAD", async () => {
+      t.app.get(
+        "/head-raw-cl",
+        () =>
+          new Response("hello world!!", {
+            status: 200,
+            headers: { "content-length": "13" },
+          }),
+      );
+      const res = await t.fetch("/head-raw-cl", { method: "HEAD" });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-length")).toBe("13");
+      expect(await res.text()).toBe("");
+    });
+
     it("route-level middleware on the GET route runs for fallback HEAD", async () => {
       let ran = false;
       t.app.get("/head-mw", () => "get", {

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -306,4 +306,69 @@ describeMatrix("router", (t, { it, expect, describe }) => {
       expect(await postRes.text()).toBe("post");
     });
   });
+
+  describe("HEAD fallback", () => {
+    it("HEAD falls back to GET route with empty body", async () => {
+      t.app.get("/head-fallback", () => ({ hello: "world" }));
+      const res = await t.fetch("/head-fallback", { method: "HEAD" });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toMatch(/application\/json/);
+      expect(await res.text()).toBe("");
+    });
+
+    it("explicit HEAD route takes precedence over GET fallback", async () => {
+      t.app.get("/head-precedence", () => "get");
+      t.app.head("/head-precedence", (event) => {
+        event.res.headers.set("x-handler", "head");
+        return null;
+      });
+      const res = await t.fetch("/head-precedence", { method: "HEAD" });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("x-handler")).toBe("head");
+      expect(await res.text()).toBe("");
+    });
+
+    it("HEAD to a path with no GET route still 404s", async () => {
+      const res = await t.fetch("/head-missing", { method: "HEAD" });
+      expect(res.status).toBe(404);
+    });
+
+    it("HEAD to a handler returning a raw Response strips body", async () => {
+      t.app.get(
+        "/head-raw",
+        () =>
+          new Response("body content", {
+            status: 200,
+            headers: { "x-custom": "value" },
+          }),
+      );
+      const res = await t.fetch("/head-raw", { method: "HEAD" });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("x-custom")).toBe("value");
+      expect(await res.text()).toBe("");
+    });
+
+    it("HEAD matching an all() route still works", async () => {
+      t.app.all("/head-all", () => "all");
+      const res = await t.fetch("/head-all", { method: "HEAD" });
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("");
+    });
+
+    it("route-level middleware on the GET route runs for fallback HEAD", async () => {
+      let ran = false;
+      t.app.get("/head-mw", () => "get", {
+        middleware: [
+          (_event, next) => {
+            ran = true;
+            return next();
+          },
+        ],
+      });
+      const res = await t.fetch("/head-mw", { method: "HEAD" });
+      expect(res.status).toBe(200);
+      expect(ran).toBe(true);
+      expect(await res.text()).toBe("");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Implements #1451. `HEAD` requests now automatically fall back to the matching `GET` route when no explicit `HEAD` (or `all()`) route is registered, following [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-head). This matches Express (implicit) and Fastify (`exposeHeadRoutes: true`) semantics, so users no longer hit surprise 404s from load balancer health checks, link checkers, or CDNs probing resources.

The request method is **not** rewritten — `event.req.method` stays `"HEAD"`, so the existing `nullBody()` logic in `prepareResponse` strips the body while the GET handler produces correct headers.

## Changes

- **`src/h3.ts`** — `~findRoute` falls back to the `GET` route on a `HEAD` miss. Zero cost on non-HEAD traffic (the extra lookup only runs on a HEAD route miss). Explicit `head()` routes still take precedence.
- **`src/response.ts`** — the raw-`Response` fast path now strips the body for `HEAD` requests for self-consistency (runtimes discard HEAD bodies at the server layer anyway, but this keeps h3 internally consistent).
- **`src/middleware.ts`** — GET-method-scoped **global** middleware (`app.use(fn, { method: "GET" })`) now also runs for `HEAD` requests, mirroring the routing fallback.
- **`test/router.test.ts`** — new `HEAD fallback` block (via `describeMatrix`, runs web + node): GET fallback with empty body & preserved headers, explicit `head()` precedence, 404 when no GET route, raw-`Response` body stripping, `all()` route, route-level middleware, and `content-length` preservation.
- **`test/middleware.test.ts`** — GET-scoped global middleware runs for HEAD.
- **`docs/1.guide/1.basics/2.routing.md`** — new "HEAD Requests" section.
- **`test/bench/bundle.test.ts`** — bumped bundle-size thresholds to accommodate the feature.

## Ecosystem alignment

Validated the behavior against three other frameworks (live repro + source inspection). All confirm both design decisions in this PR:

| Behavior | Express | Hono | Elysia | This PR |
| --- | --- | --- | --- | --- |
| HEAD auto-falls back to GET (200 + empty body) | ✅ | ✅ | ✅ | ✅ |
| Explicit `head()` route takes precedence | ✅ | ❌ (rewrites pre-routing) | ✅ | ✅ |
| GET-scoped middleware runs for HEAD | ✅ | ✅ | ✅ | ✅ |
| `Content-Length` preserved for HEAD | ✅ | – | ✅ | ✅ |

h3 matches the Express/Elysia model (fallback only on a HEAD miss, so explicit `head()` remains a usable escape hatch), rather than Hono's rewrite-before-routing model where an explicit `head()` route is unreachable.

## Trade-offs (accepted, per the issue)

- The GET handler computes the full body which is then discarded — the correct default (accurate headers matter more); explicit `head()` registration remains the optimization path.

## Test plan

- `pnpm vitest run test/router.test.ts test/middleware.test.ts` — pass; confirmed the new tests fail before their respective fixes.
- `pnpm test` — full suite green (1341 passed, 23 skipped, no type errors).

Closes #1451

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic `HEAD` support by falling back to matching `GET` routes while omitting the response body.
  - Explicit `HEAD` handlers override the `GET` fallback.
- **Bug Fixes**
  - Unmatched `HEAD` requests now return `404`.
  - Preserves status and headers for `HEAD`, including `content-length` (even when `GET` returns a raw response).
  - `GET`-scoped middleware now also applies to `HEAD`.
- **Documentation**
  - Updated the routing basics guide with a new “HEAD Requests” section and examples.
- **Tests**
  - Added comprehensive `HEAD` fallback coverage, including middleware and `all()` routes.
- **Chores**
  - Tightened bundle size benchmark thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->