### PR TITLE
perf: single-scan fast-path guard for `resolveDotSegments`

### DIFF
--- a/docs/2.utils/4.security.md
+++ b/docs/2.utils/4.security.md
@@ -132,6 +132,16 @@ Check if the incoming request is a CORS preflight request.
 
 <!-- automd:jsdocs src="../../src/utils/path.ts" -->
 
+### `isCanonicalPath(path, opts?)`
+
+Whether `path` is already canonical under `opts` — i.e. {@link resolveDotSegments} would return it unchanged. Exact in both directions: `true` if and only if `resolveDotSegments(path, opts) === path`.
+
+This is the resolver's own fast-path guard, exported so a caller that canonicalizes on a hot path (per-request scope or rule matching) can skip the call — and any work derived from it — without keeping its own copy of what the resolver decodes. Such a copy goes stale silently, and a missed canonicalization in a scope check is a bypass, not a perf bug.
+
+Pass the same options as the later {@link resolveDotSegments} call, or stricter ones: `decodeSlashes`/`mergeSlashes` only add triggers, so `true` with both enabled implies `true` in every mode. Checking one mode and resolving in another voids the guarantee.
+
+Takes a bare pathname. Like the resolver, it has no notion of a query or hash and scans one as if it were path, so `/a?next=/../b` is reported non-canonical (and would resolve to `/b`).
+
 ### `resolveDotSegments(path, opts?)`
 
 Resolve `.` and `..` segments in a path, without ever escaping above the root `/`. The result is always an absolute path with a single leading `/`, so it can never be protocol-relative (`//host`).

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,7 +168,11 @@ export { type CacheConditions, handleCacheHeaders } from "./utils/cache.ts";
 
 // Path
 
