### PR TITLE
feat!: escape interpolated values in `html` tagged template

### DIFF
--- a/docs/1.guide/1.basics/5.response.md
+++ b/docs/1.guide/1.basics/5.response.md
@@ -86,13 +86,20 @@ app.get("/", (event) => {
 });
 ```
 
-You can also use `html` utility as shortcut.
+You can also use `html` utility as shortcut. Interpolated values in the tagged template are automatically HTML-escaped to help prevent XSS.
 
 ```js
-import { html } from "h3";
+import { html, raw } from "h3";
 
-app.get("/", () => html("<h1>hello world</h1>"));
+// Tagged template: interpolations are escaped
+app.get("/hello/:name", (event) => html`<h1>hello ${event.context.params.name}</h1>`);
+
+// Trusted markup: sent as-is
+app.get("/", () => html(raw("<h1>hello world</h1>")));
 ```
+
+> [!IMPORTANT]
+> Calling `html()` with a plain string escapes the whole string (a warning is logged if escaping changed it). Use the tagged template for dynamic values, or wrap trusted markup with `raw()`.
 
 ### `Response`
 

--- a/docs/2.utils/2.response.md
+++ b/docs/2.utils/2.response.md
@@ -112,6 +112,19 @@ Respond with an empty payload.<br>
 app.get("/", () => noContent());
 ```
 
+### `raw(value)`
+
+Mark a string as trusted, pre-escaped HTML so it is interpolated into the {@link html} tagged template **without** being escaped.
+
+Only use this for markup you fully control — passing user input to `raw` re-introduces XSS risk.
+
+**Example:**
+
+```ts
+// `heading` is trusted markup; `userName` is escaped automatically.
+app.get("/", () => html`<div>${raw(heading)}<span>${userName}</span></div>`);
+```
+
 ### `redirect(location, status, statusText?)`
 
 Send a redirect response to the client.

--- a/docs/2.utils/2.response.md
+++ b/docs/2.utils/2.response.md
@@ -114,7 +114,7 @@ app.get("/", () => noContent());
 
 ### `raw(value)`
 
-Mark a string as trusted, pre-escaped HTML so it is interpolated into the {@link html} tagged template **without** being escaped.
+Mark a string as trusted, pre-escaped HTML so it is used by the {@link html} util **without** being escaped.
 
 Only use this for markup you fully control — passing user input to `raw` re-introduces XSS risk.
 
@@ -123,6 +123,13 @@ Only use this for markup you fully control — passing user input to `raw` re-in
 ```ts
 // `heading` is trusted markup; `userName` is escaped automatically.
 app.get("/", () => html`<div>${raw(heading)}<span>${userName}</span></div>`);
+```
+
+**Example:**
+
+```ts
+// Send a trusted markup string as-is:
+app.get("/", () => html(raw("<h1>Hello, World!</h1>")));
 ```
 
 ### `redirect(location, status, statusText?)`

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,9 @@ export {
   iterable,
   noContent,
   html,
+  raw,
 } from "./utils/response.ts";
