### PR TITLE
feat: export `isCanonicalPath` predicate for `resolveDotSegments`

### DIFF
--- a/docs/2.utils/4.security.md
+++ b/docs/2.utils/4.security.md
@@ -134,11 +134,13 @@ Check if the incoming request is a CORS preflight request.
 
 ### `isCanonicalPath(path, opts?)`
 
-Whether `path` is already in the canonical form {@link resolveDotSegments} produces under the same options — i.e. resolving it is guaranteed to be a no-op. Exact in both directions: `isCanonicalPath(path, opts)` is `true` if and only if `resolveDotSegments(path, opts) === path`.
+Whether `path` is already canonical under `opts` — i.e. {@link resolveDotSegments} would return it unchanged. Exact in both directions: `true` if and only if `resolveDotSegments(path, opts) === path`.
 
-This is the resolver's own fast-path guard, exported so a caller that canonicalizes on a hot path (per-request scope or rule matching) can skip the call — and any derived work — without duplicating knowledge of what the resolver decodes. Checking here and resolving elsewhere with different options voids the guarantee: pass the exact options the later call uses, or stricter ones (`decodeSlashes`/`mergeSlashes` enabled is strictly more sensitive, so a `true` result with both on implies `true` for every mode).
+This is the resolver's own fast-path guard, exported so a caller that canonicalizes on a hot path (per-request scope or rule matching) can skip the call — and any work derived from it — without keeping its own copy of what the resolver decodes. Such a copy goes stale silently, and a missed canonicalization in a scope check is a bypass, not a perf bug.
 
-Like the resolver, this never inspects a query/hash — callers pass a bare pathname.
+Pass the same options as the later {@link resolveDotSegments} call, or stricter ones: `decodeSlashes`/`mergeSlashes` only add triggers, so `true` with both enabled implies `true` in every mode. Checking one mode and resolving in another voids the guarantee.
+
+Takes a bare pathname. Like the resolver, it has no notion of a query or hash and scans one as if it were path, so `/a?next=/../b` is reported non-canonical (and would resolve to `/b`).
 
 ### `resolveDotSegments(path, opts?)`
 

--- a/docs/2.utils/4.security.md
+++ b/docs/2.utils/4.security.md
@@ -132,6 +132,14 @@ Check if the incoming request is a CORS preflight request.
 
 <!-- automd:jsdocs src="../../src/utils/path.ts" -->
 
+### `isCanonicalPath(path, opts?)`
+
+Whether `path` is already in the canonical form {@link resolveDotSegments} produces under the same options — i.e. resolving it is guaranteed to be a no-op. Exact in both directions: `isCanonicalPath(path, opts)` is `true` if and only if `resolveDotSegments(path, opts) === path`.
+
+This is the resolver's own fast-path guard, exported so a caller that canonicalizes on a hot path (per-request scope or rule matching) can skip the call — and any derived work — without duplicating knowledge of what the resolver decodes. Checking here and resolving elsewhere with different options voids the guarantee: pass the exact options the later call uses, or stricter ones (`decodeSlashes`/`mergeSlashes` enabled is strictly more sensitive, so a `true` result with both on implies `true` for every mode).
+
+Like the resolver, this never inspects a query/hash — callers pass a bare pathname.
+
 ### `resolveDotSegments(path, opts?)`
 
 Resolve `.` and `..` segments in a path, without ever escaping above the root `/`. The result is always an absolute path with a single leading `/`, so it can never be protocol-relative (`//host`).

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,7 +168,11 @@ export { type CacheConditions, handleCacheHeaders } from "./utils/cache.ts";
 
 // Path
 
-export { type ResolveDotSegmentsOptions, resolveDotSegments } from "./utils/path.ts";
+export {
+  type ResolveDotSegmentsOptions,
+  isCanonicalPath,
+  resolveDotSegments,
+} from "./utils/path.ts";
 
 // Static
 

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -73,15 +73,13 @@ const DOT_SEGMENT_SRC = String.raw`(?:^|/)(?:\.|%(?:25)*2e){1,2}(?:/|$)`;
 const ENCODED_SEP_SRC = String.raw`%(?:25)*(?:2f|5c)`;
 const ENCODED_SEP_RE_G = /* @__PURE__ */ new RegExp(ENCODED_SEP_SRC, "gi");
 