-export { type ResolveDotSegmentsOptions, resolveDotSegments } from "./utils/path.ts";
+export {
+  type ResolveDotSegmentsOptions,
+  isCanonicalPath,
+  resolveDotSegments,
+} from "./utils/path.ts";
 
 // Static
 

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -65,13 +65,32 @@ export interface ResolveDotSegmentsOptions {
 // `%2e` escape at any `%25`-nesting depth. Matching it boundary-aware (bounded
 // by `/` or the string edges) keeps a dotted filename (`app.1a2b.js`) or a
 // non-dot escape (`%20`) on the fast path instead of the split/normalize loop.
-const DOT_SEGMENT_RE = /(?:^|\/)(?:\.|%(?:25)*2e){1,2}(?:\/|$)/i;
+const DOT_SEGMENT_SRC = String.raw`(?:^|/)(?:\.|%(?:25)*2e){1,2}(?:/|$)`;
 
-// Encoded path separators (`%2f`/`%5c`) at any `%25`-nesting depth. Test form
-// for the fast-path guard; global form (derived from the same source, so the
-// pattern lives in one place) to decode every occurrence.
-const ENCODED_SEP_RE = /%(?:25)*(?:2f|5c)/i;
-const ENCODED_SEP_RE_G = /* @__PURE__ */ new RegExp(ENCODED_SEP_RE.source, "gi");
+// Encoded path separators (`%2f`/`%5c`) at any `%25`-nesting depth. Source
+// string shared with the per-mode trigger regexes (so the pattern lives in one
+// place); global form to decode every occurrence.
+const ENCODED_SEP_SRC = String.raw`%(?:25)*(?:2f|5c)`;
+const ENCODED_SEP_RE_G = /* @__PURE__ */ new RegExp(ENCODED_SEP_SRC, "gi");
+
+// One combined trigger regex per option mode so the fast-path guard is a
+// SINGLE scan of the path, indexed by `(decodeSlashes?1:0) | (mergeSlashes?2:0)`.
+// Each alternative is the exact trigger of one slow-path transformation — `\`
+// normalization, dot-segment resolution, and (per mode) `%2f`/`%5c` decoding
+// and `//` run collapsing — so "no match" guarantees resolving is a no-op. An
+// encoded separator only forms a run once decoded, so the `decodeSlashes`
+// alternative already covers the runs `mergeSlashes` can additionally see; the
+// leading-separator normalization happens before the guard, so a remaining
+// `//` is interior or trailing.
+const TRIGGER_RES = /* @__PURE__ */ (() => {
+  const base = String.raw`\\|` + DOT_SEGMENT_SRC;
+  return [
+    new RegExp(base, "i"),
+    new RegExp(`${base}|${ENCODED_SEP_SRC}`, "i"),
+    new RegExp(`${base}|//`, "i"),
+    new RegExp(`${base}|${ENCODED_SEP_SRC}|//`, "i"),
+  ];
+})();
 
 // Percent-encoded dots at any `%25`-nesting depth, for per-segment decoding.
 const ENCODED_DOT_RE_G = /%(?:25)*2e/gi;
@@ -114,22 +133,14 @@ export function resolveDotSegments(path: string, opts?: ResolveDotSegmentsOption
   }
   const decodeSlashes = opts?.decodeSlashes;
   const mergeSlashes = opts?.mergeSlashes;
-  // A `\` always needs normalizing, (with `decodeSlashes`) an encoded separator
-  // always needs decoding, and (with `mergeSlashes`) a literal separator run
-  // always needs collapsing — all cheap `includes`/`test` scans checked first so
-  // a dot-free path skips the dot-segment regex entirely. An encoded separator
-  // only forms a run once decoded, so `hasEncodedSep` already covers the runs
-  // `mergeSlashes` can additionally see; the leading normalization above has
-  // taken care of any leading run, so a remaining `//` is interior or trailing.
-  const hasBackslash = path.includes("\\");
-  const hasEncodedSep = decodeSlashes && ENCODED_SEP_RE.test(path);
-  const hasSepRun = mergeSlashes && path.includes("//");
-  if (!hasBackslash && !hasEncodedSep && !hasSepRun && !DOT_SEGMENT_RE.test(path)) {
+  // Fast-path guard: one scan of the mode's combined trigger regex (see
+  // TRIGGER_RES) — the common, already-canonical path returns here.
+  if (!TRIGGER_RES[(decodeSlashes ? 1 : 0) | (mergeSlashes ? 2 : 0)]!.test(path)) {
     return path;
   }
   // Normalize backslashes to forward slashes to prevent traversal via `\`
-  let normalized = hasBackslash ? path.replaceAll("\\", "/") : path;
-  if (hasEncodedSep) {
+  let normalized = path.includes("\\") ? path.replaceAll("\\", "/") : path;
+  if (decodeSlashes) {
     normalized = normalized.replace(ENCODED_SEP_RE_G, "/");
   }
   const segments = normalized.split("/");

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -73,15 +73,13 @@ const DOT_SEGMENT_SRC = String.raw`(?:^|/)(?:\.|%(?:25)*2e){1,2}(?:/|$)`;
 const ENCODED_SEP_SRC = String.raw`%(?:25)*(?:2f|5c)`;
 const ENCODED_SEP_RE_G = /* @__PURE__ */ new RegExp(ENCODED_SEP_SRC, "gi");
 
-// One combined trigger regex per option mode so the fast-path guard is a
-// SINGLE scan of the path, indexed by `(decodeSlashes?1:0) | (mergeSlashes?2:0)`.
-// Each alternative is the exact trigger of one slow-path transformation — `\`
-// normalization, dot-segment resolution, and (per mode) `%2f`/`%5c` decoding
-// and `//` run collapsing — so "no match" guarantees resolving is a no-op. An
-// encoded separator only forms a run once decoded, so the `decodeSlashes`
-// alternative already covers the runs `mergeSlashes` can additionally see; the
-// leading-separator normalization happens before the guard, so a remaining
-// `//` is interior or trailing.
+// One combined trigger regex per option mode, so the fast-path guard is a single
+// scan. Indexed by `(decodeSlashes ? 1 : 0) | (mergeSlashes ? 2 : 0)`. Each
+// alternative is the exact trigger of one slow-path transformation — `\`
+// normalization, dot-segment resolution, and per mode `%2f`/`%5c` decoding and
+// `//` collapsing — so "no match" guarantees resolving is a no-op. Decoding is
+// what turns an encoded separator into a run, so the `decodeSlashes` alternative
+// already covers the extra runs `mergeSlashes` would see.
 const TRIGGER_RES = /* @__PURE__ */ (() => {
   const base = String.raw`\\|` + DOT_SEGMENT_SRC;
   return [
@@ -131,13 +129,14 @@ export function resolveDotSegments(path: string, opts?: ResolveDotSegmentsOption
   if (path[0] !== "/" || path[1] === "/" || path[1] === "\\") {
     path = "/" + path.replace(/^[/\\]+/, "");
   }
-  const decodeSlashes = opts?.decodeSlashes;
-  const mergeSlashes = opts?.mergeSlashes;
-  // Fast-path guard: one scan of the mode's combined trigger regex (see
-  // TRIGGER_RES) — the common, already-canonical path returns here.
-  if (!TRIGGER_RES[(decodeSlashes ? 1 : 0) | (mergeSlashes ? 2 : 0)]!.test(path)) {
+  // Fast-path guard — the common, already-canonical path returns here. The
+  // leading run is normalized above, so any `//` the guard sees is interior or
+  // trailing, and its leading-slash checks are already satisfied.
+  if (isCanonicalPath(path, opts)) {
     return path;
   }
+  const decodeSlashes = opts?.decodeSlashes;
+  const mergeSlashes = opts?.mergeSlashes;
   // Normalize backslashes to forward slashes to prevent traversal via `\`
   let normalized = path.includes("\\") ? path.replaceAll("\\", "/") : path;
   if (decodeSlashes) {
@@ -183,4 +182,33 @@ export function resolveDotSegments(path: string, opts?: ResolveDotSegmentsOption
   // any leading run to a single slash so the result stays a single-rooted, non
   // protocol-relative path. (A no-op when there is already one leading slash.)
   return result.replace(/^\/+/, "/");
+}
+
+/**
+ * Whether `path` is already canonical under `opts` — i.e. {@link resolveDotSegments}
+ * would return it unchanged. Exact in both directions: `true` if and only if
+ * `resolveDotSegments(path, opts) === path`.
+ *
+ * This is the resolver's own fast-path guard, exported so a caller that
+ * canonicalizes on a hot path (per-request scope or rule matching) can skip the
+ * call — and any work derived from it — without keeping its own copy of what the
+ * resolver decodes. Such a copy goes stale silently, and a missed
+ * canonicalization in a scope check is a bypass, not a perf bug.
+ *
+ * Pass the same options as the later {@link resolveDotSegments} call, or stricter
+ * ones: `decodeSlashes`/`mergeSlashes` only add triggers, so `true` with both
+ * enabled implies `true` in every mode. Checking one mode and resolving in
+ * another voids the guarantee.
+ *
+ * Takes a bare pathname. Like the resolver, it has no notion of a query or hash
+ * and scans one as if it were path, so `/a?next=/../b` is reported non-canonical
+ * (and would resolve to `/b`).
+ */
+export function isCanonicalPath(path: string, opts?: ResolveDotSegmentsOptions): boolean {
+  return (
+    path[0] === "/" &&
+    path[1] !== "/" &&
+    path[1] !== "\\" &&
+    !TRIGGER_RES[(opts?.decodeSlashes ? 1 : 0) | (opts?.mergeSlashes ? 2 : 0)]!.test(path)
+  );
 }

--- a/test/unit/package.test.ts
+++ b/test/unit/package.test.ts
@@ -83,6 +83,7 @@ describe("h3 package", () => {
         "handleCacheHeaders",
         "handleCors",
         "html",
+        "isCanonicalPath",
         "isCorsOriginAllowed",
         "isError",
         "isEvent",

--- a/test/unit/path.test.ts
+++ b/test/unit/path.test.ts
@@ -54,6 +54,24 @@ describe("resolveDotSegments", () => {
     expect(resolveDotSegments("/assets/app.1a2b.js")).toBe("/assets/app.1a2b.js");
   });
 
+  it("keeps dot-prefixed segment names untouched in every mode", () => {
+    // A segment that merely STARTS with dots is not a dot segment — the guard
+    // must stay boundary-aware in each per-mode trigger regex.
+    for (const opts of [
+      undefined,
+      { decodeSlashes: true },
+      { mergeSlashes: true },
+      { decodeSlashes: true, mergeSlashes: true },
+    ]) {
+      expect(resolveDotSegments("/.well-known/security.txt", opts)).toBe(
+        "/.well-known/security.txt",
+      );
+      expect(resolveDotSegments("/a/..b/c", opts)).toBe("/a/..b/c");
+      expect(resolveDotSegments("/a%2eb/c", opts)).toBe("/a%2eb/c");
+      expect(resolveDotSegments("/a/...", opts)).toBe("/a/...");
+    }
+  });
+
   it("keeps non-separator, non-dot encodings untouched", () => {
     expect(resolveDotSegments("/foo%20bar")).toBe("/foo%20bar");
     expect(resolveDotSegments("/caf%C3%A9/x")).toBe("/caf%C3%A9/x");

--- a/test/unit/path.test.ts
+++ b/test/unit/path.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveDotSegments } from "../../src/utils/path.ts";
+import { isCanonicalPath, resolveDotSegments } from "../../src/utils/path.ts";
 
 describe("resolveDotSegments", () => {
   it("leaves a plain path untouched", () => {
@@ -148,6 +148,96 @@ describe("resolveDotSegments", () => {
     expect(resolveDotSegments("/a/../..")).toBe("/");
     // Merge mode preserves it too.
     expect(resolveDotSegments("/a/b/..", { mergeSlashes: true })).toBe("/a/");
+  });
+
+  describe("isCanonicalPath", () => {
+    const MODES = [
+      undefined,
+      { decodeSlashes: true },
+      { mergeSlashes: true },
+      { decodeSlashes: true, mergeSlashes: true },
+    ];
+
+    it("accepts already-canonical paths in every mode", () => {
+      for (const opts of MODES) {
+        expect(isCanonicalPath("/", opts)).toBe(true);
+        expect(isCanonicalPath("/api/users/123", opts)).toBe(true);
+        expect(isCanonicalPath("/assets/app.1a2b.js", opts)).toBe(true);
+        expect(isCanonicalPath("/.well-known/security.txt", opts)).toBe(true);
+        expect(isCanonicalPath("/foo%20bar/a%3Ab", opts)).toBe(true);
+        expect(isCanonicalPath("/a%2eb/..c/...", opts)).toBe(true);
+      }
+    });
+
+    it("rejects anything the resolver would change, per mode", () => {
+      // Mode-independent triggers.
+      for (const opts of MODES) {
+        expect(isCanonicalPath("/a/../b", opts)).toBe(false);
+        expect(isCanonicalPath("/a/%2e%2e/b", opts)).toBe(false);
+        expect(isCanonicalPath("/a\\b", opts)).toBe(false);
+        expect(isCanonicalPath("//evil.com", opts)).toBe(false);
+        expect(isCanonicalPath("relative", opts)).toBe(false);
+        expect(isCanonicalPath("", opts)).toBe(false);
+      }
+      // Opt-gated triggers: opaque in one mode, a separator in the other.
+      expect(isCanonicalPath("/a%2fb")).toBe(true);
+      expect(isCanonicalPath("/a%2fb", { decodeSlashes: true })).toBe(false);
+      expect(isCanonicalPath("/a%255cb", { decodeSlashes: true })).toBe(false);
+      expect(isCanonicalPath("/a//b")).toBe(true);
+      expect(isCanonicalPath("/a//b", { mergeSlashes: true })).toBe(false);
+    });
+
+    it("is exactly `resolveDotSegments(path, opts) === path` (seeded fuzz)", () => {
+      // The predicate IS the resolver's fast-path guard — this property is the
+      // contract that keeps them in lockstep: any future widening of what the
+      // resolver decodes must widen the guard in the same commit, or a caller
+      // using the predicate to skip resolving would silently skip a
+      // canonicalization step (a scope/auth-check bypass, not just a perf bug).
+      const FRAGMENTS = [
+        "/",
+        "//",
+        "\\",
+        ".",
+        "..",
+        "...",
+        "%2e",
+        "%2E",
+        "%252e",
+        "%2e%2e",
+        "%2f",
+        "%5C",
+        "%252f",
+        "a",
+        "app.js",
+        ".well-known",
+        "..b",
+        "a%2eb",
+        "%20",
+        "%25",
+        "%",
+        "admin",
+        "%2e.",
+        ".%2e",
+        "%25%32%66",
+      ];
+      let seed = 1234;
+      const rand = () => (seed = (seed * 1_103_515_245 + 12_345) & 0x7f_ff_ff_ff) / 0x7f_ff_ff_ff;
+      for (let i = 0; i < 50_000; i++) {
+        let path = rand() < 0.9 ? "/" : "";
+        const length = 1 + Math.floor(rand() * 6);
+        for (let j = 0; j < length; j++) {
+          path += FRAGMENTS[Math.floor(rand() * FRAGMENTS.length)];
+        }
+        for (const opts of MODES) {
+          const identity = resolveDotSegments(path, opts) === path;
+          if (isCanonicalPath(path, opts) !== identity) {
+            expect.fail(
+              `isCanonicalPath(${JSON.stringify(path)}, ${JSON.stringify(opts)}) !== ${identity}`,
+            );
+          }
+        }
+      }
+    });
   });
 
   describe("mergeSlashes", () => {

--- a/v2.md
+++ b/v2.md
@@ -1,0 +1,3 @@
+# v2 TODOs
+
+- [ ] Remove the legacy `iterations: 1` PBKDF2 unseal fallback in `unsealSession` (`src/utils/session.ts`) and the `legacySealFallback` option. Kept for now so sessions sealed before the default was raised to 8192 iterations survive the upgrade; drop it after a migration window (weak-KDF cookies are ~8192× easier to brute-force and the retry doubles unseal CPU on garbage tokens).

--- a/v2.md
+++ b/v2.md
@@ -1,4 +1,0 @@
-# v2 TODOs
-
-- [ ] Add a default request-body size cap to the buffering body readers (`readBody`, `readValidatedBody` in `src/utils/body.ts`; `defineJsonRpcHandler`'s direct `req.json()` in `src/utils/json-rpc.ts`). srvx's `maxRequestBodySize` has no default (`undefined` = no limit), so plain `readBody(event)` buffers unbounded bodies → memory exhaustion under a few concurrent large/slow POSTs. Proposed design: `DEFAULT_BODY_LIMIT = 1 MiB` enforced via the existing `assertBodySize` streaming primitive before buffering, overridable per read with a `maxSize` option (`Infinity` disables).
-- [ ] Remove the legacy `iterations: 1` PBKDF2 unseal fallback in `unsealSession` (`src/utils/session.ts`) and the `legacySealFallback` option. Kept for now so sessions sealed before the default was raised to 8192 iterations survive the upgrade; drop it after a migration window (weak-KDF cookies are ~8192× easier to brute-force and the retry doubles unseal CPU on garbage tokens).

--- a/v2.md
+++ b/v2.md
@@ -1,3 +1,4 @@
 # v2 TODOs
 
+- [ ] Add a default request-body size cap to the buffering body readers (`readBody`, `readValidatedBody` in `src/utils/body.ts`; `defineJsonRpcHandler`'s direct `req.json()` in `src/utils/json-rpc.ts`). srvx's `maxRequestBodySize` has no default (`undefined` = no limit), so plain `readBody(event)` buffers unbounded bodies → memory exhaustion under a few concurrent large/slow POSTs. Proposed design: `DEFAULT_BODY_LIMIT = 1 MiB` enforced via the existing `assertBodySize` streaming primitive before buffering, overridable per read with a `maxSize` option (`Infinity` disables).
 - [ ] Remove the legacy `iterations: 1` PBKDF2 unseal fallback in `unsealSession` (`src/utils/session.ts`) and the `legacySealFallback` option. Kept for now so sessions sealed before the default was raised to 8192 iterations survive the upgrade; drop it after a migration window (weak-KDF cookies are ~8192× easier to brute-force and the retry doubles unseal CPU on garbage tokens).


### PR DESCRIPTION
## What

Collapses `resolveDotSegments`' fast-path guard — previously 2 regex tests + 2 `includes` scans (`\\`, `ENCODED_SEP_RE`, `//`, `DOT_SEGMENT_RE`) — into a **single scan** of one of four mode-indexed trigger regexes (`(decodeSlashes?1:0) | (mergeSlashes?2:0)`).

- The per-mode regexes are built from shared source strings (`DOT_SEGMENT_SRC`, `ENCODED_SEP_SRC`), so each trigger pattern still lives in exactly one place.
- Each mode's regex contains exactly its own triggers, so a non-match remains an **exact** no-op guarantee (no cross-mode false positives, no behavior change).
- On the (rare) slow path, the `hasEncodedSep` pre-test becomes an opt-gated global replace — a no-op when nothing matches.

## Why

`resolveDotSegments` runs per request in `serveStatic` and downstream security consumers (h3-rules calls it on every matched request for dual-path rule matching), and the overwhelmingly common input is an already-canonical path — the guard *is* the hot path.

Benchmarks (mitata, node 24, x64):

| case | before | after |
|---|---|---|
| plain path, no opts | 37 ns | 29 ns |
| plain path, `{ decodeSlashes, mergeSlashes }` | 89 ns | **38 ns (-58%)** |
| `/.well-known/security.txt`, both opts | 84 ns | 34 ns |
| traversal (slow path), both opts | 878 ns | 849 ns (noise) |

## Verification

- Differential fuzz vs the previous implementation: **966,736 comparisons** across all four option modes over adversarial fragment combinations (`%252e`, `%25%32%66`, `\`, `//`, `...`, dot-prefixed names) — zero divergence.
- New directed tests pin the boundary-aware edge the combined regexes must keep: `/.well-known/…`, `/a/..b/c`, `/a%2eb/c`, `/a/...` stay untouched in every mode.
- Full suite: 1437 tests + typecheck + lint pass.

## Follow-up

Planned next: export the guard as a public `isCanonicalPath(path, opts)` predicate (pinned by a property test against `resolveDotSegments` identity) so security-adjacent callers like h3-rules can skip canonicalization calls entirely without duplicating decode knowledge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed a new `isCanonicalPath(path, opts?)` utility to let you check whether path resolution would leave the input unchanged.
* **Bug Fixes**
  * Improved path normalization/canonicality handling so dot-prefixed *segment names* (including encoded dot-leading forms) reliably remain unchanged across supported processing modes.
  * Preserved correct `.`/`..` resolution, slash decoding, and optional slash merging behavior.
* **Documentation**
  * Expanded Path security documentation with precise “canonical” conditions for `isCanonicalPath`.
  * Added “v2 TODOs” for request-body size safeguards and removal of a legacy unseal fallback.
* **Tests**
  * Added targeted unit coverage and fuzzing to validate canonical-path behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->