+export type { RawHTML } from "./utils/response.ts";
 
 // Query (RFC 10008 HTTP QUERY method)
 

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -216,44 +216,65 @@ export function iterable<Value = unknown, Return = unknown>(
  * HTML-escaped (`& < > " '`) to help prevent XSS. Wrap a value with {@link raw}
  * to opt out of escaping for trusted markup.
  *
- * When called with a **plain string**, the markup is used as-is (no escaping).
+ * When called with a **plain string**, the whole string is HTML-escaped and
+ * rendered as text. If escaping changes the input, a warning is logged — use
+ * the tagged template for dynamic values, or pass trusted markup with
+ * {@link raw}: `html(raw(markup))`.
  *
- * @example
- * // Plain string (used as-is, not escaped):
- * app.get("/", () => html("<h1>Hello, World!</h1>"));
+ * Escaping protects values in element content and inside quoted attribute
+ * values only. It cannot make unquoted attributes, URL attributes (e.g.
+ * `href` with a `javascript:` URL) or `<script>`/`<style>` contents safe —
+ * validate such values separately.
  *
  * @example
  * // Tagged template (interpolations are escaped):
  * app.get("/", () => html`<h1>Hello, ${name}!</h1>`);
  *
  * @example
- * // Opt out of escaping for trusted markup:
+ * // Trusted markup (used as-is, not escaped):
+ * app.get("/", () => html(raw("<h1>Hello, World!</h1>")));
+ *
+ * @example
+ * // Opt out of escaping for a trusted interpolation:
  * app.get("/", () => html`<div>${raw(trustedMarkup)}</div>`);
  */
 export function html(strings: TemplateStringsArray, ...values: unknown[]): HTTPResponse;
-export function html(markup: string): HTTPResponse;
-export function html(first: TemplateStringsArray | string, ...values: unknown[]): HTTPResponse {
-  const body =
-    typeof first === "string"
-      ? first
-      : first.reduce((out, str, i) => {
-          const value = values[i];
-          const rendered =
-            value == null
-              ? ""
-              : value instanceof RawHTMLValue
-                ? value.value
-                : escapeHtml(String(value));
-          return out + str + rendered;
-        }, "");
+export function html(markup: string | RawHTML): HTTPResponse;
+export function html(
+  first: TemplateStringsArray | string | RawHTMLValue,
+  ...values: unknown[]
+): HTTPResponse {
+  let body: string;
+  if (typeof first === "string") {
+    body = escapeHtml(first);
+    if (body !== first && (html as { _isWarned?: boolean })._isWarned !== true) {
+      (html as { _isWarned?: boolean })._isWarned = true;
+      console.warn(
+        "[h3] `html()` received a plain string containing HTML characters and escaped it. Use the html`` tagged template for dynamic values, or wrap trusted markup with `raw()`.",
+      );
+    }
+  } else if (first instanceof RawHTMLValue) {
+    body = first.value;
+  } else {
+    body = first.reduce((out, str, i) => {
+      const value = values[i];
+      const rendered =
+        value == null
+          ? ""
+          : value instanceof RawHTMLValue
+            ? value.value
+            : escapeHtml(String(value));
+      return out + str + rendered;
+    }, "");
+  }
   return new HTTPResponse(body, {
     headers: { "content-type": "text/html; charset=utf-8" },
   });
 }
 
 /**
- * Mark a string as trusted, pre-escaped HTML so it is interpolated into the
- * {@link html} tagged template **without** being escaped.
+ * Mark a string as trusted, pre-escaped HTML so it is used by the
+ * {@link html} util **without** being escaped.
  *
  * Only use this for markup you fully control — passing user input to `raw`
  * re-introduces XSS risk.
@@ -261,6 +282,10 @@ export function html(first: TemplateStringsArray | string, ...values: unknown[])
  * @example
  * // `heading` is trusted markup; `userName` is escaped automatically.
  * app.get("/", () => html`<div>${raw(heading)}<span>${userName}</span></div>`);
+ *
+ * @example
+ * // Send a trusted markup string as-is:
+ * app.get("/", () => html(raw("<h1>Hello, World!</h1>")));
  */
 export function raw(value: string): RawHTML {
   return new RawHTMLValue(value);

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -241,7 +241,7 @@ export function iterable<Value = unknown, Return = unknown>(
 export function html(strings: TemplateStringsArray, ...values: unknown[]): HTTPResponse;
 export function html(markup: string | RawHTML): HTTPResponse;
 export function html(
-  first: TemplateStringsArray | string | RawHTMLValue,
+  first: TemplateStringsArray | string | RawHTML,
   ...values: unknown[]
 ): HTTPResponse {
   let body: string;
@@ -253,17 +253,13 @@ export function html(
         "[h3] `html()` received a plain string containing HTML characters and escaped it. Use the html`` tagged template for dynamic values, or wrap trusted markup with `raw()`.",
       );
     }
-  } else if (first instanceof RawHTMLValue) {
+  } else if (isRawHTML(first)) {
     body = first.value;
   } else {
     body = first.reduce((out, str, i) => {
       const value = values[i];
       const rendered =
-        value == null
-          ? ""
-          : value instanceof RawHTMLValue
-            ? value.value
-            : escapeHtml(String(value));
+        value == null ? "" : isRawHTML(value) ? value.value : escapeHtml(String(value));
       return out + str + rendered;
     }, "");
   }
@@ -288,7 +284,7 @@ export function html(
  * app.get("/", () => html(raw("<h1>Hello, World!</h1>")));
  */
 export function raw(value: string): RawHTML {
-  return new RawHTMLValue(value);
+  return { [kRawHTML]: true, value } as RawHTML;
 }
 
 /** Trusted raw HTML wrapper produced by {@link raw}. */
@@ -296,11 +292,14 @@ export interface RawHTML {
   readonly value: string;
 }
 
-class RawHTMLValue implements RawHTML {
-  readonly value: string;
-  constructor(value: string) {
-    this.value = value;
-  }
+const kRawHTML: unique symbol = /* @__PURE__ */ Symbol.for("h3.rawHTML");
+
+function isRawHTML(value: unknown): value is RawHTML {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { [kRawHTML]?: unknown })[kRawHTML] === true
+  );
 }
 
 /** HTML-escape the special characters `& < > " '`. */

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -44,11 +44,7 @@ export function redirect(
   status: number = 302,
   statusText?: string,
 ): HTTPResponse {
-  const htmlLoc = location.replace(
-    /[&"<>]/g,
-    (c) => ({ "&": "&amp;", '"': "&quot;", "<": "&lt;", ">": "&gt;" })[c]!,
-  );
-  const body = /* html */ `<html><head><meta http-equiv="refresh" content="0; url=${htmlLoc}" /></head></html>`;
+  const body = /* html */ `<html><head><meta http-equiv="refresh" content="0; url=${escapeHtml(location)}" /></head></html>`;
   return new HTTPResponse(body, {
     status,
     statusText: statusText || (status === 301 ? "Moved Permanently" : "Found"),
@@ -216,9 +212,23 @@ export function iterable<Value = unknown, Return = unknown>(
 /**
  * Respond with HTML content.
  *
+ * When used as a **tagged template**, interpolated values are automatically
+ * HTML-escaped (`& < > " '`) to help prevent XSS. Wrap a value with {@link raw}
+ * to opt out of escaping for trusted markup.
+ *
+ * When called with a **plain string**, the markup is used as-is (no escaping).
+ *
  * @example
+ * // Plain string (used as-is, not escaped):
  * app.get("/", () => html("<h1>Hello, World!</h1>"));
+ *
+ * @example
+ * // Tagged template (interpolations are escaped):
  * app.get("/", () => html`<h1>Hello, ${name}!</h1>`);
+ *
+ * @example
+ * // Opt out of escaping for trusted markup:
+ * app.get("/", () => html`<div>${raw(trustedMarkup)}</div>`);
  */
 export function html(strings: TemplateStringsArray, ...values: unknown[]): HTTPResponse;
 export function html(markup: string): HTTPResponse;
@@ -226,8 +236,52 @@ export function html(first: TemplateStringsArray | string, ...values: unknown[])
   const body =
     typeof first === "string"
       ? first
-      : first.reduce((out, str, i) => out + str + (values[i] ?? ""), "");
+      : first.reduce((out, str, i) => {
+          const value = values[i];
+          const rendered =
+            value == null
+              ? ""
+              : value instanceof RawHTMLValue
+                ? value.value
+                : escapeHtml(String(value));
+          return out + str + rendered;
+        }, "");
   return new HTTPResponse(body, {
     headers: { "content-type": "text/html; charset=utf-8" },
   });
+}
+
+/**
+ * Mark a string as trusted, pre-escaped HTML so it is interpolated into the
+ * {@link html} tagged template **without** being escaped.
+ *
+ * Only use this for markup you fully control — passing user input to `raw`
+ * re-introduces XSS risk.
+ *
+ * @example
+ * // `heading` is trusted markup; `userName` is escaped automatically.
+ * app.get("/", () => html`<div>${raw(heading)}<span>${userName}</span></div>`);
+ */
+export function raw(value: string): RawHTML {
+  return new RawHTMLValue(value);
+}
+
+/** Trusted raw HTML wrapper produced by {@link raw}. */
+export interface RawHTML {
+  readonly value: string;
+}
+
+class RawHTMLValue implements RawHTML {
+  readonly value: string;
+  constructor(value: string) {
+    this.value = value;
+  }
+}
+
+/** HTML-escape the special characters `& < > " '`. */
+function escapeHtml(str: string): string {
+  return str.replace(
+    /[&"'<>]/g,
+    (c) => ({ "&": "&amp;", '"': "&quot;", "'": "&#39;", "<": "&lt;", ">": "&gt;" })[c]!,
+  );
 }

--- a/test/unit/package.test.ts
+++ b/test/unit/package.test.ts
@@ -99,6 +99,7 @@ describe("h3 package", () => {
         "parseCookies",
         "proxy",
         "proxyRequest",
+        "raw",
         "readBody",
         "readFormData",
         "readFormDataBody",

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -11,6 +11,7 @@ import {
   getRequestFingerprint,
   handleCacheHeaders,
   html,
+  raw,
   writeEarlyHints,
 } from "../src/index.ts";
 import { describeMatrix } from "./_setup.ts";
@@ -27,6 +28,30 @@ describeMatrix("utils", (t, { it, describe, expect }) => {
       const res2 = await t.fetch("/test2");
       expect(res2.headers.get("content-type")).toBe("text/html; charset=utf-8");
       expect((await res2.text()).trim()).toBe("<h1>Hello</h1>");
+    });
+
+    it("escapes interpolated values in tagged template", async () => {
+      const name = `<script>alert("xss")</script>&'`;
+      t.app.get("/test", () => html`<h1>Hello, ${name}!</h1>`);
+      const res = await t.fetch("/test");
+      expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
+      expect(await res.text()).toBe(
+        "<h1>Hello, &lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;&amp;&#39;!</h1>",
+      );
+    });
+
+    it("passes raw() values through unescaped", async () => {
+      const trusted = "<b>bold</b>";
+      const user = "<script>";
+      t.app.get("/test", () => html`<div>${raw(trusted)}${user}</div>`);
+      const res = await t.fetch("/test");
+      expect(await res.text()).toBe("<div><b>bold</b>&lt;script&gt;</div>");
+    });
+
+    it("does not escape plain string usage", async () => {
+      t.app.get("/test", () => html("<p>raw & <string></p>"));
+      const res = await t.fetch("/test");
+      expect(await res.text()).toBe("<p>raw & <string></p>");
     });
   });
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -55,6 +55,14 @@ describeMatrix("utils", (t, { it, describe, expect }) => {
       expect(await res.text()).not.toContain("<script>");
     });
 
+    it("accepts raw() values from another h3 instance (symbol brand)", async () => {
+      // Simulates raw() from a duplicated copy of h3 via the global symbol registry
+      const foreignRaw = { [Symbol.for("h3.rawHTML")]: true, value: "<b>bold</b>" };
+      t.app.get("/test", () => html`<div>${foreignRaw}</div>`);
+      const res = await t.fetch("/test");
+      expect(await res.text()).toBe("<div><b>bold</b></div>");
+    });
+
     it("escapes plain string usage and warns once", async () => {
       (html as { _isWarned?: boolean })._isWarned = false;
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach } from "vitest";
+import { beforeEach, vi } from "vitest";
 import {
   redirect,
   redirectBack,
@@ -19,7 +19,7 @@ import { describeMatrix } from "./_setup.ts";
 describeMatrix("utils", (t, { it, describe, expect }) => {
   describe("html", () => {
     it("can return html response", async () => {
-      t.app.get("/test", () => html("<h1>Hello</h1>"));
+      t.app.get("/test", () => html(raw("<h1>Hello</h1>")));
       const res1 = await t.fetch("/test");
       expect(res1.headers.get("content-type")).toBe("text/html; charset=utf-8");
       expect(await res1.text()).toBe("<h1>Hello</h1>");
@@ -48,10 +48,42 @@ describeMatrix("utils", (t, { it, describe, expect }) => {
       expect(await res.text()).toBe("<div><b>bold</b>&lt;script&gt;</div>");
     });
 
-    it("does not escape plain string usage", async () => {
-      t.app.get("/test", () => html("<p>raw & <string></p>"));
+    it("does not treat duck-typed objects as raw values", async () => {
+      const spoofed = { value: "<script>alert(1)</script>" };
+      t.app.get("/test", () => html`<div>${spoofed}</div>`);
       const res = await t.fetch("/test");
-      expect(await res.text()).toBe("<p>raw & <string></p>");
+      expect(await res.text()).not.toContain("<script>");
+    });
+
+    it("escapes plain string usage and warns once", async () => {
+      (html as { _isWarned?: boolean })._isWarned = false;
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        t.app.get("/test", () => html("<p>raw & <string></p>"));
+        const res = await t.fetch("/test");
+        expect(await res.text()).toBe("&lt;p&gt;raw &amp; &lt;string&gt;&lt;/p&gt;");
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy.mock.calls[0][0]).toContain("html``");
+
+        const res2 = await t.fetch("/test");
+        expect(await res2.text()).toBe("&lt;p&gt;raw &amp; &lt;string&gt;&lt;/p&gt;");
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("does not warn for plain strings without special characters", async () => {
+      (html as { _isWarned?: boolean })._isWarned = false;
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        t.app.get("/test", () => html("Hello, World!"));
+        const res = await t.fetch("/test");
+        expect(await res.text()).toBe("Hello, World!");
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
   });
 


### PR DESCRIPTION
## Why

The `html``` tagged template raw-concatenates interpolated values, while its docstring example (`html`<h1>Hello, ${name}!</h1>``) and its name (matching auto-escaping libraries like lit-html) suggest values are sanitized. Interpolating user input this way is a reflected/stored XSS footgun.

## What

- Tagged-template interpolations are now HTML-escaped (`& < > " '`) by default.
- New `raw()` helper marks trusted markup (e.g. adding `<script>` tags) to pass through unescaped:
  ```ts
  app.get("/", () => html`<head>${raw(analyticsScript)}</head><h1>Hello ${userName}</h1>`);
  ```
- **Plain-string usage is now escaped too**: `html(string)` escapes the whole string and renders it as text, and logs a one-time warning suggesting the tagged template (or `raw()`) when escaping changed the input. This closes the near-miss footgun where `html(`...${user}...`)` — parentheses instead of a tagged template — was silently unescaped.
- Trusted markup strings are sent as-is with the new `html(raw(markup))` form.
- The escape helper is extracted and shared with `redirect()`'s meta-refresh body, which now also escapes single quotes.
- `raw()` values are branded with `Symbol.for("h3.rawHTML")` rather than an `instanceof` check, so they stay recognized across duplicated copies of h3 (dual package hazard) while remaining unforgeable through JSON deserialization.
- JSDoc and guide docs state the escaping contexts explicitly: safe for element content and quoted attribute values only — unquoted attributes, URL attributes (`javascript:` in `href`), and `<script>`/`<style>` contents still need separate validation.

## Tests

Regression tests in `test/utils.test.ts` (web + node matrix): interpolated `<script>` payload is escaped and served as `text/html`; `raw()` passes markup through while adjacent values are still escaped; plain-string form is fully escaped and warns exactly once (no warning when escaping is a no-op); duck-typed `{ value }` objects do not bypass escaping while symbol-branded values from another h3 copy pass through. All failed before the fix, pass after. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `raw` and `RawHTML` to support inserting trusted, pre-escaped HTML without further escaping.
  - Enhanced `html` to auto-escape tagged template interpolations, while passing trusted `raw` markup through unchanged.
  - `raw` (and `RawHTML`) are now exported publicly.
- **Bug Fixes**
  - Redirect responses now generate the meta-refresh HTML body with safe escaping.
- **Documentation**
  - Updated response docs with safer `html` and `raw` usage examples and warnings.
- **Tests**
  - Expanded `html`/`raw` test coverage and updated export snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
