### PR TITLE
fix(cors): correct vary handling and credentialed wildcard behavior

### DIFF
--- a/src/utils/cors.ts
+++ b/src/utils/cors.ts
@@ -32,6 +32,9 @@ export interface CorsOptions {
    * When using an explicit allowlist, remember that `QUERY` is **not** a CORS-safelisted
    * method, so browsers preflight it — include `"QUERY"` in the array to allow it.
    *
+   * When `credentials` is enabled, browsers treat `"*"` as a literal method name — in that
+   * case the requested method is reflected back instead of sending a literal `*`.
+   *
    * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods
    * @default "*"
    * @example ["GET", "HEAD", "PUT", "POST", "QUERY"]
@@ -48,6 +51,9 @@ export interface CorsOptions {
 
   /**
    * This determines the value of the "access-control-expose-headers" response header.
+   *
+   * When `credentials` is enabled, browsers treat `"*"` as a literal header name — in that
+   * case the header is omitted; list the headers explicitly to expose them.
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
    * @default "*"
@@ -95,18 +101,17 @@ export function isPreflightRequest(event: HTTPEvent): boolean {
  * Append CORS preflight headers to the response.
  */
 export function appendCorsPreflightHeaders(event: H3Event, options: CorsOptions): void {
-  const originHeaders = createOriginHeaders(event, options);
-  const allowHeaderHeaders = createAllowHeaderHeaders(event, options);
-  const headers = {
-    ...originHeaders,
-    ...createCredentialsHeaders(options),
-    ...createMethodsHeaders(options),
-    ...allowHeaderHeaders,
-    ...createMaxAgeHeader(options),
-  };
-  // Both createOriginHeaders and createAllowHeaderHeaders can independently emit a `vary`
-  // key. Plain spread overwrites the first — merge them so neither is lost.
-  const varyValues = [originHeaders.vary, allowHeaderHeaders.vary].filter(Boolean);
+  const headerGroups = [
+    createOriginHeaders(event, options),
+    createCredentialsHeaders(options),
+    createMethodsHeaders(event, options),
+    createAllowHeaderHeaders(event, options),
+    createMaxAgeHeader(options),
+  ];
+  // Several groups can independently emit a `vary` key. Plain spread would keep
+  // only the last one — merge them so none is lost.
+  const headers: Record<string, string> = Object.assign({}, ...headerGroups);
+  const varyValues = headerGroups.map((group) => group.vary).filter(Boolean);
   if (varyValues.length > 0) {
     headers.vary = varyValues.join(", ");
   }

--- a/src/utils/internal/cors.ts
+++ b/src/utils/internal/cors.ts
@@ -44,6 +44,12 @@ export function resolveCorsOptions(options: CorsOptions = {}): ResolvedCorsOptio
     );
   }
 
+  if (resolved.credentials && options.exposeHeaders === "*") {
+    console.warn(
+      "[h3] CORS: `credentials: true` with wildcard `exposeHeaders` has no effect. Browsers treat `*` literally on credentialed requests — list the headers explicitly.",
+    );
+  }
+
   return resolved;
 }
 
@@ -92,28 +98,36 @@ export function createOriginHeaders(event: H3Event, options: CorsOptions): Recor
     return { "access-control-allow-origin": "*" };
   }
 
-  if (originOption === "null") {
-    return { "access-control-allow-origin": "null", vary: "origin" };
-  }
-
   if (isCorsOriginAllowed(origin, options)) {
     return { "access-control-allow-origin": origin!, vary: "origin" };
   }
 
-  return {};
+  // The response depends on the request origin even when it is rejected —
+  // without `vary: origin` a shared cache could serve this response to an allowed origin.
+  return { vary: "origin" };
 }
 
 /**
  * Create the `access-control-allow-methods` header.
  */