-// One combined trigger regex per option mode so the fast-path guard is a
-// SINGLE scan of the path, indexed by `(decodeSlashes?1:0) | (mergeSlashes?2:0)`.
-// Each alternative is the exact trigger of one slow-path transformation — `\`
-// normalization, dot-segment resolution, and (per mode) `%2f`/`%5c` decoding
-// and `//` run collapsing — so "no match" guarantees resolving is a no-op. An
-// encoded separator only forms a run once decoded, so the `decodeSlashes`
-// alternative already covers the runs `mergeSlashes` can additionally see; the
-// leading-separator normalization happens before the guard, so a remaining
-// `//` is interior or trailing.
+// One combined trigger regex per option mode, so the fast-path guard is a single
+// scan. Indexed by `(decodeSlashes ? 1 : 0) | (mergeSlashes ? 2 : 0)`. Each
+// alternative is the exact trigger of one slow-path transformation — `\`
+// normalization, dot-segment resolution, and per mode `%2f`/`%5c` decoding and
+// `//` collapsing — so "no match" guarantees resolving is a no-op. Decoding is
+// what turns an encoded separator into a run, so the `decodeSlashes` alternative
+// already covers the extra runs `mergeSlashes` would see.
 const TRIGGER_RES = /* @__PURE__ */ (() => {
   const base = String.raw`\\|` + DOT_SEGMENT_SRC;
   return [
@@ -131,13 +129,14 @@ export function resolveDotSegments(path: string, opts?: ResolveDotSegmentsOption
   if (path[0] !== "/" || path[1] === "/" || path[1] === "\\") {
     path = "/" + path.replace(/^[/\\]+/, "");
   }
-  const decodeSlashes = opts?.decodeSlashes;
-  const mergeSlashes = opts?.mergeSlashes;
-  // Fast-path guard: one scan of the mode's combined trigger regex (see
-  // TRIGGER_RES) — the common, already-canonical path returns here.
-  if (!TRIGGER_RES[(decodeSlashes ? 1 : 0) | (mergeSlashes ? 2 : 0)]!.test(path)) {
+  // Fast-path guard — the common, already-canonical path returns here. The
+  // leading run is normalized above, so any `//` the guard sees is interior or
+  // trailing, and its leading-slash checks are already satisfied.
+  if (isCanonicalPath(path, opts)) {
     return path;
   }
+  const decodeSlashes = opts?.decodeSlashes;
+  const mergeSlashes = opts?.mergeSlashes;
   // Normalize backslashes to forward slashes to prevent traversal via `\`
   let normalized = path.includes("\\") ? path.replaceAll("\\", "/") : path;
   if (decodeSlashes) {
@@ -186,21 +185,24 @@ export function resolveDotSegments(path: string, opts?: ResolveDotSegmentsOption
 }
 
 /**
- * Whether `path` is already in the canonical form {@link resolveDotSegments}
- * produces under the same options — i.e. resolving it is guaranteed to be a
- * no-op. Exact in both directions: `isCanonicalPath(path, opts)` is `true` if
- * and only if `resolveDotSegments(path, opts) === path`.
+ * Whether `path` is already canonical under `opts` — i.e. {@link resolveDotSegments}
+ * would return it unchanged. Exact in both directions: `true` if and only if
+ * `resolveDotSegments(path, opts) === path`.
  *
  * This is the resolver's own fast-path guard, exported so a caller that
- * canonicalizes on a hot path (per-request scope or rule matching) can skip
- * the call — and any derived work — without duplicating knowledge of what the
- * resolver decodes. Checking here and resolving elsewhere with different
- * options voids the guarantee: pass the exact options the later call uses, or
- * stricter ones (`decodeSlashes`/`mergeSlashes` enabled is strictly more
- * sensitive, so a `true` result with both on implies `true` for every mode).
+ * canonicalizes on a hot path (per-request scope or rule matching) can skip the
+ * call — and any work derived from it — without keeping its own copy of what the
+ * resolver decodes. Such a copy goes stale silently, and a missed
+ * canonicalization in a scope check is a bypass, not a perf bug.
  *
- * Like the resolver, this never inspects a query/hash — callers pass a bare
- * pathname.
+ * Pass the same options as the later {@link resolveDotSegments} call, or stricter
+ * ones: `decodeSlashes`/`mergeSlashes` only add triggers, so `true` with both
+ * enabled implies `true` in every mode. Checking one mode and resolving in
+ * another voids the guarantee.
+ *
+ * Takes a bare pathname. Like the resolver, it has no notion of a query or hash
+ * and scans one as if it were path, so `/a?next=/../b` is reported non-canonical
+ * (and would resolve to `/b`).
  */
 export function isCanonicalPath(path: string, opts?: ResolveDotSegmentsOptions): boolean {
   return (

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -184,3 +184,29 @@ export function resolveDotSegments(path: string, opts?: ResolveDotSegmentsOption
   // protocol-relative path. (A no-op when there is already one leading slash.)
   return result.replace(/^\/+/, "/");
 }
+
+/**
+ * Whether `path` is already in the canonical form {@link resolveDotSegments}
+ * produces under the same options — i.e. resolving it is guaranteed to be a
+ * no-op. Exact in both directions: `isCanonicalPath(path, opts)` is `true` if
+ * and only if `resolveDotSegments(path, opts) === path`.
+ *
+ * This is the resolver's own fast-path guard, exported so a caller that
+ * canonicalizes on a hot path (per-request scope or rule matching) can skip
+ * the call — and any derived work — without duplicating knowledge of what the
+ * resolver decodes. Checking here and resolving elsewhere with different
+ * options voids the guarantee: pass the exact options the later call uses, or
+ * stricter ones (`decodeSlashes`/`mergeSlashes` enabled is strictly more
+ * sensitive, so a `true` result with both on implies `true` for every mode).
+ *
+ * Like the resolver, this never inspects a query/hash — callers pass a bare
+ * pathname.
+ */
+export function isCanonicalPath(path: string, opts?: ResolveDotSegmentsOptions): boolean {
+  return (
+    path[0] === "/" &&
+    path[1] !== "/" &&
+    path[1] !== "\\" &&
+    !TRIGGER_RES[(opts?.decodeSlashes ? 1 : 0) | (opts?.mergeSlashes ? 2 : 0)]!.test(path)
+  );
+}

--- a/test/unit/package.test.ts
+++ b/test/unit/package.test.ts
@@ -83,6 +83,7 @@ describe("h3 package", () => {
         "handleCacheHeaders",
         "handleCors",
         "html",
+        "isCanonicalPath",
         "isCorsOriginAllowed",
         "isError",
         "isEvent",

--- a/test/unit/path.test.ts
+++ b/test/unit/path.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveDotSegments } from "../../src/utils/path.ts";
+import { isCanonicalPath, resolveDotSegments } from "../../src/utils/path.ts";
 
 describe("resolveDotSegments", () => {
   it("leaves a plain path untouched", () => {
@@ -148,6 +148,96 @@ describe("resolveDotSegments", () => {
     expect(resolveDotSegments("/a/../..")).toBe("/");
     // Merge mode preserves it too.
     expect(resolveDotSegments("/a/b/..", { mergeSlashes: true })).toBe("/a/");
+  });
+
+  describe("isCanonicalPath", () => {
+    const MODES = [
+      undefined,
+      { decodeSlashes: true },
+      { mergeSlashes: true },
+      { decodeSlashes: true, mergeSlashes: true },
+    ];
+
+    it("accepts already-canonical paths in every mode", () => {
+      for (const opts of MODES) {
+        expect(isCanonicalPath("/", opts)).toBe(true);
+        expect(isCanonicalPath("/api/users/123", opts)).toBe(true);
+        expect(isCanonicalPath("/assets/app.1a2b.js", opts)).toBe(true);
+        expect(isCanonicalPath("/.well-known/security.txt", opts)).toBe(true);
+        expect(isCanonicalPath("/foo%20bar/a%3Ab", opts)).toBe(true);
+        expect(isCanonicalPath("/a%2eb/..c/...", opts)).toBe(true);
+      }
+    });
+
+    it("rejects anything the resolver would change, per mode", () => {
+      // Mode-independent triggers.
+      for (const opts of MODES) {
+        expect(isCanonicalPath("/a/../b", opts)).toBe(false);
+        expect(isCanonicalPath("/a/%2e%2e/b", opts)).toBe(false);
+        expect(isCanonicalPath("/a\\b", opts)).toBe(false);
+        expect(isCanonicalPath("//evil.com", opts)).toBe(false);
+        expect(isCanonicalPath("relative", opts)).toBe(false);
+        expect(isCanonicalPath("", opts)).toBe(false);
+      }
+      // Opt-gated triggers: opaque in one mode, a separator in the other.
+      expect(isCanonicalPath("/a%2fb")).toBe(true);
+      expect(isCanonicalPath("/a%2fb", { decodeSlashes: true })).toBe(false);
+      expect(isCanonicalPath("/a%255cb", { decodeSlashes: true })).toBe(false);
+      expect(isCanonicalPath("/a//b")).toBe(true);
+      expect(isCanonicalPath("/a//b", { mergeSlashes: true })).toBe(false);
+    });
+
+    it("is exactly `resolveDotSegments(path, opts) === path` (seeded fuzz)", () => {
+      // The predicate IS the resolver's fast-path guard — this property is the
+      // contract that keeps them in lockstep: any future widening of what the
+      // resolver decodes must widen the guard in the same commit, or a caller
+      // using the predicate to skip resolving would silently skip a
+      // canonicalization step (a scope/auth-check bypass, not just a perf bug).
+      const FRAGMENTS = [
+        "/",
+        "//",
+        "\\",
+        ".",
+        "..",
+        "...",
+        "%2e",
+        "%2E",
+        "%252e",
+        "%2e%2e",
+        "%2f",
+        "%5C",
+        "%252f",
+        "a",
+        "app.js",
+        ".well-known",
+        "..b",
+        "a%2eb",
+        "%20",
+        "%25",
+        "%",
+        "admin",
+        "%2e.",
+        ".%2e",
+        "%25%32%66",
+      ];
+      let seed = 1234;
+      const rand = () => (seed = (seed * 1_103_515_245 + 12_345) & 0x7f_ff_ff_ff) / 0x7f_ff_ff_ff;
+      for (let i = 0; i < 50_000; i++) {
+        let path = rand() < 0.9 ? "/" : "";
+        const length = 1 + Math.floor(rand() * 6);
+        for (let j = 0; j < length; j++) {
+          path += FRAGMENTS[Math.floor(rand() * FRAGMENTS.length)];
+        }
+        for (const opts of MODES) {
+          const identity = resolveDotSegments(path, opts) === path;
+          if (isCanonicalPath(path, opts) !== identity) {
+            expect.fail(
+              `isCanonicalPath(${JSON.stringify(path)}, ${JSON.stringify(opts)}) !== ${identity}`,
+            );
+          }
+        }
+      }
+    });
   });
 
   describe("mergeSlashes", () => {


### PR DESCRIPTION
Stacked on #1458 (retarget to `main` after it merges).

## What

Exports the resolver's fast-path guard as a public predicate:

```ts
isCanonicalPath(path, opts?: ResolveDotSegmentsOptions): boolean
```

Exact in both directions: `true` **iff** `resolveDotSegments(path, opts) === path`.

## Why

Callers that canonicalize on a hot path (per-request scope checks, route-rule matching) want to skip the resolve *and the work derived from it* — h3-rules matches both the empty-preserving and slash-merged readings on every request, and can collapse to a single match when the path is already canonical in the strictest mode.

They can't safely answer "is this canonical?" themselves. A caller-side prescan duplicates knowledge of what the resolver decodes, and a stale copy silently skips a canonicalization step — for these consumers that's a scope-check bypass, not a perf bug. The alternative, `resolveDotSegments(p, o) === p`, only works because the fast path happens to return the same string reference, which is an implementation detail and not part of the contract.

Exporting the resolver's own guard gives callers the check without either dependency.

## Pinning

- 200k-assertion seeded-fuzz equivalence test across all four option modes: `isCanonicalPath(p, o) === (resolveDotSegments(p, o) === p)`. Any future widening of what the resolver decodes must widen the guard in the same commit, or the property breaks.
- Directed cases for per-mode triggers (`%2f` opaque by default vs decoded with `decodeSlashes`, `//` with `mergeSlashes`) and fast-path retention (`/.well-known/…`, `/a%2eb`, `/a/...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
