### PR TITLE
fix(session): raise default seal PBKDF2 iterations to 8192

### DIFF
--- a/docs/4.examples/handle-session.md
+++ b/docs/4.examples/handle-session.md
@@ -34,7 +34,13 @@ app.use(async (event) => {
 ```
 
 > [!WARNING]
-> You must provide a password to encrypt the session. The examples below use a hardcoded value so they stay readable, but in a real app load it from an environment variable such as `process.env.SESSION_PASSWORD`, keep it a strong secret of at least 32 characters, and never commit it to source control.
+> The `password` seals every session cookie, and its **entropy is the real security boundary**. A stolen session cookie carries the salt and integrity digest in plaintext, so a weak or guessable password can be brute-forced offline — increasing PBKDF2 iterations only slows this, it does not fix a low-entropy secret. Always generate the password from a cryptographically secure random source, for example:
+>
+> ```sh
+> node -e "console.log(require('node:crypto').randomBytes(32).toString('base64'))"
+> ```
+>
+> The examples below use a hardcoded value so they stay readable, but in a real app load a randomly generated secret of at least 32 characters from an environment variable such as `process.env.SESSION_PASSWORD`, and never commit it to source control. A guessable passphrase (even one ≥32 characters) is not safe.
 
 This will initialize a session and return an header `Set-Cookie` with a cookie named `h3` and an encrypted content.
 

--- a/src/utils/internal/iron-crypto.ts
+++ b/src/utils/internal/iron-crypto.ts
@@ -20,13 +20,13 @@ export const defaults: Readonly<SealOptions> = /* @__PURE__ */ Object.freeze({
   encryption: /* @__PURE__ */ Object.freeze({
     saltBits: 256,
     algorithm: "aes-256-cbc",
-    iterations: 1,
+    iterations: 8192,
     minPasswordlength: 32,
   }),
   integrity: /* @__PURE__ */ Object.freeze({
     saltBits: 256,
     algorithm: "sha256",
-    iterations: 1,
+    iterations: 8192,
     minPasswordlength: 32,
   }),
 });

--- a/src/utils/internal/session.ts
+++ b/src/utils/internal/session.ts
@@ -2,6 +2,10 @@ import type { SessionConfig } from "../session.ts";
 
 export const kGetSession: unique symbol = /* @__PURE__ */ Symbol.for("h3.internal.session.promise");
 
+export const kLegacySeal: unique symbol = /* @__PURE__ */ Symbol.for(
+  "h3.internal.session.legacy-seal",
+);
+
 export const DEFAULT_SESSION_NAME = "h3";
 
 export const DEFAULT_SESSION_COOKIE: SessionConfig["cookie"] = {

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -2,7 +2,7 @@ import { seal, unseal, defaults as sealDefaults } from "./internal/iron-crypto.t
 import { getChunkedCookie, setChunkedCookie, deleteChunkedCookie } from "./cookie.ts";
 import { DEFAULT_SESSION_NAME, DEFAULT_SESSION_COOKIE } from "./internal/session.ts";
 import { EmptyObject } from "./internal/obj.ts";
-import { kGetSession } from "./internal/session.ts";
+import { kGetSession, kLegacySeal } from "./internal/session.ts";
 
 import type { H3Event, HTTPEvent } from "../event.ts";
 import type { CookieSerializeOptions } from "cookie-es";
@@ -29,7 +29,14 @@ export interface SessionManager<T extends SessionDataT = SessionDataT> {
 }
 
 export interface SessionConfig {
-  /** Private key used to encrypt session tokens */
+  /**
+   * Private key used to seal session tokens. Must be at least 32 characters.
+   *
+   * Its entropy is the security boundary: a stolen cookie can be brute-forced
+   * offline, so generate this from a cryptographically random source (e.g.
+   * `crypto.randomBytes(32).toString("base64")`) — a guessable passphrase is
+   * unsafe even at 32+ characters.
+   */
   password: string;
   /** Session expiration time in seconds */
   maxAge?: number;
@@ -120,16 +127,26 @@ export async function getSession<T extends SessionData = SessionData>(
     }
   }
   // Fallback to cookies
+  let sessionFromCookie = false;
   if (!sealedSession) {
     sealedSession = getChunkedCookie(event, sessionName);
+    sessionFromCookie = true;
   }
   if (sealedSession) {
     // Unseal session data from cookie
     const promise = unsealSession(event, config, sealedSession)
       .catch(() => {})
-      .then((unsealed) => {
+      .then(async (unsealed) => {
+        const legacySeal = unsealed && (unsealed as any)[kLegacySeal];
+        if (legacySeal) {
+          delete (unsealed as any)[kLegacySeal];
+        }
         Object.assign(session, unsealed);
         delete context.sessions![sessionName][kGetSession];
+        if (legacySeal && sessionFromCookie) {
+          // Proactively reseal legacy cookies with the current seal options
+          await updateSession(event, config);
+        }
         return session as Session<T>;
       });
     context.sessions![sessionName][kGetSession] = promise;
@@ -217,11 +234,36 @@ export async function unsealSession(
   config: SessionConfig,
   sealed: string,
 ): Promise<Partial<Session>> {
-  const unsealed = (await unseal(sealed, config.password, {
+  const sealOptions = {
     ...sealDefaults,
     ttl: config.maxAge ? config.maxAge * 1000 : 0,
     ...config.seal,
-  })) as Partial<Session>;
+  };
+  let unsealed: Partial<Session>;
+  try {
+    unsealed = (await unseal(sealed, config.password, sealOptions)) as Partial<Session>;
+  } catch (error) {
+    // TODO: Remove this fallback before the v2 stable release
+    // Sessions sealed before the default PBKDF2 iterations were raised from 1
+    // to 8192 fail HMAC verification; retry with the legacy count so existing
+    // sessions survive the upgrade (getSession reseals them with the current
+    // options).
+    if (
+      sealOptions.integrity.iterations === 1 ||
+      !(error instanceof Error) ||
+      error.message !== "Bad hmac value"
+    ) {
+      throw error;
+    }
+    unsealed = (await unseal(sealed, config.password, {
+      ...sealOptions,
+      encryption: { ...sealOptions.encryption, iterations: 1 },
+      integrity: { ...sealOptions.integrity, iterations: 1 },
+    })) as Partial<Session>;
+    if (unsealed) {
+      (unsealed as any)[kLegacySeal] = true;
+    }
+  }
   if (config.maxAge) {
     const age = Date.now() - (unsealed.createdAt || Number.NEGATIVE_INFINITY);
     if (age > config.maxAge * 1000) {

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -47,6 +47,12 @@ export interface SessionConfig {
   /** Default is x-h3-session / x-{name}-session */
   sessionHeader?: false | string;
   seal?: SealOptions;
+  /**
+   * Set to `false` to reject sessions sealed with the legacy default of 1
+   * PBKDF2 iteration instead of unsealing and resealing them.
+   *
+   */
+  legacySealFallback?: boolean;
   crypto?: Crypto;
   /** Default is Crypto.randomUUID */
   generateId?: () => string;
@@ -249,6 +255,7 @@ export async function unsealSession(
     // sessions survive the upgrade (getSession reseals them with the current
     // options).
     if (
+      config.legacySealFallback === false ||
       sealOptions.integrity.iterations === 1 ||
       !(error instanceof Error) ||
       error.message !== "Bad hmac value"

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -1,6 +1,7 @@
 import type { SessionConfig } from "../src/utils/session.ts";
 import { beforeEach } from "vitest";
 import { useSession, clearSession, readBody, H3 } from "../src/index.ts";
+import { seal, unseal, defaults as sealDefaults } from "../src/utils/internal/iron-crypto.ts";
 import { describeMatrix } from "./_setup.ts";
 
 describeMatrix("session", (t, { it, expect }) => {
@@ -93,6 +94,33 @@ describeMatrix("session", (t, { it, expect }) => {
     const cookies = res.headers.getSetCookie();
     expect(cookies.length).toBeGreaterThanOrEqual(1);
     expect(cookies[0]).toContain("Max-Age=0");
+  });
+
+  it("unseals and reseals legacy sessions sealed with iterations: 1", async () => {
+    const legacySealed = await seal(
+      { id: "legacy", createdAt: Date.now(), data: { foo: "legacy" } },
+      sessionConfig.password,
+      {
+        ...sealDefaults,
+        encryption: { ...sealDefaults.encryption, iterations: 1 },
+        integrity: { ...sealDefaults.integrity, iterations: 1 },
+      },
+    );
+
+    const result = await t.fetch("/", {
+      headers: { Cookie: `h3-test=${legacySealed}` },
+    });
+    expect(await result.json()).toMatchObject({
+      session: { id: "legacy", data: { foo: "legacy" } },
+    });
+
+    // Legacy cookie is transparently resealed with the current default
+    const setCookies = result.headers.getSetCookie();
+    expect(setCookies).toHaveLength(1);
+    const resealed = decodeURIComponent(setCookies[0].match(/h3-test=([^;]+)/)![1]);
+    expect(
+      await unseal(resealed, sessionConfig.password, sealDefaults), // current iterations, no fallback
+    ).toMatchObject({ id: "legacy", data: { foo: "legacy" } });
   });
 
   it("stores large data in chunks", async () => {

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -123,6 +123,33 @@ describeMatrix("session", (t, { it, expect }) => {
     ).toMatchObject({ id: "legacy", data: { foo: "legacy" } });
   });
 
+  it("rejects legacy sessions with legacySealFallback: false", async () => {
+    const legacySealed = await seal(
+      { id: "legacy", createdAt: Date.now(), data: { foo: "legacy" } },
+      sessionConfig.password,
+      {
+        ...sealDefaults,
+        encryption: { ...sealDefaults.encryption, iterations: 1 },
+        integrity: { ...sealDefaults.integrity, iterations: 1 },
+      },
+    );
+
+    t.app.all("/strict", async (event) => {
+      const session = await useSession(event, {
+        ...sessionConfig,
+        legacySealFallback: false,
+      });
+      return { session };
+    });
+
+    const result = await t.fetch("/strict", {
+      headers: { Cookie: `h3-test=${legacySealed}` },
+    });
+    const body = await result.json();
+    expect(body.session.id).not.toBe("legacy");
+    expect(body.session.data).toEqual({});
+  });
+
   it("stores large data in chunks", async () => {
     const token = Array.from({ length: 5000 /* ~4k + one more */ }).fill("x").join("");
     const res = await t.fetch("/", {

--- a/test/unit/iron-crypto.test.ts
+++ b/test/unit/iron-crypto.test.ts
@@ -214,19 +214,28 @@ describe(`iron crypto`, () => {
     it("unseals a ticket", async () => {
       const ticket =
         "Fe26.2**0cdd607945dd1dffb7da0b0bf5f1a7daa6218cbae14cac51dcbd91fb077aeb5b*aOZLCKLhCt0D5IU1qLTtYw*g0ilNDlQ3TsdFUqJCqAm9iL7Wa60H7eYcHL_5oP136TOJREkS3BzheDC1dlxz5oJ**05b8943049af490e913bbc3a2485bee2aaf7b823f4c41d0ff0b7c168371a3772*R8yscVdTBRMdsoVbdDiFmUL8zb-c3PQLGJn4Y8C-AqI";
-      const unsealed = await Iron.unseal(ticket, password, Iron.defaults);
+      // Fixed iron test vector: sealed upstream with iterations:1
+      const options = {
+        ...Iron.defaults,
+        encryption: { ...Iron.defaults.encryption, iterations: 1 },
+        integrity: { ...Iron.defaults.integrity, iterations: 1 },
+      };
+      const unsealed = await Iron.unseal(ticket, password, options);
       assert.deepEqual(unsealed, obj);
     });
 
     it("unseals a aes-128-ctr ticket", async () => {
       const ticket =
         "Fe26.2**63c87cc87254b834dbb13cc62abc8713d1da035a9b38f54e5d5795135e217167*TpIsHHn-7txnl14Or7-D6A*HFGMGpcTRPUBSTQobuo27KOZ76MhVWgOsjA5SkFoy3vyqaHuixbd**3c8c403569a744a39c58adfb81e654f6860cb01f145488313e1895276e719f52*d5J1jY3WxP61klQza6q7zTqiYpjWPwocqHmjtDcSeq0";
+      // Fixed iron test vector: sealed upstream with iterations:1
       const options = {
         ...Iron.defaults,
         encryption: {
           ...Iron.defaults.encryption,
           algorithm: "aes-128-ctr" as any,
+          iterations: 1,
         },
+        integrity: { ...Iron.defaults.integrity, iterations: 1 },
       };
       const unsealed = await Iron.unseal(ticket, password, options);
       assert.deepEqual(unsealed, obj);


### PR DESCRIPTION
Hardens session sealing by raising the default PBKDF2 iteration count from `1` to `8192` (KDF stretching as defense-in-depth; secret entropy remains the primary boundary).

- Existing sessions sealed with the legacy default keep working via a transitional fallback unseal and are transparently resealed with the new default.
- Documents that the session `password` must be generated from a cryptographically random source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened the default protection for encrypted session cookies by increasing PBKDF2 iterations (encryption and integrity).
  * Expanded session security guidance, including clearer explanation of the real password boundary and a command to generate a cryptographically secure secret.

* **Bug Fixes**
  * Added transparent acceptance and upgrade of legacy sealed session tokens when cookies are refreshed.
  * Added legacy-seal fallback behavior control (`legacySealFallback`) to reject older tokens when disabled.

* **Tests**
  * Extended test coverage for legacy session sealing/unsealing and updated iron-crypto test-vector behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->