-export function createMethodsHeaders(options: CorsOptions): Record<string, string> {
-  const { methods } = options;
+export function createMethodsHeaders(event: H3Event, options: CorsOptions): Record<string, string> {
+  const { methods, credentials } = options;
 
   if (!methods) {
     return {};
   }
 
   if (methods === "*") {
+    if (credentials) {
+      // Browsers treat `*` literally on credentialed requests — reflect the requested method instead
+      const requestMethod = event.req.headers.get("access-control-request-method");
+      return requestMethod
+        ? {
+            "access-control-allow-methods": requestMethod,
+            vary: "access-control-request-method",
+          }
+        : {};
+    }
     return { "access-control-allow-methods": "*" };
   }
 
@@ -145,12 +159,14 @@ export function createAllowHeaderHeaders(
   if (!allowHeaders || allowHeaders === "*" || allowHeaders.length === 0) {
     const header = event.req.headers.get("access-control-request-headers");
 
+    // The response reflects the request header, so declare the variance
+    // even when the header is absent.
     return header
       ? {
           "access-control-allow-headers": header,
           vary: "access-control-request-headers",
         }
-      : {};
+      : { vary: "access-control-request-headers" };
   }
 
   return {
@@ -163,14 +179,15 @@ export function createAllowHeaderHeaders(
  * Create the `access-control-expose-headers` header.
  */
 export function createExposeHeaders(options: CorsOptions): Record<string, string> {
-  const { exposeHeaders } = options;
+  const { exposeHeaders, credentials } = options;
 
   if (!exposeHeaders) {
     return {};
   }
 
   if (exposeHeaders === "*") {
-    return { "access-control-expose-headers": exposeHeaders };
+    // Browsers treat `*` literally on credentialed requests — omit the useless header
+    return credentials ? {} : { "access-control-expose-headers": exposeHeaders };
   }
 
   return { "access-control-expose-headers": exposeHeaders.join(",") };

--- a/src/utils/internal/cors.ts
+++ b/src/utils/internal/cors.ts
@@ -38,14 +38,14 @@ export function resolveCorsOptions(options: CorsOptions = {}): ResolvedCorsOptio
     },
   };
 
-  if (resolved.credentials && (!options.origin || options.origin === "*")) {
-    console.warn(
+  if (resolved.credentials && resolved.origin === "*") {
+    warnOnce(
       "[h3] CORS: `credentials: true` with wildcard origin is not allowed. Browsers will reject the response.",
     );
   }
 
-  if (resolved.credentials && options.exposeHeaders === "*") {
-    console.warn(
+  if (resolved.credentials && resolved.exposeHeaders === "*") {
+    warnOnce(
       "[h3] CORS: `credentials: true` with wildcard `exposeHeaders` has no effect. Browsers treat `*` literally on credentialed requests — list the headers explicitly.",
     );
   }
@@ -204,4 +204,18 @@ export function createMaxAgeHeader(options: CorsOptions): Record<string, string>
   }
 
   return {};
+}
+
+// `resolveCorsOptions` runs on every request, so config warnings are emitted
+// at most once per process to avoid flooding logs under load. The dedup set is
+// allocated lazily so there is no top-level side effect and a correctly
+// configured app never pays for it.
+let warnedMessages: Set<string> | undefined;
+function warnOnce(message: string): void {
+  warnedMessages ??= new Set();
+  if (warnedMessages.has(message)) {
+    return;
+  }
+  warnedMessages.add(message);
+  console.warn(message);
 }

--- a/test/unit/cors.test.ts
+++ b/test/unit/cors.test.ts
@@ -90,6 +90,20 @@ describe("cors (unit)", () => {
 
       warnSpy.mockRestore();
     });
+
+    it("warns when credentials is used with an explicit wildcard exposeHeaders", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      resolveCorsOptions({
+        credentials: true,
+        origin: ["https://example.com"],
+        exposeHeaders: "*",
+      });
+      expect(warnSpy).toHaveBeenCalledOnce();
+      expect(warnSpy.mock.calls[0][0]).toContain("exposeHeaders");
+
+      warnSpy.mockRestore();
+    });
   });
 
   describe("isPreflightRequest", () => {
@@ -244,8 +258,14 @@ describe("cors (unit)", () => {
       });
     });
 
-    it('returns an object with `access-control-allow-origin` and `vary` keys if `origin` option is `"null"`', () => {
-      const eventMock = mockEvent("/", {
+    it('handles `"null"` origin option consistently with `isCorsOriginAllowed`', () => {
+      const nullOriginEventMock = mockEvent("/", {
+        method: "OPTIONS",
+        headers: {
+          origin: "null",
+        },
+      });
+      const otherOriginEventMock = mockEvent("/", {
         method: "OPTIONS",
         headers: {
           origin: "https://example.com",
@@ -255,8 +275,11 @@ describe("cors (unit)", () => {
         origin: "null",
       };
 
-      expect(createOriginHeaders(eventMock, options)).toEqual({
+      expect(createOriginHeaders(nullOriginEventMock, options)).toEqual({
         "access-control-allow-origin": "null",
+        vary: "origin",
+      });
+      expect(createOriginHeaders(otherOriginEventMock, options)).toEqual({
         vary: "origin",
       });
     });
@@ -285,15 +308,19 @@ describe("cors (unit)", () => {
         "access-control-allow-origin": "http://example.com",
         vary: "origin",
       });
-      expect(createOriginHeaders(noMatchEventMock, options1)).toEqual({});
+      expect(createOriginHeaders(noMatchEventMock, options1)).toEqual({
+        vary: "origin",
+      });
       expect(createOriginHeaders(eventMock, options2)).toEqual({
         "access-control-allow-origin": "http://example.com",
         vary: "origin",
       });
-      expect(createOriginHeaders(noMatchEventMock, options2)).toEqual({});
+      expect(createOriginHeaders(noMatchEventMock, options2)).toEqual({
+        vary: "origin",
+      });
     });
 
-    it("returns an empty object if `origin` option is one that is not allowed", () => {
+    it("returns only `vary` if `origin` option is one that is not allowed", () => {
       const eventMock = mockEvent("/", {
         method: "OPTIONS",
         headers: {
@@ -307,11 +334,11 @@ describe("cors (unit)", () => {
         origin: () => false,
       };
 
-      expect(createOriginHeaders(eventMock, options1)).toEqual({});
-      expect(createOriginHeaders(eventMock, options2)).toEqual({});
+      expect(createOriginHeaders(eventMock, options1)).toEqual({ vary: "origin" });
+      expect(createOriginHeaders(eventMock, options2)).toEqual({ vary: "origin" });
     });
 
-    it("returns an empty object if `origin` option is not wildcard and `origin` header is not defined", () => {
+    it("returns only `vary` if `origin` option is not wildcard and `origin` header is not defined", () => {
       const eventMock = mockEvent("/", {
         method: "OPTIONS",
         headers: {},
@@ -323,20 +350,27 @@ describe("cors (unit)", () => {
         origin: () => false,
       };
 
-      expect(createOriginHeaders(eventMock, options1)).toEqual({});
-      expect(createOriginHeaders(eventMock, options2)).toEqual({});
+      expect(createOriginHeaders(eventMock, options1)).toEqual({ vary: "origin" });
+      expect(createOriginHeaders(eventMock, options2)).toEqual({ vary: "origin" });
     });
   });
 
   describe("createMethodsHeaders", () => {
+    const eventMock = mockEvent("/", {
+      method: "OPTIONS",
+      headers: {
+        "access-control-request-method": "POST",
+      },
+    });
+
     it("returns an empty object if `methods` option is not defined or an empty array", () => {
       const options1: CorsOptions = {};
       const options2: CorsOptions = {
         methods: [],
       };
 
-      expect(createMethodsHeaders(options1)).toEqual({});
-      expect(createMethodsHeaders(options2)).toEqual({});
+      expect(createMethodsHeaders(eventMock, options1)).toEqual({});
+      expect(createMethodsHeaders(eventMock, options2)).toEqual({});
     });
 
     it('returns an object whose `access-control-allow-methods` is `"*"` if `methods` option is `"*"`', () => {
@@ -344,9 +378,27 @@ describe("cors (unit)", () => {
         methods: "*",
       };
 
-      expect(createMethodsHeaders(options1)).toEqual({
+      expect(createMethodsHeaders(eventMock, options1)).toEqual({
         "access-control-allow-methods": "*",
       });
+    });
+
+    it('reflects the requested method if `methods` option is `"*"` and `credentials` is enabled', () => {
+      const options: CorsOptions = {
+        methods: "*",
+        credentials: true,
+      };
+
+      expect(createMethodsHeaders(eventMock, options)).toEqual({
+        "access-control-allow-methods": "POST",
+        vary: "access-control-request-method",
+      });
+
+      const noRequestMethodEventMock = mockEvent("/", {
+        method: "OPTIONS",
+        headers: {},
+      });
+      expect(createMethodsHeaders(noRequestMethodEventMock, options)).toEqual({});
     });
 
     it("returns an object whose `access-control-allow-methods` is set as `methods` option", () => {
@@ -354,7 +406,7 @@ describe("cors (unit)", () => {
         methods: ["GET", "POST"],
       };
 
-      expect(createMethodsHeaders(options)).toEqual({
+      expect(createMethodsHeaders(eventMock, options)).toEqual({
         "access-control-allow-methods": "GET,POST",
       });
     });
@@ -423,7 +475,7 @@ describe("cors (unit)", () => {
       });
     });
 
-    it('returns an empty object if `allowHeaders` option is not defined, `"*"`, or an empty array, and `access-control-request-headers` is not defined', () => {
+    it('returns only `vary` if `allowHeaders` option is not defined, `"*"`, or an empty array, and `access-control-request-headers` is not defined', () => {
       const eventMock = mockEvent("/", {
         method: "OPTIONS",
         headers: {},
@@ -436,9 +488,10 @@ describe("cors (unit)", () => {
         allowHeaders: [],
       };
 
-      expect(createAllowHeaderHeaders(eventMock, options1)).toEqual({});
-      expect(createAllowHeaderHeaders(eventMock, options2)).toEqual({});
-      expect(createAllowHeaderHeaders(eventMock, options3)).toEqual({});
+      const expected = { vary: "access-control-request-headers" };
+      expect(createAllowHeaderHeaders(eventMock, options1)).toEqual(expected);
+      expect(createAllowHeaderHeaders(eventMock, options2)).toEqual(expected);
+      expect(createAllowHeaderHeaders(eventMock, options3)).toEqual(expected);
     });
   });
 
@@ -463,6 +516,15 @@ describe("cors (unit)", () => {
       expect(createExposeHeaders(options2)).toEqual({
         "access-control-expose-headers": "EXPOSED-HEADER-1,EXPOSED-HEADER-2",
       });
+    });
+
+    it('omits the header if `exposeHeaders` option is `"*"` and `credentials` is enabled', () => {
+      const options: CorsOptions = {
+        exposeHeaders: "*",
+        credentials: true,
+      };
+
+      expect(createExposeHeaders(options)).toEqual({});
     });
   });
 
@@ -577,11 +639,35 @@ describe("cors (unit)", () => {
         expect(eventMock.res.headers.get("access-control-allow-origin")).toEqual(
           "https://example.com",
         );
-        expect(eventMock.res.headers.get("vary")).toEqual("origin");
+        expect(eventMock.res.headers.get("vary")).toEqual("origin, access-control-request-headers");
         expect(eventMock.res.headers.get("access-control-allow-credentials")).toEqual("true");
         expect(eventMock.res.headers.has("access-control-allow-methods")).toEqual(false);
         expect(eventMock.res.headers.has("access-control-allow-headers")).toEqual(false);
         expect(eventMock.res.headers.has("access-control-max-age")).toEqual(false);
+      }
+
+      {
+        // credentials + wildcard methods: the requested method is reflected
+        // (browsers treat a literal `*` as a method name on credentialed requests)
+        const eventMock = mockEvent("/", {
+          method: "OPTIONS",
+          headers: {
+            origin: "https://example.com",
+            "access-control-request-method": "PUT",
+          },
+        });
+        const options: CorsOptions = {
+          origin: ["https://example.com"],
+          methods: "*",
+          credentials: true,
+        };
+
+        appendCorsPreflightHeaders(eventMock, options);
+
+        expect(eventMock.res.headers.get("access-control-allow-methods")).toEqual("PUT");
+        const vary = eventMock.res.headers.get("vary") ?? "";
+        expect(vary).toContain("origin");
+        expect(vary).toContain("access-control-request-method");
       }
 
       {
@@ -683,6 +769,24 @@ describe("cors (unit)", () => {
         expect(eventMock.res.headers.get("vary")).toEqual("origin");
         expect(eventMock.res.headers.get("access-control-allow-credentials")).toEqual("true");
       }
+    });
+
+    it("adds `vary: origin` even when the origin is not allowed", () => {
+      // Without `vary: origin`, a shared cache could store this response (which
+      // has no `access-control-allow-origin`) and serve it to an allowed origin.
+      const eventMock = mockEvent("/", {
+        method: "GET",
+        headers: {
+          origin: "https://evil.example",
+        },
+      });
+
+      appendCorsHeaders(eventMock, {
+        origin: ["https://example.com"],
+      });
+
+      expect(eventMock.res.headers.has("access-control-allow-origin")).toEqual(false);
+      expect(eventMock.res.headers.get("vary")).toEqual("origin");
     });
   });
 

--- a/test/unit/cors.test.ts
+++ b/test/unit/cors.test.ts
@@ -1,4 +1,4 @@
-import { expect, it, describe, vi } from "vitest";
+import { expect, it, describe, beforeEach, vi } from "vitest";
 import {
   mockEvent,
   isPreflightRequest,
@@ -60,49 +60,85 @@ describe("cors (unit)", () => {
       });
     });
 
-    it("warns when credentials is used with wildcard origin", () => {
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
-      resolveCorsOptions({ credentials: true });
-      expect(warnSpy).toHaveBeenCalledOnce();
-      expect(warnSpy.mock.calls[0][0]).toContain("credentials");
-
-      warnSpy.mockRestore();
-    });
-
-    it("does not warn when credentials is used with specific origin", () => {
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
-      resolveCorsOptions({
-        credentials: true,
-        origin: ["https://example.com"],
+    describe("credentials warnings", () => {
+      // `resolveCorsOptions` runs on every request and warns at most once per
+      // process (warn-once dedup), so reset module state between tests to
+      // observe each warning in isolation.
+      let resolveCorsOptions: (typeof import("../../src/utils/internal/cors.ts"))["resolveCorsOptions"];
+      beforeEach(async () => {
+        vi.resetModules();
+        ({ resolveCorsOptions } = await import("../../src/utils/internal/cors.ts"));
       });
-      expect(warnSpy).not.toHaveBeenCalled();
 
-      warnSpy.mockRestore();
-    });
+      it("warns when credentials is used with wildcard origin", () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    it("does not warn when credentials is false", () => {
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        resolveCorsOptions({ credentials: true, exposeHeaders: ["X-Custom"] });
+        expect(warnSpy).toHaveBeenCalledOnce();
+        expect(warnSpy.mock.calls[0][0]).toContain("origin");
 
-      resolveCorsOptions({ credentials: false, origin: "*" });
-      expect(warnSpy).not.toHaveBeenCalled();
-
-      warnSpy.mockRestore();
-    });
-
-    it("warns when credentials is used with an explicit wildcard exposeHeaders", () => {
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
-      resolveCorsOptions({
-        credentials: true,
-        origin: ["https://example.com"],
-        exposeHeaders: "*",
+        warnSpy.mockRestore();
       });
-      expect(warnSpy).toHaveBeenCalledOnce();
-      expect(warnSpy.mock.calls[0][0]).toContain("exposeHeaders");
 
-      warnSpy.mockRestore();
+      it("warns when credentials is used with default wildcard exposeHeaders", () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        resolveCorsOptions({
+          credentials: true,
+          origin: ["https://example.com"],
+        });
+        expect(warnSpy).toHaveBeenCalledOnce();
+        expect(warnSpy.mock.calls[0][0]).toContain("exposeHeaders");
+
+        warnSpy.mockRestore();
+      });
+
+      it("warns when credentials is used with an explicit wildcard exposeHeaders", () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        resolveCorsOptions({
+          credentials: true,
+          origin: ["https://example.com"],
+          exposeHeaders: "*",
+        });
+        expect(warnSpy).toHaveBeenCalledOnce();
+        expect(warnSpy.mock.calls[0][0]).toContain("exposeHeaders");
+
+        warnSpy.mockRestore();
+      });
+
+      it("does not warn when credentials is properly configured", () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        resolveCorsOptions({
+          credentials: true,
+          origin: ["https://example.com"],
+          exposeHeaders: ["X-Custom"],
+        });
+        expect(warnSpy).not.toHaveBeenCalled();
+
+        warnSpy.mockRestore();
+      });
+
+      it("does not warn when credentials is false", () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        resolveCorsOptions({ credentials: false, origin: "*" });
+        expect(warnSpy).not.toHaveBeenCalled();
+
+        warnSpy.mockRestore();
+      });
+
+      it("warns at most once per message across repeated calls", () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        // Default origin + exposeHeaders are both wildcard → two distinct messages.
+        resolveCorsOptions({ credentials: true });
+        resolveCorsOptions({ credentials: true });
+        expect(warnSpy).toHaveBeenCalledTimes(2);
+
+        warnSpy.mockRestore();
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes several spec-level correctness issues in the CORS utils found during a review of `src/utils/cors.ts` / `src/utils/internal/cors.ts`.

### `vary: origin` was missing when the origin is rejected (cache poisoning)

When `origin` is an allowlist/function, an allowed origin got `access-control-allow-origin` + `vary: origin`, but a rejected origin got neither. The response varies by request origin without declaring it, so a shared cache could store the ACAO-less response from a disallowed origin and serve it to an allowed one (or cache the reflected header and serve it to everyone). `createOriginHeaders` now always emits `vary: origin` when the origin option is not `"*"`.

### Wildcards are treated literally on credentialed requests

Per the Fetch spec, `*` in `access-control-allow-methods` / `access-control-expose-headers` is a literal token when credentials are included:

- `methods: "*"` + `credentials: true` now reflects `access-control-request-method` back (with `vary: access-control-request-method`) instead of sending a literal `*` that browsers would reject — same technique already used for `allowHeaders`.
- `exposeHeaders: "*"` + `credentials: true` now omits the useless header and logs a warning suggesting an explicit list.

### `vary: access-control-request-headers` was missing when the header is absent

With wildcard `allowHeaders`, the preflight response reflects `access-control-request-headers`, but no `vary` was declared when the request omitted that header — same undeclared-variance class as the origin issue.

### `origin: "null"` was inconsistent with `isCorsOriginAllowed`

`createOriginHeaders` unconditionally emitted `access-control-allow-origin: null` for any request origin, while `isCorsOriginAllowed` only matches a literal `"null"` origin. Both now agree: `null` is only reflected when the request origin is actually `null`.

The `vary` merge in `appendCorsPreflightHeaders` was generalized since three header groups can now emit `vary` independently.

## Testing

- Updated unit tests for the new `vary` behavior and added regression tests for each fix (`test/unit/cors.test.ts`, 44 tests)
- Full suite passes: 1345 passed, no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved credentialed CORS preflight handling for `methods: "*"` by reflecting the requested method when available.
  - Suppressed `access-control-expose-headers` for `exposeHeaders: "*"` when credentials are enabled.
  - Corrected `Vary` header behavior for allowed and rejected origins, and for preflight responses (including combined variation across relevant dimensions).
  - Deduplicated and clarified warnings for ineffective credentialed wildcard configurations.

- **Tests**
  - Expanded and reorganized CORS unit coverage for wildcard + credentials scenarios, origin edge cases, and updated expected `Vary`/header outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->