### PR TITLE
feat: proxy improvements

### DIFF
--- a/docs/2.utils/5.proxy.md
+++ b/docs/2.utils/5.proxy.md
@@ -10,9 +10,21 @@ icon: arcticons:super-proxy
 
 ### `fetchWithEvent(event, url, init?)`
 
-Make a fetch request with the event's context and headers.
+Make a fetch request carrying the event's context.
 
-If the `url` starts with `/`, the request is dispatched internally via `event.app.fetch()` (sub-request) and never leaves the process.
+Behavior depends on the target: - An **internal** `url` (starting with `/`) is dispatched via
+
+`event.app.fetch()` (sub-request) and never leaves the process. It inherits
+
+the incoming request's filtered headers (via `getProxyRequestHeaders`) and
+
+runtime metadata (`ip`, `waitUntil`, ...). - An **external** `url` is sent with native `fetch(url, init)` **unchanged** —
+
+the event's headers and context are _not_ inherited (forwarding cookies or
+
+authorization to arbitrary hosts would be unsafe). A streamed `init.body`
+
+is given `duplex: "half"` when unset, which Node's `fetch` requires.
 
 **Security:** Never pass unsanitized user input as the `url`. Callers are responsible for validating and restricting the URL.
 

--- a/docs/2.utils/5.proxy.md
+++ b/docs/2.utils/5.proxy.md
@@ -26,6 +26,10 @@ Make a proxy request to a target URL and send the response back to the client.
 
 If the `target` starts with `/`, the request is dispatched internally via `event.app.fetch()` (sub-request) and never leaves the process. This bypasses any external security layer (reverse proxy auth, IP allowlisting, mTLS).
 
+Upstream 3xx responses are passed through to the client by default rather than followed. Set `fetchOptions: { redirect: "follow" }` to follow them instead — but following a redirect with a streamed request body can fail, since the body cannot be replayed once consumed. (Internal sub-requests via `event.app.fetch()` never follow redirects.)
+
+**Limitations** (inherited from `fetch`): upstream response bodies are always decompressed (compression is not preserved end-to-end), the `host` header is rewritten to the target (preserving it via `forwardHeaders: ["host"]` works on Node.js but may be ignored on other runtimes), and unix sockets, TLS options, or connection agents require a runtime-specific escape hatch (e.g. undici's `dispatcher` in `fetchOptions` on Node.js).
+
 **Security:** Never pass unsanitized user input as the `target`. Callers are responsible for validating and restricting the target URL (e.g. allowlisting hosts, blocking internal paths, enforcing protocol).
 
 ### `proxyRequest(event, target, opts)`
@@ -35,6 +39,8 @@ Proxy the incoming request to a target URL.
 If the `target` starts with `/`, the request is handled internally by the app router via `event.app.fetch()` instead of making an external HTTP request.
 
 The request body is streamed to the target without buffering. Per the Fetch standard, a request body can only be consumed once, so reading it beforehand (e.g. via `readBody()`, `readFormData()`, or body-reading middleware) locks the stream and proxying fails. If you need to inspect the body and still proxy it, read from a clone and leave the original event untouched.
+
+Upstream 3xx responses are passed through to the client by default rather than followed. Set `fetchOptions: { redirect: "follow" }` to follow them instead — but following a redirect with a streamed request body can fail, since the body cannot be replayed once consumed.
 
 **Security:** Never pass unsanitized user input as the `target`. Callers are responsible for validating and restricting the target URL (e.g. allowlisting hosts, blocking internal paths, enforcing protocol). Consider using `bodyLimit()` middleware to prevent large request bodies from consuming excessive resources when proxying untrusted input.
 

--- a/docs/2.utils/5.proxy.md
+++ b/docs/2.utils/5.proxy.md
@@ -16,7 +16,7 @@ Behavior depends on the target:
 
 An **internal** `url` (starting with `/`) is dispatched via `event.app.fetch()` (sub-request) and never leaves the process. It inherits the incoming request's filtered headers (via `getProxyRequestHeaders`) and runtime metadata (`ip`, `waitUntil`, ...).
 
-An **external** `url` is sent with native `fetch(url, init)` **unchanged** — the event's headers and context are *not* inherited (forwarding cookies or authorization to arbitrary hosts would be unsafe). A streamed `init.body` is given `duplex: "half"` when unset, which Node's `fetch` requires.
+An **external** `url` is sent with native `fetch(url, init)` **unchanged** — the event's headers and context are _not_ inherited (forwarding cookies or authorization to arbitrary hosts would be unsafe). A streamed `init.body` is given `duplex: "half"` when unset, which Node's `fetch` requires.
 
 **Security:** Never pass unsanitized user input as the `url`. Callers are responsible for validating and restricting the URL.
 

--- a/docs/2.utils/5.proxy.md
+++ b/docs/2.utils/5.proxy.md
@@ -12,19 +12,11 @@ icon: arcticons:super-proxy
 
 Make a fetch request carrying the event's context.
 
-Behavior depends on the target: - An **internal** `url` (starting with `/`) is dispatched via
+Behavior depends on the target:
 
-`event.app.fetch()` (sub-request) and never leaves the process. It inherits
+An **internal** `url` (starting with `/`) is dispatched via `event.app.fetch()` (sub-request) and never leaves the process. It inherits the incoming request's filtered headers (via `getProxyRequestHeaders`) and runtime metadata (`ip`, `waitUntil`, ...).
 
-the incoming request's filtered headers (via `getProxyRequestHeaders`) and
-
-runtime metadata (`ip`, `waitUntil`, ...). - An **external** `url` is sent with native `fetch(url, init)` **unchanged** —
-
-the event's headers and context are _not_ inherited (forwarding cookies or
-
-authorization to arbitrary hosts would be unsafe). A streamed `init.body`
-
-is given `duplex: "half"` when unset, which Node's `fetch` requires.
+An **external** `url` is sent with native `fetch(url, init)` **unchanged** — the event's headers and context are *not* inherited (forwarding cookies or authorization to arbitrary hosts would be unsafe). A streamed `init.body` is given `duplex: "half"` when unset, which Node's `fetch` requires.
 
 **Security:** Never pass unsanitized user input as the `url`. Callers are responsible for validating and restricting the URL.
 

--- a/docs/2.utils/5.proxy.md
+++ b/docs/2.utils/5.proxy.md
@@ -28,7 +28,7 @@ If the `target` starts with `/`, the request is dispatched internally via `event
 
 Upstream 3xx responses are passed through to the client by default rather than followed. Set `fetchOptions: { redirect: "follow" }` to follow them instead — but following a redirect with a streamed request body can fail, since the body cannot be replayed once consumed. (Internal sub-requests via `event.app.fetch()` never follow redirects.)
 
-**Limitations** (inherited from `fetch`): upstream response bodies are always decompressed (compression is not preserved end-to-end), the `host` header is rewritten to the target (preserving it via `forwardHeaders: ["host"]` works on Node.js but may be ignored on other runtimes), and unix sockets, TLS options, or connection agents require a runtime-specific escape hatch (e.g. undici's `dispatcher` in `fetchOptions` on Node.js).
+**Limitations** (inherited from `fetch`): upstream response bodies are always decompressed (compression is not preserved end-to-end), the `host` header is rewritten to the target (preserving it via `forwardHeaders: ["host"]` works on Node.js but may be ignored on other runtimes), and unix sockets, TLS options, or connection agents require a runtime-specific escape hatch (e.g. undici's `dispatcher` in `fetchOptions` on Node.js). On browser and service-worker runtimes, `redirect: "manual"` produces an unrelayable opaque-redirect for external targets (a `502` is returned) — set `fetchOptions: { redirect: "follow" }` there.
 
 **Security:** Never pass unsanitized user input as the `target`. Callers are responsible for validating and restricting the target URL (e.g. allowlisting hosts, blocking internal paths, enforcing protocol).
 

--- a/docs/2.utils/9.more.md
+++ b/docs/2.utils/9.more.md
@@ -103,19 +103,25 @@ Note: the `http` handler only handles non-upgrade requests. To reject or customi
 
 ```ts
 // WebSocket-only route (non-upgrade requests get `426 Upgrade Required`)
-app.get("/_ws", defineWebSocketHandler({
-  message: (peer, message) => peer.send(message.text()),
-}));
+app.get(
+  "/_ws",
+  defineWebSocketHandler({
+    message: (peer, message) => peer.send(message.text()),
+  }),
+);
 ```
 
 **Example:**
 
 ```ts
 // Handle both WebSocket upgrades and plain HTTP on the same route
-app.get("/_ws", defineWebSocketHandler(
-  { message: (peer, message) => peer.send(message.text()) },
-  () => "Send a WebSocket upgrade request to connect.",
-));
+app.get(
+  "/_ws",
+  defineWebSocketHandler(
+    { message: (peer, message) => peer.send(message.text()) },
+    () => "Send a WebSocket upgrade request to connect.",
+  ),
+);
 ```
 
 <!-- /automd -->

--- a/docs/2.utils/9.more.md
+++ b/docs/2.utils/9.more.md
@@ -103,25 +103,19 @@ Note: the `http` handler only handles non-upgrade requests. To reject or customi
 
 ```ts
 // WebSocket-only route (non-upgrade requests get `426 Upgrade Required`)
-app.get(
-  "/_ws",
-  defineWebSocketHandler({
-    message: (peer, message) => peer.send(message.text()),
-  }),
-);
+app.get("/_ws", defineWebSocketHandler({
+  message: (peer, message) => peer.send(message.text()),
+}));
 ```
 
 **Example:**
 
 ```ts
 // Handle both WebSocket upgrades and plain HTTP on the same route
-app.get(
-  "/_ws",
-  defineWebSocketHandler(
-    { message: (peer, message) => peer.send(message.text()) },
-    () => "Send a WebSocket upgrade request to connect.",
-  ),
-);
+app.get("/_ws", defineWebSocketHandler(
+  { message: (peer, message) => peer.send(message.text()) },
+  () => "Send a WebSocket upgrade request to connect.",
+));
 ```
 
 <!-- /automd -->

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,5 +1,5 @@
 import type { H3Event } from "../event.ts";
-import { matchETag } from "./internal/cache.ts";
+import { isCacheMatch } from "./internal/cache.ts";
 
 export interface CacheConditions {
   modifiedTime?: string | Date;
@@ -58,20 +58,7 @@ export function handleCacheHeaders(event: H3Event, opts: CacheConditions): boole
 
   event.res.headers.set("cache-control", cacheControls.join(", "));
 
-  // RFC 9110 §13.1.3: a recipient MUST ignore `If-Modified-Since` when the
-  // request contains an `If-None-Match` header field. `If-None-Match` takes
-  // precedence; `If-Modified-Since` is only evaluated when it is absent. A
-  // present-but-empty `If-None-Match` is malformed and treated as absent.
-  let cacheMatched = false;
-  const ifNoneMatch = event.req.headers.get("if-none-match");
-  if (ifNoneMatch) {
-    cacheMatched = !!opts.etag && matchETag(ifNoneMatch, opts.etag);
-  } else if (lastModified) {
-    const ifModifiedSince = event.req.headers.get("if-modified-since");
-    cacheMatched = !!ifModifiedSince && new Date(ifModifiedSince) >= lastModified;
-  }
-
-  if (cacheMatched) {
+  if (isCacheMatch(event.req.headers, { etag: opts.etag, lastModified })) {
     event.res.status = 304;
     return true;
   }

--- a/src/utils/internal/cache.ts
+++ b/src/utils/internal/cache.ts
@@ -16,6 +16,31 @@ export function matchETag(ifNoneMatch: string, etag: string): boolean {
   return splitETags(ifNoneMatch).some((tag) => opaqueTag(tag.trim()) === target);
 }
 
+/**
+ * Evaluate an incoming conditional request against the current representation's
+ * validators, returning `true` when it matches and a `304 Not Modified` should
+ * be sent.
+ *
+ * RFC 9110 §13.1.3: a recipient MUST ignore `If-Modified-Since` when the request
+ * contains an `If-None-Match` header field. `If-None-Match` takes precedence;
+ * `If-Modified-Since` is only evaluated when it is absent. A present-but-empty
+ * `If-None-Match` is malformed and treated as absent.
+ */
+export function isCacheMatch(
+  headers: Headers,
+  validators: { etag?: string; lastModified?: Date },
+): boolean {
+  const ifNoneMatch = headers.get("if-none-match");
+  if (ifNoneMatch) {
+    return !!validators.etag && matchETag(ifNoneMatch, validators.etag);
+  }
+  if (validators.lastModified) {
+    const ifModifiedSince = headers.get("if-modified-since");
+    return !!ifModifiedSince && new Date(ifModifiedSince) >= validators.lastModified;
+  }
+  return false;
+}
+
 function opaqueTag(tag: string): string {
   return tag.startsWith("W/") ? tag.slice(2) : tag;
 }

--- a/src/utils/internal/proxy.ts
+++ b/src/utils/internal/proxy.ts
@@ -14,7 +14,27 @@ export const ignoredHeaders: Set<string> = new Set([
   "te",
   "trailer",
   "host",
+  // Hop-by-hop credentials/controls meant for this proxy, not the upstream.
+  // Forwarding `proxy-authorization` would disclose the inbound proxy's
+  // credentials to the target (RFC 9110 §7.6.1 / §11.7.1).
+  "proxy-authorization",
+  "proxy-connection",
 ]);
+
+/**
+ * Parse a `Connection` header value into a lowercased set of the field names it
+ * nominates as hop-by-hop (RFC 9110 §7.6.1). Those fields must not be relayed
+ * across the proxy in either direction.
+ */
+export function connectionTokens(connection: string | null): Set<string> {
+  return new Set(
+    (connection || "")
+      .toLowerCase()
+      .split(",")
+      .map((name) => name.trim())
+      .filter(Boolean),
+  );
+}
 
 /**
  * Hop-by-hop response headers (plus length/encoding headers that fetch has
@@ -43,10 +63,12 @@ export function rewriteCookieProperty(
   return header.replace(
     new RegExp(`(;\\s*${property}=)([^;]+)`, "gi"),
     (match, prefix, previousValue) => {
+      // Own-property checks (like `rewritePrefix`) so a polluted
+      // `Object.prototype` cannot inject phantom domain/path rewrite rules.
       let newValue;
-      if (previousValue in _map) {
+      if (Object.hasOwn(_map, previousValue)) {
         newValue = _map[previousValue];
-      } else if ("*" in _map) {
+      } else if (Object.hasOwn(_map, "*")) {
         newValue = _map["*"];
       } else {
         return match;

--- a/src/utils/internal/proxy.ts
+++ b/src/utils/internal/proxy.ts
@@ -11,6 +11,8 @@ export const ignoredHeaders: Set<string> = new Set([
   "keep-alive",
   "upgrade",
   "expect",
+  "te",
+  "trailer",
   "host",
 ]);
 
@@ -56,10 +58,10 @@ export function rewriteCookieProperty(
 
 /**
  * Apply `x-forwarded-*` headers derived from the incoming request onto the
- * given proxy headers (mutating and returning a `Headers` instance).
+ * given proxy headers (returning a `Headers` instance).
  *
- * `x-forwarded-for` / `x-forwarded-proto` are appended to any existing value;
- * `x-forwarded-host` / `x-forwarded-port` are only set when absent.
+ * Each header is only set when absent — a value already present (from the
+ * incoming request or header options) is never modified.
  */
 export function applyXForwardedHeaders(headers: HeadersInit, event: H3Event): Headers {
   const merged = headers instanceof Headers ? headers : new Headers(headers);
@@ -112,11 +114,12 @@ export function rewriteLocationHeaders(
   }
   const refresh = headers.get("refresh");
   if (refresh) {
-    // `Refresh: 5; url=https://target/path`
-    const match = refresh.match(/^(\s*[\d.]+\s*;\s*url=\s*)(.+)$/i);
-    const rewritten = match && rewriteValue(match[2]!);
+    // `Refresh: 5; url=https://target/path` — the delay is optional in
+    // practice, `=` may be padded, and the URL may be quoted.
+    const match = refresh.match(/^(\s*(?:[\d.]+\s*[;,]\s*)?url\s*=\s*)(['"]?)(.*?)\2(\s*)$/i);
+    const rewritten = match && rewriteValue(match[3]!);
     if (rewritten) {
-      headers.set("refresh", match![1]! + rewritten);
+      headers.set("refresh", match![1]! + match![2]! + rewritten + match![2]! + match![4]!);
     }
   }
 }
@@ -129,25 +132,59 @@ function rewriteOrigin(
   if (!targetOrigin || targetOrigin === requestOrigin) {
     return undefined;
   }
-  // A relative URL already resolves against the proxy origin on the client.
-  if (!URL.canParse(value)) {
-    return undefined;
-  }
-  const url = new URL(value);
+  // A protocol-relative URL (`//host/path`) needs a base to parse; resolve it
+  // against the target origin so one pointing at the target is caught too
+  // (otherwise it would leak the upstream host). A plain-relative URL already
+  // resolves against the proxy origin on the client and stays untouched.
+  const url = value.startsWith("//")
+    ? URL.canParse(value, targetOrigin)
+      ? new URL(value, targetOrigin)
+      : undefined
+    : URL.canParse(value)
+      ? new URL(value)
+      : undefined;
   // A URL pointing anywhere but the proxied target is not ours to rewrite.
-  if (url.origin !== targetOrigin) {
+  if (!url || url.origin !== targetOrigin) {
     return undefined;
   }
   return requestOrigin + url.pathname + url.search + url.hash;
 }
 
 function rewritePrefix(value: string, map: Record<string, string>): string | undefined {
-  for (const prefix in map) {
+  // `Object.keys` (not `for...in`) so a polluted `Object.prototype` cannot
+  // inject phantom rewrite rules.
+  for (const prefix of Object.keys(map)) {
     if (value.startsWith(prefix)) {
       return map[prefix] + value.slice(prefix.length);
     }
   }
   return undefined;
+}
+
+/**
+ * Run a task raced against an abort signal, rejecting with the signal's
+ * reason on abort (without starting the task when already aborted). Needed
+ * for internal sub-requests: `H3.fetch()` does not observe the request
+ * signal, so timeouts/disconnects would otherwise never settle it.
+ */
+export function abortable<T>(run: () => Promise<T> | T, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    return Promise.reject(signal.reason as Error);
+  }
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(signal.reason as Error);
+    signal.addEventListener("abort", onAbort, { once: true });
+    Promise.resolve(run()).then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error as Error);
+      },
+    );
+  });
 }
 
 export function mergeHeaders(

--- a/src/utils/internal/proxy.ts
+++ b/src/utils/internal/proxy.ts
@@ -1,5 +1,3 @@
-export const PayloadMethods: Set<string> = new Set(["PATCH", "POST", "PUT", "DELETE", "QUERY"]);
-
 export const ignoredHeaders: Set<string> = new Set([
   "transfer-encoding",
   "accept-encoding",

--- a/src/utils/internal/proxy.ts
+++ b/src/utils/internal/proxy.ts
@@ -86,22 +86,26 @@ export function applyXForwardedHeaders(headers: HeadersInit, event: H3Event): He
 }
 
 /**
- * Rewrite `location` and `refresh` response headers that point at the proxy
- * target back to the proxy's own origin (like nginx `proxy_redirect`), so the
- * client follows redirects through the proxy instead of reaching for the
- * upstream host directly. Relative and third-party URLs are left untouched.
+ * Rewrite `location` and `refresh` response headers (like nginx
+ * `proxy_redirect`) so the client follows redirects through the proxy instead
+ * of reaching for the upstream host directly. With `rewrite: true`, a URL
+ * whose origin matches the proxy target is rewritten to the proxy's own
+ * origin (relative and third-party URLs are left untouched). With a record,
+ * the first matching URL prefix is replaced with its mapped value.
  */
 export function rewriteLocationHeaders(
   headers: Headers,
-  targetOrigin: string,
+  rewrite: true | Record<string, string>,
+  targetOrigin: string | undefined,
   requestOrigin: string,
 ): void {
-  if (targetOrigin === requestOrigin) {
-    return;
-  }
+  const rewriteValue = (value: string) =>
+    rewrite === true
+      ? rewriteOrigin(value, targetOrigin, requestOrigin)
+      : rewritePrefix(value, rewrite);
   const location = headers.get("location");
   if (location) {
-    const rewritten = rewriteOrigin(location, targetOrigin, requestOrigin);
+    const rewritten = rewriteValue(location);
     if (rewritten) {
       headers.set("location", rewritten);
     }
@@ -110,7 +114,7 @@ export function rewriteLocationHeaders(
   if (refresh) {
     // `Refresh: 5; url=https://target/path`
     const match = refresh.match(/^(\s*[\d.]+\s*;\s*url=\s*)(.+)$/i);
-    const rewritten = match && rewriteOrigin(match[2]!, targetOrigin, requestOrigin);
+    const rewritten = match && rewriteValue(match[2]!);
     if (rewritten) {
       headers.set("refresh", match![1]! + rewritten);
     }
@@ -119,9 +123,12 @@ export function rewriteLocationHeaders(
 
 function rewriteOrigin(
   value: string,
-  targetOrigin: string,
+  targetOrigin: string | undefined,
   requestOrigin: string,
 ): string | undefined {
+  if (!targetOrigin || targetOrigin === requestOrigin) {
+    return undefined;
+  }
   // A relative URL already resolves against the proxy origin on the client.
   if (!URL.canParse(value)) {
     return undefined;
@@ -132,6 +139,15 @@ function rewriteOrigin(
     return undefined;
   }
   return requestOrigin + url.pathname + url.search + url.hash;
+}
+
+function rewritePrefix(value: string, map: Record<string, string>): string | undefined {
+  for (const prefix in map) {
+    if (value.startsWith(prefix)) {
+      return map[prefix] + value.slice(prefix.length);
+    }
+  }
+  return undefined;
 }
 
 export function mergeHeaders(

--- a/src/utils/internal/proxy.ts
+++ b/src/utils/internal/proxy.ts
@@ -65,15 +65,13 @@ export function applyXForwardedHeaders(headers: HeadersInit, event: H3Event): He
   const merged = headers instanceof Headers ? headers : new Headers(headers);
 
   const ip = event.req.ip;
-  if (ip) {
-    const existing = merged.get("x-forwarded-for");
-    merged.set("x-forwarded-for", existing ? `${existing}, ${ip}` : ip);
+  if (ip && !merged.has("x-forwarded-for")) {
+    merged.set("x-forwarded-for", ip);
   }
 
   const proto = event.url.protocol.slice(0, -1); // strip trailing ":"
-  if (proto) {
-    const existing = merged.get("x-forwarded-proto");
-    merged.set("x-forwarded-proto", existing ? `${existing}, ${proto}` : proto);
+  if (proto && !merged.has("x-forwarded-proto")) {
+    merged.set("x-forwarded-proto", proto);
   }
 
   if (!merged.has("x-forwarded-host")) {

--- a/src/utils/internal/proxy.ts
+++ b/src/utils/internal/proxy.ts
@@ -85,6 +85,55 @@ export function applyXForwardedHeaders(headers: HeadersInit, event: H3Event): He
   return merged;
 }
 
+/**
+ * Rewrite `location` and `refresh` response headers that point at the proxy
+ * target back to the proxy's own origin (like nginx `proxy_redirect`), so the
+ * client follows redirects through the proxy instead of reaching for the
+ * upstream host directly. Relative and third-party URLs are left untouched.
+ */
+export function rewriteLocationHeaders(
+  headers: Headers,
+  targetOrigin: string,
+  requestOrigin: string,
+): void {
+  if (targetOrigin === requestOrigin) {
+    return;
+  }
+  const location = headers.get("location");
+  if (location) {
+    const rewritten = rewriteOrigin(location, targetOrigin, requestOrigin);
+    if (rewritten) {
+      headers.set("location", rewritten);
+    }
+  }
+  const refresh = headers.get("refresh");
+  if (refresh) {
+    // `Refresh: 5; url=https://target/path`
+    const match = refresh.match(/^(\s*[\d.]+\s*;\s*url=\s*)(.+)$/i);
+    const rewritten = match && rewriteOrigin(match[2]!, targetOrigin, requestOrigin);
+    if (rewritten) {
+      headers.set("refresh", match![1]! + rewritten);
+    }
+  }
+}
+
+function rewriteOrigin(
+  value: string,
+  targetOrigin: string,
+  requestOrigin: string,
+): string | undefined {
+  // A relative URL already resolves against the proxy origin on the client.
+  if (!URL.canParse(value)) {
+    return undefined;
+  }
+  const url = new URL(value);
+  // A URL pointing anywhere but the proxied target is not ours to rewrite.
+  if (url.origin !== targetOrigin) {
+    return undefined;
+  }
+  return requestOrigin + url.pathname + url.search + url.hash;
+}
+
 export function mergeHeaders(
   defaults: HeadersInit,
   ...inputs: (HeadersInit | undefined)[]

--- a/src/utils/internal/proxy.ts
+++ b/src/utils/internal/proxy.ts
@@ -1,3 +1,5 @@
+import type { H3Event } from "../../event.ts";
+
 export const PayloadMethods: Set<string> = new Set(["PATCH", "POST", "PUT", "DELETE", "QUERY"]);
 
 export const ignoredHeaders: Set<string> = new Set([
@@ -31,6 +33,39 @@ export function rewriteCookieProperty(
       return newValue ? prefix + newValue : "";
     },
   );
+}
+
+/**
+ * Apply `x-forwarded-*` headers derived from the incoming request onto the
+ * given proxy headers (mutating and returning a `Headers` instance).
+ *
+ * `x-forwarded-for` / `x-forwarded-proto` are appended to any existing value;
+ * `x-forwarded-host` / `x-forwarded-port` are only set when absent.
+ */
+export function applyXForwardedHeaders(headers: HeadersInit, event: H3Event): Headers {
+  const merged = headers instanceof Headers ? headers : new Headers(headers);
+
+  const ip = event.req.ip;
+  if (ip) {
+    const existing = merged.get("x-forwarded-for");
+    merged.set("x-forwarded-for", existing ? `${existing}, ${ip}` : ip);
+  }
+
+  const proto = event.url.protocol.slice(0, -1); // strip trailing ":"
+  if (proto) {
+    const existing = merged.get("x-forwarded-proto");
+    merged.set("x-forwarded-proto", existing ? `${existing}, ${proto}` : proto);
+  }
+
+  if (!merged.has("x-forwarded-host")) {
+    merged.set("x-forwarded-host", event.url.host);
+  }
+
+  if (!merged.has("x-forwarded-port")) {
+    merged.set("x-forwarded-port", event.url.port || (proto === "https" ? "443" : "80"));
+  }
+
+  return merged;
 }
 
 export function mergeHeaders(

--- a/src/utils/internal/proxy.ts
+++ b/src/utils/internal/proxy.ts
@@ -2,13 +2,34 @@ export const PayloadMethods: Set<string> = new Set(["PATCH", "POST", "PUT", "DEL
 
 export const ignoredHeaders: Set<string> = new Set([
   "transfer-encoding",
+  // `accept-encoding` is stripped because fetch auto-decompresses upstream
+  // responses; forwarding the client's value would advertise encodings we
+  // then transparently decode. The client's `accept` header is forwarded so
+  // upstream content negotiation (JSON vs HTML) keeps working behind the proxy.
   "accept-encoding",
   "connection",
   "keep-alive",
   "upgrade",
   "expect",
   "host",
-  "accept",
+]);
+
+/**
+ * Hop-by-hop response headers (plus length/encoding headers that fetch has
+ * already normalized) that must be stripped from the upstream response instead
+ * of being relayed to the client.
+ */
+export const ignoredResponseHeaders: Set<string> = new Set([
+  "content-encoding",
+  "content-length",
+  "transfer-encoding",
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-connection",
+  "upgrade",
+  "trailer",
+  "te",
 ]);
 
 export function rewriteCookieProperty(

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -476,12 +476,12 @@ export function getProxyRequestHeaders(
  * Make a fetch request carrying the event's context.
  *
  * Behavior depends on the target:
- * 
+ *
  * An **internal** `url` (starting with `/`) is dispatched via
  * `event.app.fetch()` (sub-request) and never leaves the process. It inherits
  * the incoming request's filtered headers (via `getProxyRequestHeaders`) and
  * runtime metadata (`ip`, `waitUntil`, ...).
- *   
+ *
  * An **external** `url` is sent with native `fetch(url, init)` **unchanged** —
  * the event's headers and context are *not* inherited (forwarding cookies or
  * authorization to arbitrary hosts would be unsafe). A streamed `init.body`

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -166,6 +166,13 @@ export async function proxyRequest(
  * cannot be replayed once consumed. (Internal sub-requests via `event.app.fetch()`
  * never follow redirects.)
  *
+ * **Limitations** (inherited from `fetch`): upstream response bodies are always
+ * decompressed (compression is not preserved end-to-end), the `host` header is
+ * rewritten to the target (preserving it via `forwardHeaders: ["host"]` works on
+ * Node.js but may be ignored on other runtimes), and unix sockets, TLS options,
+ * or connection agents require a runtime-specific escape hatch (e.g. undici's
+ * `dispatcher` in `fetchOptions` on Node.js).
+ *
  * **Security:** Never pass unsanitized user input as the `target`. Callers are
  * responsible for validating and restricting the target URL (e.g. allowlisting
  * hosts, blocking internal paths, enforcing protocol).

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -4,6 +4,7 @@ import { HTTPError } from "../error.ts";
 import {
   PayloadMethods,
   ignoredHeaders,
+  ignoredResponseHeaders,
   mergeHeaders,
   rewriteCookieProperty,
 } from "./internal/proxy.ts";
@@ -13,7 +14,15 @@ import { HTTPResponse } from "../response.ts";
 
 export interface ProxyOptions {
   headers?: HeadersInit;
+  /**
+   * Allowlist of incoming request header names to forward to the upstream.
+   * Header names are matched case-insensitively.
+   */
   forwardHeaders?: string[];
+  /**
+   * Denylist of incoming request header names to drop before proxying.
+   * Header names are matched case-insensitively.
+   */
   filterHeaders?: string[];
   fetchOptions?: RequestInit & { duplex?: "half" | "full" };
   cookieDomainRewrite?: string | Record<string, string>;
@@ -150,7 +159,7 @@ export async function proxy(
   const cookies: string[] = [];
 
   for (const [key, value] of response.headers.entries()) {
-    if (key === "content-encoding" || key === "content-length" || key === "transfer-encoding") {
+    if (ignoredResponseHeaders.has(key)) {
       continue;
     }
     if (key === "set-cookie") {
@@ -204,12 +213,16 @@ export function getProxyRequestHeaders(
   },
 ): Record<string, string> {
   const headers = new EmptyObject();
+  // `Headers.entries()` yields lowercased names, so lowercase the option arrays
+  // once up front to keep the allow/deny matching case-insensitive.
+  const filterHeaders = opts?.filterHeaders?.map((h) => h.toLowerCase());
+  const forwardHeaders = opts?.forwardHeaders?.map((h) => h.toLowerCase());
   for (const [name, value] of event.req.headers.entries()) {
-    if (opts?.filterHeaders?.includes(name)) {
+    if (filterHeaders?.includes(name)) {
       continue;
     }
 
-    if (opts?.forwardHeaders?.includes(name)) {
+    if (forwardHeaders?.includes(name)) {
       headers[name] = value;
       continue;
     }

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -32,6 +32,17 @@ export interface ProxyOptions {
    * (e.g. to run cleanup). This also applies to a custom `fetchOptions.signal`.
    */
   propagateAbortError?: boolean;
+
+  /**
+   * Milliseconds to wait for the upstream response before giving up. On timeout
+   * the proxy responds with `504 Gateway Timeout`.
+   *
+   * Internally this composes an `AbortSignal.timeout(timeout)` into the request's
+   * abort signal. Because a fired timeout aborts with a `TimeoutError`, a
+   * caller-supplied `fetchOptions.signal` that is itself an `AbortSignal.timeout`
+   * is also mapped to `504` (rather than the `499` used for client disconnects).
+   */
+  timeout?: number;
 }
 
 /**
@@ -113,11 +124,20 @@ export async function proxy(
   // upstream request and releases its connection. If the caller also supplied
   // `fetchOptions.signal`, honor both (either aborting aborts the request)
   // instead of letting the spread silently drop `event.req.signal`.
-  const callerSignal = opts.fetchOptions?.signal;
+  // Optionally add a timeout signal so a slow upstream maps to `504` instead of
+  // hanging. Combine every applicable signal (client, caller, timeout) so any of
+  // them aborting aborts the request, without dropping `event.req.signal`.
+  const signals: AbortSignal[] = [event.req.signal];
+  if (opts.fetchOptions?.signal) {
+    signals.push(opts.fetchOptions.signal);
+  }
+  if (opts.timeout) {
+    signals.push(AbortSignal.timeout(opts.timeout));
+  }
   const fetchOptions: RequestInit = {
     headers: opts.headers as HeadersInit,
     ...opts.fetchOptions,
-    signal: callerSignal ? AbortSignal.any([event.req.signal, callerSignal]) : event.req.signal,
+    signal: signals.length > 1 ? AbortSignal.any(signals) : signals[0],
   };
 
   let response: Response | undefined;
@@ -127,6 +147,12 @@ export async function proxy(
         ? await event.app!.fetch(createSubRequest(event, target, fetchOptions))
         : await fetch(target, fetchOptions);
   } catch (error) {
+    // A fired timeout signal aborts with a `TimeoutError`. Map it (including a
+    // caller-supplied `AbortSignal.timeout`) to `504 Gateway Timeout`, never the
+    // `499`/propagation path used for client disconnects.
+    if ((error as Error)?.name === "TimeoutError") {
+      throw new HTTPError({ status: 504, statusText: "Gateway Timeout", cause: error });
+    }
     // Key off the error itself (not `event.req.signal.aborted`) so an abort is
     // detected even with a custom `fetchOptions.signal`, and a real upstream
     // failure is never mistaken for an abort.

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -113,11 +113,13 @@ export interface ProxyOptions {
    * incoming values first with `filterHeaders: ["x-forwarded-for"]` if the
    * upstream trusts this header for allowlisting, rate limiting, or logging.
    *
-   * Note that `x-forwarded-proto`/`-host` are derived from `event.url`, which
-   * some runtimes (e.g. Node via srvx) build from the incoming
-   * `x-forwarded-proto`/`host` headers. On such a runtime `filterHeaders`
-   * cannot fully sanitize them — the value is recreated from `event.url`. Trust
-   * these only behind a proxy you control (configure its trust-proxy handling).
+   * Note that `x-forwarded-proto`/`-host` reflect `event.url` (the server's
+   * resolved protocol and host), not the raw client headers — so `filterHeaders`
+   * does not affect them. By default the server derives these from the real
+   * transport and the on-the-wire `Host`, so a client cannot spoof them; they
+   * only follow an inbound `x-forwarded-*` header when the server is explicitly
+   * configured to trust an upstream proxy (e.g. srvx's `trustProxy`), which is
+   * the correct setup when a proxy you control sits in front.
    *
    * Only applied by `proxyRequest` (which forwards the incoming request);
    * the lower-level `proxy` ignores this option.

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -260,8 +260,10 @@ export async function proxy(
     timeoutId = setTimeout(
       () => timeoutController.abort(new DOMException("Proxy request timed out", "TimeoutError")),
       // setTimeout clamps anything above its int32 limit down to 1ms — treat
-      // larger deadlines as "practically no timeout" instead.
-      Math.min(Math.trunc(opts.timeout!), 2_147_483_647),
+      // larger deadlines as "practically no timeout" instead. Clamp up to 1ms
+      // too, so a sub-millisecond deadline doesn't `Math.trunc` to `0` and fire
+      // immediately, aborting every request before the upstream can respond.
+      Math.min(Math.max(Math.trunc(opts.timeout!), 1), 2_147_483_647),
     );
     signals.push(timeoutController.signal);
   }
@@ -282,6 +284,9 @@ export async function proxy(
     // `H3.fetch()` does not observe the request signal, so race internal
     // sub-requests against it explicitly — otherwise `timeout` and client
     // disconnects would be silent no-ops for internal (`/`) targets.
+    // Note: because `abortable` short-circuits an already-aborted signal, an
+    // internal sub-request whose client disconnected *before* the proxy call is
+    // never dispatched — its handler side effects (writes, logging) do not run.
     response =
       target[0] === "/"
         ? await abortable(

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -15,6 +15,15 @@ export interface ProxyOptions {
   headers?: HeadersInit;
   forwardHeaders?: string[];
   filterHeaders?: string[];
+  /**
+   * Options forwarded to the underlying `fetch()` call.
+   *
+   * Upstream 3xx responses are passed through to the client by default
+   * (`redirect: "manual"`) rather than followed. Set
+   * `fetchOptions: { redirect: "follow" }` to restore following redirects — but
+   * note that following a redirect for a request with a streamed body can fail,
+   * since the body cannot be replayed once it has been consumed.
+   */
   fetchOptions?: RequestInit & { duplex?: "half" | "full" };
   cookieDomainRewrite?: string | Record<string, string>;
   cookiePathRewrite?: string | Record<string, string>;
@@ -45,6 +54,11 @@ export interface ProxyOptions {
  * (e.g. via `readBody()`, `readFormData()`, or body-reading middleware) locks
  * the stream and proxying fails. If you need to inspect the body and still
  * proxy it, read from a clone and leave the original event untouched.
+ *
+ * Upstream 3xx responses are passed through to the client by default rather than
+ * followed. Set `fetchOptions: { redirect: "follow" }` to follow them instead —
+ * but following a redirect with a streamed request body can fail, since the body
+ * cannot be replayed once consumed.
  *
  * **Security:** Never pass unsanitized user input as the `target`. Callers are
  * responsible for validating and restricting the target URL (e.g. allowlisting
@@ -100,6 +114,12 @@ export async function proxyRequest(
  * `event.app.fetch()` (sub-request) and never leaves the process. This bypasses
  * any external security layer (reverse proxy auth, IP allowlisting, mTLS).
  *
+ * Upstream 3xx responses are passed through to the client by default rather than
+ * followed. Set `fetchOptions: { redirect: "follow" }` to follow them instead —
+ * but following a redirect with a streamed request body can fail, since the body
+ * cannot be replayed once consumed. (Internal sub-requests via `event.app.fetch()`
+ * never follow redirects.)
+ *
  * **Security:** Never pass unsanitized user input as the `target`. Callers are
  * responsible for validating and restricting the target URL (e.g. allowlisting
  * hosts, blocking internal paths, enforcing protocol).
@@ -116,6 +136,10 @@ export async function proxy(
   const callerSignal = opts.fetchOptions?.signal;
   const fetchOptions: RequestInit = {
     headers: opts.headers as HeadersInit,
+    // Default to passing upstream 3xx responses through to the client instead of
+    // silently following them. Placed before the spread so an explicit
+    // `fetchOptions.redirect` from the caller still wins.
+    redirect: "manual",
     ...opts.fetchOptions,
     signal: callerSignal ? AbortSignal.any([event.req.signal, callerSignal]) : event.req.signal,
   };

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -38,17 +38,24 @@ export interface ProxyOptions {
   cookieDomainRewrite?: string | Record<string, string>;
   cookiePathRewrite?: string | Record<string, string>;
   /**
-   * Rewrite `location` and `refresh` response headers that point at the proxy
-   * `target` back to the proxy's own origin (like nginx `proxy_redirect`), so
-   * client-side redirects keep flowing through the proxy instead of exposing
-   * the upstream host. Relative and third-party URLs are left untouched, as
-   * are internal (`/`-prefixed) targets, which already share the proxy origin.
+   * Rewrite `location` and `refresh` response headers, like nginx
+   * `proxy_redirect`:
    *
-   * Set to `false` to forward these headers verbatim.
+   * - `true` (default): a URL whose origin matches the proxy `target` is
+   *   rewritten to the proxy's own origin (path and query preserved), so
+   *   client-side redirects keep flowing through the proxy instead of
+   *   exposing the upstream host. Relative and third-party URLs are left
+   *   untouched, as are internal (`/`-prefixed) targets, which already share
+   *   the proxy origin.
+   * - A record maps URL prefixes to replacements (nginx
+   *   `proxy_redirect <from> <to>`); the first matching prefix is replaced,
+   *   e.g. `{ "https://upstream.example/two/": "/one/" }`. Only the explicit
+   *   mappings apply in this mode (including for internal targets).
+   * - `false`: forward these headers verbatim.
    *
    * @default true
    */
-  locationRewrite?: boolean;
+  locationRewrite?: boolean | Record<string, string>;
   onResponse?: (event: H3Event, response: Response) => void | Promise<void>;
   /**
    * Control how a client disconnect is handled.
@@ -282,10 +289,17 @@ export async function proxy(
   }
 
   // Rewrite redirect-ish headers pointing at the target back to the proxy's
-  // own origin (like nginx `proxy_redirect`) so the client keeps talking to
-  // the proxy. Internal (`/`) targets already share the request origin.
-  if (opts.locationRewrite !== false && target[0] !== "/") {
-    rewriteLocationHeaders(headers, new URL(target).origin, event.url.origin);
+  // own origin, or per explicit prefix mappings (like nginx `proxy_redirect`),
+  // so the client keeps talking to the proxy. In default mode internal (`/`)
+  // targets are skipped: they already share the request origin.
+  const locationRewrite = opts.locationRewrite ?? true;
+  if (locationRewrite !== false && (locationRewrite !== true || target[0] !== "/")) {
+    rewriteLocationHeaders(
+      headers,
+      locationRewrite,
+      target[0] === "/" ? undefined : new URL(target).origin,
+      event.url.origin,
+    );
   }
 
   if (opts.onResponse) {

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -7,6 +7,7 @@ import {
   ignoredResponseHeaders,
   mergeHeaders,
   rewriteCookieProperty,
+  rewriteLocationHeaders,
 } from "./internal/proxy.ts";
 import { EmptyObject } from "./internal/obj.ts";
 import type { ServerRequest } from "srvx";
@@ -36,6 +37,18 @@ export interface ProxyOptions {
   fetchOptions?: RequestInit & { duplex?: "half" | "full" };
   cookieDomainRewrite?: string | Record<string, string>;
   cookiePathRewrite?: string | Record<string, string>;
+  /**
+   * Rewrite `location` and `refresh` response headers that point at the proxy
+   * `target` back to the proxy's own origin (like nginx `proxy_redirect`), so
+   * client-side redirects keep flowing through the proxy instead of exposing
+   * the upstream host. Relative and third-party URLs are left untouched, as
+   * are internal (`/`-prefixed) targets, which already share the proxy origin.
+   *
+   * Set to `false` to forward these headers verbatim.
+   *
+   * @default true
+   */
+  locationRewrite?: boolean;
   onResponse?: (event: H3Event, response: Response) => void | Promise<void>;
   /**
    * Control how a client disconnect is handled.
@@ -266,6 +279,13 @@ export async function proxy(
     for (const cookie of _cookies) {
       headers.append("set-cookie", cookie);
     }
+  }
+
+  // Rewrite redirect-ish headers pointing at the target back to the proxy's
+  // own origin (like nginx `proxy_redirect`) so the client keeps talking to
+  // the proxy. Internal (`/`) targets already share the request origin.
+  if (opts.locationRewrite !== false && target[0] !== "/") {
+    rewriteLocationHeaders(headers, new URL(target).origin, event.url.origin);
   }
 
   if (opts.onResponse) {

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -4,6 +4,7 @@ import { HTTPError } from "../error.ts";
 import {
   abortable,
   applyXForwardedHeaders,
+  connectionTokens,
   ignoredHeaders,
   ignoredResponseHeaders,
   mergeHeaders,
@@ -17,11 +18,13 @@ import { HTTPResponse } from "../response.ts";
 export interface ProxyOptions {
   headers?: HeadersInit;
   /**
-   * Allowlist of incoming request header names to forward to the upstream.
-   * Header names are matched case-insensitively.
+   * Header names allowed to bypass the built-in hop-by-hop denylist. Matched
+   * case-insensitively.
    *
-   * Note: this bypasses the built-in hop-by-hop denylist — e.g.
-   * `forwardHeaders: ["host"]` forwards the client's `host` verbatim.
+   * This is **not** an exclusive allowlist: all ordinary request headers are
+   * still forwarded regardless. It only lists exceptions that force-forward a
+   * header the proxy would otherwise drop — e.g. `forwardHeaders: ["host"]`
+   * forwards the client's `host` verbatim. `filterHeaders` still wins over it.
    */
   forwardHeaders?: string[];
   /**
@@ -109,6 +112,12 @@ export interface ProxyOptions {
    * added. On an internet-facing server (no trusted proxy in front), strip
    * incoming values first with `filterHeaders: ["x-forwarded-for"]` if the
    * upstream trusts this header for allowlisting, rate limiting, or logging.
+   *
+   * Note that `x-forwarded-proto`/`-host` are derived from `event.url`, which
+   * some runtimes (e.g. Node via srvx) build from the incoming
+   * `x-forwarded-proto`/`host` headers. On such a runtime `filterHeaders`
+   * cannot fully sanitize them — the value is recreated from `event.url`. Trust
+   * these only behind a proxy you control (configure its trust-proxy handling).
    *
    * Only applied by `proxyRequest` (which forwards the incoming request);
    * the lower-level `proxy` ignores this option.
@@ -295,23 +304,33 @@ export async function proxy(
           )
         : await fetch(target, fetchOptions);
   } catch (error) {
+    // Classify by the composed signal's abort reason, not just the thrown
+    // error's `name`: some runtimes abort with the raw cause rather than an
+    // `AbortError`. srvx on Node, for instance, aborts a client disconnect with
+    // the socket error (`ECONNRESET`), whose name is `"Error"` — keying only off
+    // `name === "AbortError"` would misreport that disconnect as a `502`.
+    const reason = signal.aborted ? (signal.reason as Error | undefined) : undefined;
+
     // A fired timeout signal aborts with a `TimeoutError`. Map it (including a
     // caller-supplied `AbortSignal.timeout`) to `504 Gateway Timeout`, never the
     // `499`/propagation path used for client disconnects.
-    if ((error as Error)?.name === "TimeoutError") {
+    if (reason?.name === "TimeoutError" || (error as Error)?.name === "TimeoutError") {
       throw new HTTPError({ status: 504, statusText: "Gateway Timeout", cause: error });
     }
-    // Key off the error itself (not `event.req.signal.aborted`) so an abort is
-    // detected even with a custom `fetchOptions.signal`, and a real upstream
-    // failure is never mistaken for an abort.
-    if ((error as Error)?.name === "AbortError") {
+
+    // Treat the failure as an abort when our composed signal fired, or (for a
+    // custom `fetchOptions.signal` on runtimes that surface it that way) when
+    // the thrown error is itself an `AbortError`. A genuine upstream failure —
+    // where no signal aborted — is never mistaken for an abort.
+    if (signal.aborted || (error as Error)?.name === "AbortError") {
       // Opted in: surface the abort as-is so the caller can handle it.
       if (opts.propagateAbortError) {
         throw error;
       }
       // Default: a client disconnect is not a gateway failure. Respond quietly
       // instead of throwing a 502 for every dropped connection (the response is
-      // never delivered — the client is already gone).
+      // never delivered — the client is already gone). A caller-signal abort
+      // (client still connected) falls through to the 502 below.
       if (event.req.signal.aborted) {
         return new HTTPResponse(null, { status: 499, statusText: "Client Closed Request" });
       }
@@ -334,17 +353,23 @@ export async function proxy(
     });
   }
 
+  // A `no-cors` (`opaque`) or network-`error` filtered response — and any other
+  // status-0 response — exposes no readable status, headers, or body. Relaying
+  // it would surface an empty `200 OK` (`HTTPResponse`'s `status || 200`),
+  // falsely reporting success. Fail loudly instead.
+  if (response.type === "opaque" || response.type === "error" || response.status === 0) {
+    throw new HTTPError({
+      status: 502,
+      message:
+        "Cannot relay an opaque or errored upstream response (status 0), typically caused by a `no-cors` request mode on browser/service-worker runtimes.",
+    });
+  }
+
   const headers = new Headers();
 
   // Also strip response headers the upstream marked hop-by-hop via its
-  // `Connection` header (RFC 7230 §6.1), on top of the static denylist.
-  const connectionNominated = new Set(
-    (response.headers.get("connection") || "")
-      .toLowerCase()
-      .split(",")
-      .map((name) => name.trim())
-      .filter(Boolean),
-  );
+  // `Connection` header (RFC 9110 §7.6.1), on top of the static denylist.
+  const connectionNominated = connectionTokens(response.headers.get("connection"));
 
   for (const [key, value] of response.headers.entries()) {
     if (ignoredResponseHeaders.has(key) || connectionNominated.has(key) || key === "set-cookie") {
@@ -418,13 +443,22 @@ export function getProxyRequestHeaders(
   // once up front to keep the allow/deny matching case-insensitive.
   const filterHeaders = opts?.filterHeaders?.map((h) => h.toLowerCase());
   const forwardHeaders = opts?.forwardHeaders?.map((h) => h.toLowerCase());
+  // RFC 9110 §7.6.1: fields the incoming `Connection` header nominates are
+  // hop-by-hop and must not be forwarded upstream (mirrors the response path).
+  const connectionNominated = connectionTokens(event.req.headers.get("connection"));
   for (const [name, value] of event.req.headers.entries()) {
     if (filterHeaders?.includes(name)) {
       continue;
     }
 
+    // An explicit `forwardHeaders` entry is a deliberate escape hatch, so it
+    // wins over both the static denylist and `Connection` nominations.
     if (forwardHeaders?.includes(name)) {
       headers[name] = value;
+      continue;
+    }
+
+    if (connectionNominated.has(name)) {
       continue;
     }
 
@@ -437,10 +471,17 @@ export function getProxyRequestHeaders(
 }
 
 /**
- * Make a fetch request with the event's context and headers.
+ * Make a fetch request carrying the event's context.
  *
- * If the `url` starts with `/`, the request is dispatched internally via
- * `event.app.fetch()` (sub-request) and never leaves the process.
+ * Behavior depends on the target:
+ * - An **internal** `url` (starting with `/`) is dispatched via
+ *   `event.app.fetch()` (sub-request) and never leaves the process. It inherits
+ *   the incoming request's filtered headers (via `getProxyRequestHeaders`) and
+ *   runtime metadata (`ip`, `waitUntil`, ...).
+ * - An **external** `url` is sent with native `fetch(url, init)` **unchanged** —
+ *   the event's headers and context are *not* inherited (forwarding cookies or
+ *   authorization to arbitrary hosts would be unsafe). A streamed `init.body`
+ *   is given `duplex: "half"` when unset, which Node's `fetch` requires.
  *
  * **Security:** Never pass unsanitized user input as the `url`. Callers are
  * responsible for validating and restricting the URL.
@@ -448,9 +489,14 @@ export function getProxyRequestHeaders(
 export async function fetchWithEvent(
   event: H3Event,
   url: string,
-  init?: RequestInit,
+  init?: RequestInit & { duplex?: "half" | "full" },
 ): Promise<Response> {
   if (url[0] !== "/") {
+    // A `ReadableStream` body requires `duplex: "half"` or Node's `fetch`
+    // throws; default it when a body is present and no duplex is set.
+    if (init?.body != null && init.duplex === undefined) {
+      init = { ...init, duplex: "half" };
+    }
     return fetch(url, init);
   }
   return event.app!.fetch(

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -1,12 +1,7 @@
 import type { H3Event } from "../event.ts";
 
 import { HTTPError } from "../error.ts";
-import {
-  PayloadMethods,
-  ignoredHeaders,
-  mergeHeaders,
-  rewriteCookieProperty,
-} from "./internal/proxy.ts";
+import { ignoredHeaders, mergeHeaders, rewriteCookieProperty } from "./internal/proxy.ts";
 import { EmptyObject } from "./internal/obj.ts";
 import type { ServerRequest } from "srvx";
 import { HTTPResponse } from "../response.ts";
@@ -65,10 +60,14 @@ export async function proxyRequest(
   opts: ProxyOptions = {},
 ): Promise<HTTPResponse> {
   // Request Body
-  const requestBody = PayloadMethods.has(event.req.method) ? event.req.body : undefined;
-
-  // Method
+  // Forward the body based on presence, not a method allowlist, so bodies on
+  // WebDAV-style (PROPFIND/REPORT/SEARCH) and custom methods are not dropped.
+  // GET/HEAD are excluded because fetch rejects a body on those methods.
   const method = opts.fetchOptions?.method || event.req.method;
+  const requestBody =
+    event.req.body != null && event.req.method !== "GET" && event.req.method !== "HEAD"
+      ? event.req.body
+      : undefined;
 
   // Headers
   const fetchHeaders = mergeHeaders(
@@ -81,13 +80,19 @@ export async function proxyRequest(
     opts.headers,
   );
 
+  // Derive `duplex` from the FINAL body (a caller may override it via
+  // `opts.fetchOptions.body`), so a streamed override on a body-less incoming
+  // request still sets `duplex` and fetch does not throw. An explicit
+  // `opts.fetchOptions.duplex` still wins.
+  const fetchBody = opts.fetchOptions?.body ?? requestBody;
+
   return proxy(event, target, {
     ...opts,
     fetchOptions: {
       method,
       body: requestBody,
-      duplex: requestBody ? "half" : undefined,
       ...opts.fetchOptions,
+      duplex: opts.fetchOptions?.duplex ?? (fetchBody != null ? "half" : undefined),
       headers: fetchHeaders,
     },
   });
@@ -249,6 +254,12 @@ export async function fetchWithEvent(
 
 function createSubRequest(event: H3Event, path: string, init: RequestInit): ServerRequest {
   const url = new URL(path, event.url);
+  // A ReadableStream body requires `duplex: "half"` or the Request constructor
+  // throws on Node. Default it when a body is present and no duplex is set (e.g.
+  // the `fetchWithEvent` path, which never sets it).
+  if (init.body != null && (init as { duplex?: string }).duplex === undefined) {
+    init = { ...init, duplex: "half" } as RequestInit;
+  }
   const req = new Request(url, init) as ServerRequest;
   req.runtime = event.req.runtime;
   req.waitUntil = event.req.waitUntil;

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -3,6 +3,7 @@ import type { H3Event } from "../event.ts";
 import { HTTPError } from "../error.ts";
 import {
   PayloadMethods,
+  applyXForwardedHeaders,
   ignoredHeaders,
   mergeHeaders,
   rewriteCookieProperty,
@@ -32,6 +33,21 @@ export interface ProxyOptions {
    * (e.g. to run cleanup). This also applies to a custom `fetchOptions.signal`.
    */
   propagateAbortError?: boolean;
+  /**
+   * When `true`, add `x-forwarded-*` request headers derived from the incoming
+   * request so the upstream learns the real client and original request info:
+   *
+   * - `x-forwarded-for`: the client IP (`event.req.ip`) appended to any existing
+   *   value; left untouched when no IP is available.
+   * - `x-forwarded-proto`: the incoming request protocol, appended to any
+   *   existing value.
+   * - `x-forwarded-host`: the original host (incl. port), only set when absent.
+   * - `x-forwarded-port`: the original port (or the protocol default — `443` for
+   *   https, `80` for http), only set when absent.
+   *
+   * @default false
+   */
+  xfwd?: boolean;
 }
 
 /**
@@ -88,7 +104,7 @@ export async function proxyRequest(
       body: requestBody,
       duplex: requestBody ? "half" : undefined,
       ...opts.fetchOptions,
-      headers: fetchHeaders,
+      headers: opts.xfwd ? applyXForwardedHeaders(fetchHeaders, event) : fetchHeaders,
     },
   });
 }

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -66,13 +66,14 @@ export interface ProxyOptions {
    * When `true`, add `x-forwarded-*` request headers derived from the incoming
    * request so the upstream learns the real client and original request info:
    *
-   * - `x-forwarded-for`: the client IP (`event.req.ip`) appended to any existing
-   *   value; left untouched when no IP is available.
-   * - `x-forwarded-proto`: the incoming request protocol, appended to any
-   *   existing value.
-   * - `x-forwarded-host`: the original host (incl. port), only set when absent.
+   * - `x-forwarded-for`: the client IP (`event.req.ip`, when available).
+   * - `x-forwarded-proto`: the incoming request protocol.
+   * - `x-forwarded-host`: the original host (incl. port).
    * - `x-forwarded-port`: the original port (or the protocol default — `443` for
-   *   https, `80` for http), only set when absent.
+   *   https, `80` for http).
+   *
+   * Each header is only set when absent — a value already present on the
+   * incoming request (or set via header options) is left untouched.
    *
    * @default false
    */

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -476,14 +476,16 @@ export function getProxyRequestHeaders(
  * Make a fetch request carrying the event's context.
  *
  * Behavior depends on the target:
- * - An **internal** `url` (starting with `/`) is dispatched via
- *   `event.app.fetch()` (sub-request) and never leaves the process. It inherits
- *   the incoming request's filtered headers (via `getProxyRequestHeaders`) and
- *   runtime metadata (`ip`, `waitUntil`, ...).
- * - An **external** `url` is sent with native `fetch(url, init)` **unchanged** —
- *   the event's headers and context are *not* inherited (forwarding cookies or
- *   authorization to arbitrary hosts would be unsafe). A streamed `init.body`
- *   is given `duplex: "half"` when unset, which Node's `fetch` requires.
+ * 
+ * An **internal** `url` (starting with `/`) is dispatched via
+ * `event.app.fetch()` (sub-request) and never leaves the process. It inherits
+ * the incoming request's filtered headers (via `getProxyRequestHeaders`) and
+ * runtime metadata (`ip`, `waitUntil`, ...).
+ *   
+ * An **external** `url` is sent with native `fetch(url, init)` **unchanged** —
+ * the event's headers and context are *not* inherited (forwarding cookies or
+ * authorization to arbitrary hosts would be unsafe). A streamed `init.body`
+ * is given `duplex: "half"` when unset, which Node's `fetch` requires.
  *
  * **Security:** Never pass unsanitized user input as the `url`. Callers are
  * responsible for validating and restricting the URL.

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -2,6 +2,7 @@ import type { H3Event } from "../event.ts";
 
 import { HTTPError } from "../error.ts";
 import {
+  abortable,
   applyXForwardedHeaders,
   ignoredHeaders,
   ignoredResponseHeaders,
@@ -18,6 +19,9 @@ export interface ProxyOptions {
   /**
    * Allowlist of incoming request header names to forward to the upstream.
    * Header names are matched case-insensitively.
+   *
+   * Note: this bypasses the built-in hop-by-hop denylist — e.g.
+   * `forwardHeaders: ["host"]` forwards the client's `host` verbatim.
    */
   forwardHeaders?: string[];
   /**
@@ -67,24 +71,29 @@ export interface ProxyOptions {
    * the client is already gone) rather than logged as a `502` gateway error.
    *
    * Set this to `true` to instead let the `AbortError` propagate to your handler
-   * (e.g. to run cleanup). This also applies to a custom `fetchOptions.signal`.
+   * (e.g. to run cleanup). This also applies to a custom `fetchOptions.signal`,
+   * except when it aborts with a `TimeoutError` — timeouts always map to `504`
+   * (see `timeout`).
    */
   propagateAbortError?: boolean;
 
   /**
-   * Milliseconds to wait for the upstream response before giving up. On timeout
-   * the proxy responds with `504 Gateway Timeout`.
+   * Milliseconds to wait for the upstream response (headers) before giving up.
+   * On timeout the proxy responds with `504 Gateway Timeout`. The deadline is
+   * cleared once the upstream responds — it never cuts off a long-running
+   * response body stream.
    *
-   * Internally this composes an `AbortSignal.timeout(timeout)` into the request's
-   * abort signal. Because a fired timeout aborts with a `TimeoutError`, a
-   * caller-supplied `fetchOptions.signal` that is itself an `AbortSignal.timeout`
-   * is also mapped to `504` (rather than the `499` used for client disconnects).
+   * Because a fired timeout aborts with a `TimeoutError`, a caller-supplied
+   * `fetchOptions.signal` that is itself an `AbortSignal.timeout` is also
+   * mapped to `504` (rather than the `499` used for client disconnects) — note
+   * that such a signal stays armed during body streaming and can truncate it;
+   * prefer this option.
    */
   timeout?: number;
 
   /**
    * When `true`, add `x-forwarded-*` request headers derived from the incoming
-   * request so the upstream learns the real client and original request info:
+   * request so the upstream learns the client and original request info:
    *
    * - `x-forwarded-for`: the client IP (`event.req.ip`, when available).
    * - `x-forwarded-proto`: the incoming request protocol.
@@ -94,6 +103,15 @@ export interface ProxyOptions {
    *
    * Each header is only set when absent — a value already present on the
    * incoming request (or set via header options) is left untouched.
+   *
+   * **Security:** because present values win, a client-supplied
+   * `x-forwarded-for` is forwarded verbatim and the real client IP is never
+   * added. On an internet-facing server (no trusted proxy in front), strip
+   * incoming values first with `filterHeaders: ["x-forwarded-for"]` if the
+   * upstream trusts this header for allowlisting, rate limiting, or logging.
+   *
+   * Only applied by `proxyRequest` (which forwards the incoming request);
+   * the lower-level `proxy` ignores this option.
    *
    * @default false
    */
@@ -138,11 +156,15 @@ export async function proxyRequest(
   // Request Body
   // Forward the body based on presence, not a method allowlist, so bodies on
   // WebDAV-style (PROPFIND/REPORT/SEARCH) and custom methods are not dropped.
-  // GET/HEAD are excluded because fetch rejects a body on those methods.
+  // GET/HEAD are excluded — keyed off the OUTGOING method (a caller can
+  // override it via `fetchOptions.method`) because fetch rejects a body on
+  // those methods.
   const method = opts.fetchOptions?.method || event.req.method;
+  const methodUpper = method.toUpperCase();
+  const incomingBody = event.req.body;
   const requestBody =
-    event.req.body != null && event.req.method !== "GET" && event.req.method !== "HEAD"
-      ? event.req.body
+    incomingBody != null && methodUpper !== "GET" && methodUpper !== "HEAD"
+      ? incomingBody
       : undefined;
 
   // Headers
@@ -155,6 +177,18 @@ export async function proxyRequest(
     opts.fetchOptions?.headers,
     opts.headers,
   );
+
+  // When the forwarded body is not the incoming request's own stream, the
+  // incoming `content-length` no longer describes it — and fetch trusts a
+  // caller-supplied `content-length` verbatim, mis-framing the upstream
+  // request. Drop it and let fetch derive the framing from the actual body.
+  if ((opts.fetchOptions && "body" in opts.fetchOptions) || (incomingBody && !requestBody)) {
+    if (fetchHeaders instanceof Headers) {
+      fetchHeaders.delete("content-length");
+    } else if (!Array.isArray(fetchHeaders)) {
+      delete (fetchHeaders as Record<string, string>)["content-length"];
+    }
+  }
 
   // Derive `duplex` from the FINAL body (a caller may override it via
   // `opts.fetchOptions.body`), so a streamed override on a body-less incoming
@@ -192,7 +226,10 @@ export async function proxyRequest(
  * rewritten to the target (preserving it via `forwardHeaders: ["host"]` works on
  * Node.js but may be ignored on other runtimes), and unix sockets, TLS options,
  * or connection agents require a runtime-specific escape hatch (e.g. undici's
- * `dispatcher` in `fetchOptions` on Node.js).
+ * `dispatcher` in `fetchOptions` on Node.js). On browser and service-worker
+ * runtimes, `redirect: "manual"` produces an unrelayable opaque-redirect for
+ * external targets (a `502` is returned) — set
+ * `fetchOptions: { redirect: "follow" }` there.
  *
  * **Security:** Never pass unsanitized user input as the `target`. Callers are
  * responsible for validating and restricting the target URL (e.g. allowlisting
@@ -214,24 +251,43 @@ export async function proxy(
   if (opts.fetchOptions?.signal) {
     signals.push(opts.fetchOptions.signal);
   }
-  if (opts.timeout) {
-    signals.push(AbortSignal.timeout(opts.timeout));
+  // A cancelable timer (not `AbortSignal.timeout`) so the deadline only covers
+  // waiting for the response: it is cleared as soon as the upstream responds
+  // and can never abort a long-running body stream mid-flight.
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  if (opts.timeout! > 0 && Number.isFinite(opts.timeout)) {
+    const timeoutController = new AbortController();
+    timeoutId = setTimeout(
+      () => timeoutController.abort(new DOMException("Proxy request timed out", "TimeoutError")),
+      // setTimeout clamps anything above its int32 limit down to 1ms — treat
+      // larger deadlines as "practically no timeout" instead.
+      Math.min(Math.trunc(opts.timeout!), 2_147_483_647),
+    );
+    signals.push(timeoutController.signal);
   }
+  const signal = signals.length > 1 ? AbortSignal.any(signals) : signals[0]!;
   const fetchOptions: RequestInit = {
     headers: opts.headers as HeadersInit,
-    // Default to passing upstream 3xx responses through to the client instead of
-    // silently following them. Placed before the spread so an explicit
-    // `fetchOptions.redirect` from the caller still wins.
-    redirect: "manual",
     ...opts.fetchOptions,
-    signal: signals.length > 1 ? AbortSignal.any(signals) : signals[0],
+    // Default to passing upstream 3xx responses through to the client instead
+    // of silently following them. `?? "manual"` (instead of a default before
+    // the spread) so even an explicit `redirect: undefined` cannot silently
+    // restore fetch's follow behavior.
+    redirect: opts.fetchOptions?.redirect ?? "manual",
+    signal,
   };
 
   let response: Response | undefined;
   try {
+    // `H3.fetch()` does not observe the request signal, so race internal
+    // sub-requests against it explicitly — otherwise `timeout` and client
+    // disconnects would be silent no-ops for internal (`/`) targets.
     response =
       target[0] === "/"
-        ? await event.app!.fetch(createSubRequest(event, target, fetchOptions))
+        ? await abortable(
+            () => event.app!.fetch(createSubRequest(event, target, fetchOptions)),
+            signal,
+          )
         : await fetch(target, fetchOptions);
   } catch (error) {
     // A fired timeout signal aborts with a `TimeoutError`. Map it (including a
@@ -256,23 +312,45 @@ export async function proxy(
       }
     }
     throw new HTTPError({ status: 502, cause: error });
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  // Browser/service-worker fetch filters `redirect: "manual"` 3xx responses
+  // into an opaque-redirect (status 0, no headers) that cannot be relayed.
+  // Fail loudly instead of returning an empty response.
+  if (response.type === "opaqueredirect") {
+    throw new HTTPError({
+      status: 502,
+      message:
+        'Cannot relay an opaque redirect response on this runtime. Set `fetchOptions: { redirect: "follow" }` to follow upstream redirects instead.',
+    });
   }
 
   const headers = new Headers();
 
-  const cookies: string[] = [];
+  // Also strip response headers the upstream marked hop-by-hop via its
+  // `Connection` header (RFC 7230 §6.1), on top of the static denylist.
+  const connectionNominated = new Set(
+    (response.headers.get("connection") || "")
+      .toLowerCase()
+      .split(",")
+      .map((name) => name.trim())
+      .filter(Boolean),
+  );
 
   for (const [key, value] of response.headers.entries()) {
-    if (ignoredResponseHeaders.has(key)) {
-      continue;
-    }
-    if (key === "set-cookie") {
-      cookies.push(value);
+    if (ignoredResponseHeaders.has(key) || connectionNominated.has(key) || key === "set-cookie") {
       continue;
     }
     headers.append(key, value);
   }
 
+  // `getSetCookie()` is the only spec-guaranteed way to get each `set-cookie`
+  // value separately (cookie attributes may contain commas).
+  const cookies = response.headers.getSetCookie();
   if (cookies.length > 0) {
     const _cookies = cookies.map((cookie) => {
       if (opts.cookieDomainRewrite) {

--- a/src/utils/static.ts
+++ b/src/utils/static.ts
@@ -3,7 +3,7 @@ import { HTTPError } from "../error.ts";
 import { withoutTrailingSlash } from "./internal/path.ts";
 import { resolveDotSegments } from "./path.ts";
 import { getType, getExtension } from "./internal/mime.ts";
-import { matchETag } from "./internal/cache.ts";
+import { isCacheMatch } from "./internal/cache.ts";
 import { HTTPResponse } from "../response.ts";
 
 export interface StaticAssetMeta {
@@ -164,19 +164,7 @@ export async function serveStatic(
     event.res.headers.set("etag", meta.etag);
   }
 
-  // RFC 9110 §13.1.3: a recipient MUST ignore `If-Modified-Since` when the
-  // request contains an `If-None-Match` header field. `If-None-Match` takes
-  // precedence; `If-Modified-Since` is only evaluated when it is absent.
-  let cacheMatched = false;
-  const ifNoneMatch = event.req.headers.get("if-none-match");
-  if (ifNoneMatch) {
-    cacheMatched = !!meta.etag && matchETag(ifNoneMatch, meta.etag);
-  } else if (mtimeDate) {
-    const ifModifiedSinceH = event.req.headers.get("if-modified-since");
-    cacheMatched = !!ifModifiedSinceH && new Date(ifModifiedSinceH) >= mtimeDate;
-  }
-
-  if (cacheMatched) {
+  if (isCacheMatch(event.req.headers, { etag: meta.etag, lastModified: mtimeDate })) {
     return new HTTPResponse(null, {
       status: 304,
       statusText: "Not Modified",

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -725,6 +725,44 @@ describeMatrix("proxy", (t, { it, expect, describe }) => {
             }
           },
         );
+
+        it.runIf(t.target === "web")(
+          "replaces the first matching prefix with a locationRewrite record",
+          async () => {
+            const fetchMock = mockUpstream({ location: "https://upstream.test/two/some/uri?x=1" });
+            try {
+              t.app.all("/", (event) =>
+                proxyRequest(event, "https://upstream.test/test", {
+                  locationRewrite: {
+                    "https://other.test/": "/none/",
+                    "https://upstream.test/two/": "/one/",
+                  },
+                }),
+              );
+
+              const res = await t.fetch("/", { redirect: "manual" });
+              expect(res.headers.get("location")).toBe("/one/some/uri?x=1");
+            } finally {
+              fetchMock.mockRestore();
+            }
+          },
+        );
+
+        it("applies a locationRewrite record to internal targets too", async () => {
+          t.app.all("/sub/redirect", (event) => {
+            event.res.headers.set("location", "/sub/moved");
+            return new Response(null, { status: 302, headers: event.res.headers });
+          });
+          t.app.all("/", (event) =>
+            proxy(event, "/sub/redirect", {
+              locationRewrite: { "/sub/": "/" },
+            }),
+          );
+
+          const res = await t.fetch("/", { redirect: "manual" });
+          expect(res.status).toBe(302);
+          expect(res.headers.get("location")).toBe("/moved");
+        });
       });
 
       it(

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -476,16 +476,24 @@ describeMatrix("proxy", (t, { it, expect, describe }) => {
       );
 
       it.runIf(t.target === "web")(
-        "forwards the client abort signal to the proxied request",
+        "responds 499 for internal targets when the client is already gone",
         async () => {
-          t.app.all("/debug", (event) => ({ aborted: event.req.signal.aborted }));
+          // Consistent with external targets: a pre-aborted client signal
+          // short-circuits the internal sub-request into a quiet 499 (the
+          // signal is still attached to the sub-request for mid-flight aborts).
+          let handled = false;
+          t.app.all("/debug", () => {
+            handled = true;
+            return "hello";
+          });
           t.app.all("/", (event) => proxyRequest(event, "/debug"));
 
           const controller = new AbortController();
           controller.abort();
 
           const res = await t.fetch("/", { signal: controller.signal });
-          expect(await res.json()).toMatchObject({ aborted: true });
+          expect(res.status).toBe(499);
+          expect(handled).toBe(false);
         },
       );
 
@@ -645,6 +653,162 @@ describeMatrix("proxy", (t, { it, expect, describe }) => {
         expect(await res.text()).toBe("fast");
       });
 
+      it.runIf(t.target === "web")(
+        "does not truncate a response body streaming past the timeout",
+        async () => {
+          // The upstream responds instantly but streams its body slowly, past
+          // the timeout. The deadline must only cover waiting for the response
+          // headers — it is cleared once they arrive and must never abort the
+          // body mid-stream.
+          const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation((_input, init) => {
+            const signal = (init as RequestInit | undefined)?.signal;
+            const encoder = new TextEncoder();
+            const body = new ReadableStream<Uint8Array>({
+              async start(controller) {
+                controller.enqueue(encoder.encode("first"));
+                await new Promise((r) => setTimeout(r, 150));
+                if (signal?.aborted) {
+                  controller.error(signal.reason);
+                  return;
+                }
+                controller.enqueue(encoder.encode("second"));
+                controller.close();
+              },
+            });
+            return Promise.resolve(new Response(body, { status: 200 }));
+          });
+
+          try {
+            t.app.all("/", (event) =>
+              proxyRequest(event, "https://upstream.test/", { timeout: 50 }),
+            );
+
+            const res = await t.fetch("/");
+            expect(res.status).toBe(200);
+            expect(await res.text()).toBe("firstsecond");
+          } finally {
+            fetchMock.mockRestore();
+          }
+        },
+      );
+
+      it("responds 504 when an internal target exceeds the timeout", async () => {
+        t.app.all("/slow", async () => {
+          await new Promise((r) => setTimeout(r, 300));
+          return "late";
+        });
+        t.app.all("/", (event) => proxy(event, "/slow", { timeout: 50 }));
+
+        const res = await t.fetch("/");
+        expect(res.status).toBe(504);
+      });
+
+      it.runIf(t.target === "web")(
+        "keeps manual redirect mode for an explicitly undefined redirect option",
+        async () => {
+          let redirectMode: unknown = "unset";
+          const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation((_input, init) => {
+            redirectMode = (init as RequestInit | undefined)?.redirect;
+            return Promise.resolve(new Response("ok"));
+          });
+
+          try {
+            t.app.all("/", (event) =>
+              proxyRequest(event, "https://upstream.test/", {
+                fetchOptions: { redirect: undefined },
+              }),
+            );
+
+            await t.fetch("/");
+            expect(redirectMode).toBe("manual");
+          } finally {
+            fetchMock.mockRestore();
+          }
+        },
+      );
+
+      it.runIf(t.target === "web")("fails loudly on an opaque redirect response", async () => {
+        // Browser/service-worker fetch filters manual-mode 3xx into an
+        // opaque redirect (status 0) that cannot be relayed.
+        const fetchMock = vi
+          .spyOn(globalThis, "fetch")
+          .mockImplementation(() => Promise.resolve({ type: "opaqueredirect" } as Response));
+
+        try {
+          t.app.all("/", (event) => proxyRequest(event, "https://upstream.test/"));
+
+          const res = await t.fetch("/");
+          expect(res.status).toBe(502);
+        } finally {
+          fetchMock.mockRestore();
+        }
+      });
+
+      it("drops the body when the outgoing method is overridden to GET", async () => {
+        t.app.all("/debug", async (event) => ({
+          method: event.req.method,
+          body: await event.req.text(),
+        }));
+        t.app.all("/", (event) =>
+          proxyRequest(event, "/debug", { fetchOptions: { method: "GET" } }),
+        );
+
+        const result = await t.fetch("/", { method: "POST", body: "hello" }).then((r) => r.json());
+
+        expect(result).toMatchObject({ method: "GET", body: "" });
+      });
+
+      it("drops the stale content-length when the body is overridden", async () => {
+        t.app.all("/debug", async (event) => ({
+          contentLength: event.req.headers.get("content-length"),
+          body: await event.req.text(),
+        }));
+        t.app.all("/", (event) =>
+          proxyRequest(event, "/debug", { fetchOptions: { body: "short" } }),
+        );
+
+        const result = await t
+          .fetch("/", {
+            method: "POST",
+            body: "a-much-longer-payload",
+            headers: { "content-type": "text/plain" },
+          })
+          .then((r) => r.json());
+
+        expect(result.body).toBe("short");
+        // The incoming request's content-length must not describe the new body.
+        expect(result.contentLength).not.toBe("21");
+      });
+
+      it("strips response headers nominated by the upstream connection header", async () => {
+        t.app.all("/debug", (event) => {
+          event.res.headers.set("connection", "x-internal-token");
+          event.res.headers.set("x-internal-token", "secret");
+          event.res.headers.set("x-keep", "kept");
+          return "hello";
+        });
+        t.app.all("/", (event) => proxyRequest(event, "/debug"));
+
+        const res = await t.fetch("/");
+        expect(res.headers.has("x-internal-token")).toBe(false);
+        expect(res.headers.get("x-keep")).toBe("kept");
+        expect(await res.text()).toBe("hello");
+      });
+
+      it.runIf(t.target === "web")("does not forward te/trailer request headers", async () => {
+        t.app.all("/debug", (event) => ({
+          headers: Object.fromEntries(event.req.headers.entries()),
+        }));
+        t.app.all("/", (event) => proxyRequest(event, "/debug"));
+
+        const result = await t
+          .fetch("/", { headers: { te: "trailers", trailer: "x-checksum" } })
+          .then((r) => r.json());
+
+        expect(result.headers.te).toBeUndefined();
+        expect(result.headers.trailer).toBeUndefined();
+      });
+
       describe("location rewrite", () => {
         const mockUpstream = (headers: Record<string, string>) =>
           vi
@@ -747,6 +911,46 @@ describeMatrix("proxy", (t, { it, expect, describe }) => {
             }
           },
         );
+
+        it.runIf(t.target === "web")(
+          "rewrites a protocol-relative location pointing at the target",
+          async () => {
+            const fetchMock = mockUpstream({ location: "//upstream.test/foo" });
+            try {
+              let origin = "";
+              t.app.all("/", (event) => {
+                origin = event.url.origin;
+                return proxyRequest(event, "https://upstream.test/test");
+              });
+
+              const res = await t.fetch("/", { redirect: "manual" });
+              expect(res.headers.get("location")).toBe(`${origin}/foo`);
+            } finally {
+              fetchMock.mockRestore();
+            }
+          },
+        );
+
+        it.runIf(t.target === "web")("rewrites non-canonical refresh header shapes", async () => {
+          let origin = "";
+          t.app.all("/", (event) => {
+            origin = event.url.origin;
+            return proxyRequest(event, "https://upstream.test/test");
+          });
+
+          for (const [refresh, expected] of [
+            ["url=https://upstream.test/x", () => `url=${origin}/x`],
+            ["0; url='https://upstream.test/x'", () => `0; url='${origin}/x'`],
+          ] as const) {
+            const fetchMock = mockUpstream({ refresh });
+            try {
+              const res = await t.fetch("/", { redirect: "manual" });
+              expect(res.headers.get("refresh")).toBe(expected());
+            } finally {
+              fetchMock.mockRestore();
+            }
+          }
+        });
 
         it("applies a locationRewrite record to internal targets too", async () => {
           t.app.all("/sub/redirect", (event) => {

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -264,6 +264,69 @@ describeMatrix("proxy", (t, { it, expect, describe }) => {
         expect(result.headers["x-keep"]).toBe("kept");
       });
 
+      // Node's transport layer manages the `connection` header, so a custom
+      // nomination only survives the round-trip on the web target.
+      it.runIf(t.target === "web")(
+        "does not forward request headers nominated by the incoming Connection header",
+        async () => {
+          t.app.all("/debug", (event) => {
+            return { headers: Object.fromEntries(event.req.headers.entries()) };
+          });
+          t.app.all("/", (event) => proxyRequest(event, "/debug"));
+
+          const result = await t
+            .fetch("/", {
+              headers: {
+                connection: "x-internal-auth, keep-alive",
+                "x-internal-auth": "secret",
+                "x-keep": "kept",
+              },
+            })
+            .then((r) => r.json());
+
+          // RFC 9110 §7.6.1: fields nominated by `Connection` are hop-by-hop.
+          expect(result.headers["x-internal-auth"]).toBeUndefined();
+          expect(result.headers["x-keep"]).toBe("kept");
+        },
+      );
+
+      it("does not forward proxy-authorization / proxy-connection by default", async () => {
+        t.app.all("/debug", (event) => {
+          return { headers: Object.fromEntries(event.req.headers.entries()) };
+        });
+        t.app.all("/", (event) => proxyRequest(event, "/debug"));
+
+        const result = await t
+          .fetch("/", {
+            headers: {
+              "proxy-authorization": "Basic c2VjcmV0",
+              "proxy-connection": "keep-alive",
+            },
+          })
+          .then((r) => r.json());
+
+        expect(result.headers["proxy-authorization"]).toBeUndefined();
+        expect(result.headers["proxy-connection"]).toBeUndefined();
+      });
+
+      it("lets filterHeaders win over forwardHeaders", async () => {
+        t.app.all("/debug", (event) => {
+          return { headers: Object.fromEntries(event.req.headers.entries()) };
+        });
+        t.app.all("/", (event) =>
+          proxyRequest(event, "/debug", {
+            forwardHeaders: ["x-both"],
+            filterHeaders: ["x-both"],
+          }),
+        );
+
+        const result = await t
+          .fetch("/", { headers: { "x-both": "secret" } })
+          .then((r) => r.json());
+
+        expect(result.headers["x-both"]).toBeUndefined();
+      });
+
       it("strips hop-by-hop headers from the proxied response", async () => {
         t.app.all("/debug", (event) => {
           // Hop-by-hop response headers that must not leak to the client.
@@ -512,6 +575,22 @@ describeMatrix("proxy", (t, { it, expect, describe }) => {
       );
 
       it.runIf(t.target === "web")(
+        "treats a client disconnect aborting with a non-AbortError (ECONNRESET) as 499",
+        async () => {
+          // srvx on Node aborts a client disconnect with the raw socket error
+          // (name "Error", not "AbortError"). Classifying by the composed signal
+          // reason — not the thrown error's name — must still yield a quiet 499.
+          t.app.all("/", (event) => proxyRequest(event, "https://example.test/"));
+
+          const controller = new AbortController();
+          controller.abort(Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }));
+
+          const res = await t.fetch("/", { signal: controller.signal });
+          expect(res.status).toBe(499);
+        },
+      );
+
+      it.runIf(t.target === "web")(
         "propagates the abort error when `propagateAbortError` is enabled",
         async () => {
           let caught: unknown;
@@ -745,6 +824,25 @@ describeMatrix("proxy", (t, { it, expect, describe }) => {
         const fetchMock = vi
           .spyOn(globalThis, "fetch")
           .mockImplementation(() => Promise.resolve({ type: "opaqueredirect" } as Response));
+
+        try {
+          t.app.all("/", (event) => proxyRequest(event, "https://upstream.test/"));
+
+          const res = await t.fetch("/");
+          expect(res.status).toBe(502);
+        } finally {
+          fetchMock.mockRestore();
+        }
+      });
+
+      it.runIf(t.target === "web")("fails loudly on an opaque (status 0) response", async () => {
+        // A `no-cors` fetch yields an opaque response with status 0 and no
+        // readable headers/body. Relaying it would surface an empty 200.
+        const fetchMock = vi
+          .spyOn(globalThis, "fetch")
+          .mockImplementation(() =>
+            Promise.resolve({ type: "opaque", status: 0, headers: new Headers() } as Response),
+          );
 
         try {
           t.app.all("/", (event) => proxyRequest(event, "https://upstream.test/"));

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -18,6 +18,29 @@ describeMatrix("proxy", (t, { it, expect, describe }) => {
 
         expect(await result.text()).toBe("hello");
       });
+
+      it.runIf(t.target === "node")(
+        "passes upstream redirects through to the client by default",
+        async () => {
+          t.app.all("/redirect", (event) => {
+            event.res.headers.set("location", "https://example.test/moved");
+            return new Response(null, {
+              status: 302,
+              headers: event.res.headers,
+            });
+          });
+          // Proxy to an absolute URL so the external `fetch()` path is exercised.
+          t.app.all("/", (event) => {
+            return proxy(event, `${t.url}/redirect`);
+          });
+
+          const result = await t.fetch("/", { redirect: "manual" });
+
+          // The 3xx response is passed through verbatim, not followed.
+          expect(result.status).toBe(302);
+          expect(result.headers.get("location")).toBe("https://example.test/moved");
+        },
+      );
     });
 
     describe("proxyRequest()", () => {

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -395,6 +395,41 @@ describeMatrix("proxy", (t, { it, expect, describe }) => {
         },
       );
 
+      it.runIf(t.target === "web")(
+        "responds with 504 when the upstream exceeds the timeout",
+        async () => {
+          // Upstream never resolves until its request signal aborts. The
+          // composed `AbortSignal.timeout` fires with a `TimeoutError`, which the
+          // proxy maps to `504` (not the `502` generic gateway error).
+          const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation((_input, init) => {
+            const signal = (init as RequestInit | undefined)?.signal ?? undefined;
+            return new Promise<Response>((_resolve, reject) => {
+              signal?.addEventListener("abort", () => reject(signal.reason));
+            });
+          });
+
+          try {
+            t.app.all("/", (event) =>
+              proxyRequest(event, "https://upstream.test/", { timeout: 50 }),
+            );
+
+            const res = await t.fetch("/");
+            expect(res.status).toBe(504);
+          } finally {
+            fetchMock.mockRestore();
+          }
+        },
+      );
+
+      it("succeeds within a generous timeout", async () => {
+        t.app.all("/fast", () => "fast");
+        t.app.all("/", (event) => proxy(event, "/fast", { timeout: 1000 }));
+
+        const res = await t.fetch("/");
+        expect(res.status).toBe(200);
+        expect(await res.text()).toBe("fast");
+      });
+
       it(
         "can handle failed proxy requests gracefully",
         async () => {

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -115,6 +115,68 @@ describeMatrix("proxy", (t, { it, expect, describe }) => {
         expect(result.headers["accept-encoding"]).toBeUndefined();
       });
 
+      it("forwards the incoming accept header to the upstream", async () => {
+        t.app.all("/debug", (event) => {
+          return { accept: event.req.headers.get("accept") };
+        });
+
+        t.app.all("/", (event) => {
+          return proxyRequest(event, "/debug");
+        });
+
+        const result = await t
+          .fetch("/", {
+            headers: { accept: "application/json" },
+          })
+          .then((r) => r.json());
+
+        expect(result.accept).toBe("application/json");
+      });
+
+      it("does not forward headers listed in filterHeaders (case-insensitive)", async () => {
+        t.app.all("/debug", (event) => {
+          return { headers: Object.fromEntries(event.req.headers.entries()) };
+        });
+
+        t.app.all("/", (event) => {
+          return proxyRequest(event, "/debug", {
+            // Mixed-case option must still match the lowercased header name.
+            filterHeaders: ["X-Custom"],
+          });
+        });
+
+        const result = await t
+          .fetch("/", {
+            headers: { "x-custom": "secret", "x-keep": "kept" },
+          })
+          .then((r) => r.json());
+
+        expect(result.headers["x-custom"]).toBeUndefined();
+        expect(result.headers["x-keep"]).toBe("kept");
+      });
+
+      it("strips hop-by-hop headers from the proxied response", async () => {
+        t.app.all("/debug", (event) => {
+          // Hop-by-hop response headers that must not leak to the client.
+          event.res.headers.set("proxy-authenticate", "Basic");
+          event.res.headers.set("trailer", "Expires");
+          // A normal header that must be preserved.
+          event.res.headers.set("x-custom-header", "preserved");
+          return "hello";
+        });
+
+        t.app.all("/", (event) => {
+          return proxyRequest(event, "/debug");
+        });
+
+        const res = await t.fetch("/", { method: "GET" });
+
+        expect(res.headers.has("proxy-authenticate")).toBe(false);
+        expect(res.headers.has("trailer")).toBe(false);
+        expect(res.headers.get("x-custom-header")).toBe("preserved");
+        expect(await res.text()).toBe("hello");
+      });
+
       it("can proxy binary request", async () => {
         t.app.all("/debug", async (event) => {
           const body = await event.req.arrayBuffer();

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -115,6 +115,53 @@ describeMatrix("proxy", (t, { it, expect, describe }) => {
         expect(result.headers["accept-encoding"]).toBeUndefined();
       });
 
+      describe("xfwd", () => {
+        beforeEach(() => {
+          t.app.all("/debug", (event) => {
+            return { headers: Object.fromEntries(event.req.headers.entries()) };
+          });
+        });
+
+        it("adds x-forwarded-* headers when enabled", async () => {
+          t.app.all("/", (event) => {
+            return proxyRequest(event, "/debug", { xfwd: true });
+          });
+
+          const result = await t.fetch("/").then((r) => r.json());
+          const headers = result.headers;
+
+          expect(headers["x-forwarded-proto"]).toBe("http");
+          expect(headers["x-forwarded-host"]).toBeTruthy();
+          expect(headers["x-forwarded-port"]).toBeTruthy();
+        });
+
+        it("appends the client ip to an existing x-forwarded-for", async () => {
+          t.app.all("/", (event) => {
+            return proxyRequest(event, "/debug", { xfwd: true });
+          });
+
+          const result = await t
+            .fetch("/", {
+              headers: { "x-forwarded-for": "1.2.3.4" },
+            })
+            .then((r) => r.json());
+
+          // The original value is preserved and possibly extended with the
+          // client ip (which may be undefined in web mode, `::1`/`127.0.0.1`
+          // in node mode), so assert the prefix rather than an exact match.
+          expect(result.headers["x-forwarded-for"]).toMatch(/^1\.2\.3\.4/);
+        });
+
+        it("does not add x-forwarded-* headers by default", async () => {
+          t.app.all("/", (event) => {
+            return proxyRequest(event, "/debug");
+          });
+
+          const result = await t.fetch("/").then((r) => r.json());
+          expect(result.headers["x-forwarded-proto"]).toBeUndefined();
+        });
+      });
+
       it("can proxy binary request", async () => {
         t.app.all("/debug", async (event) => {
           const body = await event.req.arrayBuffer();

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -306,7 +306,7 @@ describeMatrix("proxy", (t, { it, expect, describe }) => {
           expect(headers["x-forwarded-port"]).toBeTruthy();
         });
 
-        it("appends the client ip to an existing x-forwarded-for", async () => {
+        it("does not override an existing x-forwarded-for", async () => {
           t.app.all("/", (event) => {
             return proxyRequest(event, "/debug", { xfwd: true });
           });
@@ -317,10 +317,7 @@ describeMatrix("proxy", (t, { it, expect, describe }) => {
             })
             .then((r) => r.json());
 
-          // The original value is preserved and possibly extended with the
-          // client ip (which may be undefined in web mode, `::1`/`127.0.0.1`
-          // in node mode), so assert the prefix rather than an exact match.
-          expect(result.headers["x-forwarded-for"]).toMatch(/^1\.2\.3\.4/);
+          expect(result.headers["x-forwarded-for"]).toBe("1.2.3.4");
         });
 
         it("does not add x-forwarded-* headers by default", async () => {

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -653,6 +653,18 @@ describeMatrix("proxy", (t, { it, expect, describe }) => {
         expect(await res.text()).toBe("fast");
       });
 
+      it("does not treat a sub-millisecond timeout as an immediate deadline", async () => {
+        // `Math.trunc(0.5)` is `0`, which would schedule `setTimeout(..., 0)`
+        // and abort on the next tick — 504-ing every request. A positive
+        // timeout must clamp up to at least 1ms.
+        t.app.all("/fast", () => "fast");
+        t.app.all("/", (event) => proxy(event, "/fast", { timeout: 0.5 }));
+
+        const res = await t.fetch("/");
+        expect(res.status).toBe(200);
+        expect(await res.text()).toBe("fast");
+      });
+
       it.runIf(t.target === "web")(
         "does not truncate a response body streaming past the timeout",
         async () => {

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -645,6 +645,88 @@ describeMatrix("proxy", (t, { it, expect, describe }) => {
         expect(await res.text()).toBe("fast");
       });
 
+      describe("location rewrite", () => {
+        const mockUpstream = (headers: Record<string, string>) =>
+          vi
+            .spyOn(globalThis, "fetch")
+            .mockImplementation(() =>
+              Promise.resolve(new Response(null, { status: 302, headers })),
+            );
+
+        it.runIf(t.target === "web")(
+          "rewrites a location pointing at the target to the proxy origin",
+          async () => {
+            const fetchMock = mockUpstream({ location: "https://upstream.test/foo/bar?q=1" });
+            try {
+              let origin = "";
+              t.app.all("/", (event) => {
+                origin = event.url.origin;
+                return proxyRequest(event, "https://upstream.test/test");
+              });
+
+              const res = await t.fetch("/", { redirect: "manual" });
+              expect(res.status).toBe(302);
+              expect(res.headers.get("location")).toBe(`${origin}/foo/bar?q=1`);
+            } finally {
+              fetchMock.mockRestore();
+            }
+          },
+        );
+
+        it.runIf(t.target === "web")(
+          "rewrites a refresh header pointing at the target",
+          async () => {
+            const fetchMock = mockUpstream({ refresh: "5; url=https://upstream.test/foo" });
+            try {
+              let origin = "";
+              t.app.all("/", (event) => {
+                origin = event.url.origin;
+                return proxyRequest(event, "https://upstream.test/test");
+              });
+
+              const res = await t.fetch("/", { redirect: "manual" });
+              expect(res.headers.get("refresh")).toBe(`5; url=${origin}/foo`);
+            } finally {
+              fetchMock.mockRestore();
+            }
+          },
+        );
+
+        it.runIf(t.target === "web")(
+          "leaves third-party and relative locations untouched",
+          async () => {
+            t.app.all("/", (event) => proxyRequest(event, "https://upstream.test/test"));
+
+            for (const location of ["https://other.test/moved", "/foo/bar"]) {
+              const fetchMock = mockUpstream({ location });
+              try {
+                const res = await t.fetch("/", { redirect: "manual" });
+                expect(res.headers.get("location")).toBe(location);
+              } finally {
+                fetchMock.mockRestore();
+              }
+            }
+          },
+        );
+
+        it.runIf(t.target === "web")(
+          "forwards the location verbatim with locationRewrite: false",
+          async () => {
+            const fetchMock = mockUpstream({ location: "https://upstream.test/foo" });
+            try {
+              t.app.all("/", (event) =>
+                proxyRequest(event, "https://upstream.test/test", { locationRewrite: false }),
+              );
+
+              const res = await t.fetch("/", { redirect: "manual" });
+              expect(res.headers.get("location")).toBe("https://upstream.test/foo");
+            } finally {
+              fetchMock.mockRestore();
+            }
+          },
+        );
+      });
+
       it(
         "can handle failed proxy requests gracefully",
         async () => {

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { vi, beforeEach } from "vitest";
 import { setCookie } from "../src/index.ts";
-import { proxy, proxyRequest } from "../src/utils/proxy.ts";
+import { fetchWithEvent, proxy, proxyRequest } from "../src/utils/proxy.ts";
 import { describeMatrix } from "./_setup.ts";
 
 describeMatrix("proxy", (t, { it, expect, describe }) => {
@@ -94,6 +94,92 @@ describeMatrix("proxy", (t, { it, expect, describe }) => {
         expect(result).toMatchObject({
           method: "QUERY",
           body: "query body",
+        });
+      });
+
+      it("forwards the body of a custom method (not just the payload allowlist)", async () => {
+        t.app.all("/debug", async (event) => {
+          return {
+            method: event.req.method,
+            body: await event.req.text(),
+          };
+        });
+
+        t.app.all("/", (event) => {
+          return proxyRequest(event, "/debug");
+        });
+
+        const result = await t
+          .fetch("/", {
+            method: "REPORT",
+            body: "report body",
+            headers: {
+              "content-type": "text/plain",
+            },
+          })
+          .then((r) => r.json());
+
+        expect(result).toMatchObject({
+          method: "REPORT",
+          body: "report body",
+        });
+      });
+
+      it("sets duplex when a stream body is supplied via fetchOptions on a GET event", async () => {
+        t.app.all("/debug", async (event) => {
+          return {
+            method: event.req.method,
+            body: await event.req.text(),
+          };
+        });
+
+        t.app.all("/", (event) => {
+          const body = new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("override body"));
+              controller.close();
+            },
+          });
+          // Incoming event is a GET (no body); the caller supplies a stream body
+          // and overrides the method. `duplex` must be derived from this final
+          // body or the underlying fetch/Request throws.
+          return proxyRequest(event, "/debug", {
+            fetchOptions: { method: "POST", body },
+          });
+        });
+
+        const result = await t.fetch("/", { method: "GET" }).then((r) => r.json());
+
+        expect(result).toMatchObject({
+          method: "POST",
+          body: "override body",
+        });
+      });
+
+      it("fetchWithEvent forwards a stream body without throwing on duplex", async () => {
+        t.app.all("/debug", async (event) => {
+          return {
+            method: event.req.method,
+            body: await event.req.text(),
+          };
+        });
+
+        t.app.all("/", async (event) => {
+          const body = new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("stream body"));
+              controller.close();
+            },
+          });
+          const res = await fetchWithEvent(event, "/debug", { method: "POST", body });
+          return res.json();
+        });
+
+        const result = await t.fetch("/", { method: "GET" }).then((r) => r.json());
+
+        expect(result).toMatchObject({
+          method: "POST",
+          body: "stream body",
         });
       });
 

--- a/test/unit/proxy.test.ts
+++ b/test/unit/proxy.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { ignoredHeaders, ignoredResponseHeaders } from "../../src/utils/internal/proxy.ts";
+import {
+  ignoredHeaders,
+  ignoredResponseHeaders,
+  rewriteCookieProperty,
+} from "../../src/utils/internal/proxy.ts";
 
 describe("proxy internal header sets", () => {
   it("does not strip the incoming accept header but keeps accept-encoding", () => {
@@ -22,5 +26,33 @@ describe("proxy internal header sets", () => {
     ]) {
       expect(ignoredResponseHeaders.has(key)).toBe(true);
     }
+  });
+
+  it("drops hop-by-hop request credentials/controls by default", () => {
+    expect(ignoredHeaders.has("proxy-authorization")).toBe(true);
+    expect(ignoredHeaders.has("proxy-connection")).toBe(true);
+  });
+});
+
+describe("rewriteCookieProperty", () => {
+  it("applies own exact and wildcard mappings", () => {
+    expect(
+      rewriteCookieProperty(
+        "foo=bar; Domain=old.example",
+        { "old.example": "new.example" },
+        "domain",
+      ),
+    ).toBe("foo=bar; Domain=new.example");
+    expect(
+      rewriteCookieProperty("foo=bar; Domain=any.example", { "*": "new.example" }, "domain"),
+    ).toBe("foo=bar; Domain=new.example");
+  });
+
+  it("ignores inherited (prototype-polluted) map properties", () => {
+    // Simulate prototype pollution without mutating the global prototype: the
+    // mappings live on `map`'s prototype, so they are inherited, not own.
+    const map = Object.create({ "old.example": "evil.example", "*": "evil.example" });
+    const cookie = "foo=bar; Domain=old.example; Path=/";
+    expect(rewriteCookieProperty(cookie, map, "domain")).toBe(cookie);
   });
 });

--- a/test/unit/proxy.test.ts
+++ b/test/unit/proxy.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { ignoredHeaders, ignoredResponseHeaders } from "../../src/utils/internal/proxy.ts";
+
+describe("proxy internal header sets", () => {
+  it("does not strip the incoming accept header but keeps accept-encoding", () => {
+    expect(ignoredHeaders.has("accept")).toBe(false);
+    expect(ignoredHeaders.has("accept-encoding")).toBe(true);
+  });
+
+  it("strips hop-by-hop and length/encoding response headers", () => {
+    for (const key of [
+      "content-encoding",
+      "content-length",
+      "transfer-encoding",
+      "connection",
+      "keep-alive",
+      "proxy-authenticate",
+      "proxy-connection",
+      "upgrade",
+      "trailer",
+      "te",
+    ]) {
+      expect(ignoredResponseHeaders.has(key)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Improvements to the `proxy` / `proxyRequest` / `fetchWithEvent` utils, based on a comparison with [httpxy](https://github.com/unjs/httpxy)'s `proxyFetch`.

### Fixes

- **Do not follow upstream redirects by default** (8823fb7): `proxy()` now defaults `redirect: "manual"`, so upstream 3xx responses are passed through to the client instead of undici silently following up to 20 hops. This also fixes a `502` when proxying a streamed request body to an upstream that redirects (the body cannot be replayed on redirect). Opt back in with `fetchOptions: { redirect: "follow" }`.
- **Header hygiene** (4f9c446):
  - The client's `accept` header is forwarded again (it was in `ignoredHeaders`, breaking upstream content negotiation).
  - Hop-by-hop upstream response headers (`connection`, `keep-alive`, `proxy-authenticate`, `proxy-connection`, `upgrade`, `trailer`, `te`) are now stripped via a new `ignoredResponseHeaders` set.
  - `forwardHeaders` / `filterHeaders` now match header names case-insensitively.
- **Body forwarding** (35cde0d):
  - Request bodies are forwarded based on presence instead of a `PATCH/POST/PUT/DELETE/QUERY` allowlist, so WebDAV-style (`PROPFIND`, `REPORT`, `SEARCH`) and custom methods keep their bodies (`PayloadMethods` removed as now-unused).
  - `duplex` is derived from the final body, so a stream supplied via `fetchOptions.body` on a body-less event no longer throws.
  - `createSubRequest` defaults `duplex: "half"` for stream bodies (`fetchWithEvent` path).

### Features

- **`timeout` option** (7fe8fcc): milliseconds to wait for the upstream response; composed into the existing signal handling via `AbortSignal.timeout`. Timeouts map to **`504 Gateway Timeout`** instead of a generic `502`. Client-disconnect (`499`) behavior is unchanged.
- **`xfwd` option** (b9f83aa, 56a87a3): adds `x-forwarded-for` / `x-forwarded-proto` / `x-forwarded-host` / `x-forwarded-port` derived from `event.req.ip` and `event.url`. Each header is only set when absent — values already present on the incoming request are never modified. Default `false`.
- **`location` rewriting, like nginx `proxy_redirect`** (874c5fb, 0ce0f9f): upstream `location` / `refresh` headers whose origin matches the proxy `target` are rewritten to the incoming request's origin, so client-side redirects keep flowing through the proxy instead of exposing the upstream host. Relative and third-party URLs (and internal `/` targets) are untouched. On by default; opt out with `locationRewrite: false`, or pass a record of prefix mappings (nginx `proxy_redirect <from> <to>`, e.g. `{ "https://upstream.example/two/": "/one/" }`) to replace explicit URL prefixes instead — first match wins, and mappings also apply to internal targets.

### Docs

- Documented `fetch`-inherited limitations (db3ab5c): forced response decompression, `host` rewrite portability across runtimes, and the undici `dispatcher` escape hatch for unix sockets / TLS options / agents.

### Review hardening (e2b0040)

A parallel security/correctness review of each changed area surfaced and fixed:

- `timeout` now uses a cancelable timer cleared once the upstream responds — it can no longer truncate long-running body streams (SSE, large downloads); invalid values are sanitized instead of throwing `RangeError`.
- `timeout` / client disconnects now also apply to internal (`/`) targets by racing `event.app.fetch()` against the request signal (`H3.fetch` does not observe it); a pre-aborted client short-circuits to `499` without dispatching the sub-request.
- An explicitly `undefined` `fetchOptions.redirect` can no longer silently restore fetch's follow default; browser/service-worker opaque-redirect responses fail loudly with `502` instead of an empty `200`.
- Body forwarding is gated on the outgoing (possibly overridden) method, and a stale incoming `content-length` is dropped when the forwarded body differs (fetch trusts a supplied `content-length` verbatim — framing desync).
- Response headers nominated by the upstream `Connection` header are stripped (RFC 7230 §6.1); `set-cookie` is collected via `getSetCookie()`; request `te`/`trailer` are no longer forwarded.
- `locationRewrite` also rewrites protocol-relative locations pointing at the target (upstream host leak) and handles non-canonical `refresh` shapes (optional delay, padded `=`, quoted URLs); prefix maps iterate own keys only.
- Docs: `xfwd` spoofing warning (client-supplied `x-forwarded-for` wins; strip via `filterHeaders` on internet-facing edges) + `proxyRequest`-only note, `forwardHeaders` denylist-bypass caveat, `propagateAbortError`/`timeout` consistency, browser/SW redirect caveat.

The review confirmed the rest sound: no open-redirect in the location rewrite (origin re-rooting verified against `//`, userinfo, and backslash tricks), correct 499-vs-504 signal classification, no smuggling surface (undici re-frames; hop-by-hop stripped), and `AbortSignal.any`/`URL.canParse`/`getSetCookie` availability on `engines.node >= 20.11.1` and other supported runtimes.

### Notes

- Every fix comes with a regression test that was confirmed failing before the change; full suite passes (1383 tests, no type errors) and lint is clean.
- The branch also fast-forwards over the latest `main` commits since the work was based on `main`'s tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `X-Forwarded-*` handling when enabled (adds missing values; does not override an existing `x-forwarded-for`).
* **Bug Fixes**
  * Upstream 3xx responses now pass through correctly (no automatic following); redirect behavior is documented and respects manual redirect mode.
  * Improved streamed request handling and duplex defaults; proxy timeouts reliably return **504 Gateway Timeout**.
  * Case-insensitive header filtering plus stricter hop-by-hop response header stripping (including connection-driven headers); correct `accept`/`accept-encoding` forwarding.
* **Documentation**
  * Clarified redirect pass-through/follow rules and `location`/`refresh` rewrite behavior (including limitations with streamed bodies).
* **Tests**
  * Expanded coverage for redirects, streaming/duplex, header rules, `xfwd`, timeout-to-504, and `location`/`refresh` rewriting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
