### PR TITLE
refactor(request)!: make x-forwarded-proto trust opt-in

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -139,6 +139,9 @@ H3 v2 deprecated some legacy and aliased utilities.
 - `getRequestPath`: Migrate to `event.url.pathname`.
 - `getMethod`: Migrate to `event.req.method`.
 
+> [!IMPORTANT]
+> `getRequestProtocol` (and `getRequestURL`) no longer trust the `x-forwarded-proto` header by default. To honor it (only behind a trusted reverse proxy or CDN), opt in with `{ xForwardedProto: true }`. This matches the existing opt-in behavior of `getRequestHost` (`xForwardedHost`) and `getRequestIP` (`xForwardedFor`).
+
 > [!NOTE]
 > The following `H3Event` properties are deprecated in v2 and might be removed in a future version:
 >

--- a/docs/2.utils/1.request.md
+++ b/docs/2.utils/1.request.md
@@ -229,7 +229,9 @@ app.get("/", (event) => {
 
 Get the request protocol.
 
-If `x-forwarded-proto` header is set to "https", it will return "https". If the header contains a comma-separated list of protocols, the first entry is used. You can disable this behavior by setting `xForwardedProto` to `false`.
+If `xForwardedProto` is `true`, it will use the `x-forwarded-proto` header if it exists. When the header contains a comma-separated list of protocols, the first entry is used.
+
+Note: This header is opt-in (default `false`) since it can be spoofed by clients. Only enable it when your application runs behind a trusted reverse proxy or CDN that sets this header. This default was changed to match `getRequestHost` (`xForwardedHost`) and `getRequestIP` (`xForwardedFor`).
 
 If protocol cannot be determined, it will default to "http".
 
@@ -247,7 +249,7 @@ Generated the full incoming request URL.
 
 If `xForwardedHost` is `true`, it will use the `x-forwarded-host` header if it exists.
 
-If `xForwardedProto` is `false`, it will not use the `x-forwarded-proto` header.
+If `xForwardedProto` is `true`, it will use the `x-forwarded-proto` header if it exists.
 
 **Example:**
 

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -427,7 +427,9 @@ export function getRequestHost(event: HTTPEvent, opts: { xForwardedHost?: boolea
 /**
  * Get the request protocol.
  *
- * If `x-forwarded-proto` header is set to "https", it will return "https". If the header contains a comma-separated list of protocols, the first entry is used. You can disable this behavior by setting `xForwardedProto` to `false`.
+ * If `xForwardedProto` is `true`, it will use the `x-forwarded-proto` header if it exists. When the header contains a comma-separated list of protocols, the first entry is used.
+ *
+ * Note: This header is opt-in (default `false`) since it can be spoofed by clients. Only enable it when your application runs behind a trusted reverse proxy or CDN that sets this header. This default was changed to match `getRequestHost` (`xForwardedHost`) and `getRequestIP` (`xForwardedFor`).
  *
  * If protocol cannot be determined, it will default to "http".
  *
@@ -440,7 +442,7 @@ export function getRequestProtocol(
   event: HTTPEvent | H3Event,
   opts: { xForwardedProto?: boolean } = {},
 ): "http" | "https" | (string & {}) {
-  if (opts.xForwardedProto !== false) {
+  if (opts.xForwardedProto) {
     const _header = event.req.headers.get("x-forwarded-proto");
     const forwardedProto = (_header || "").split(",")[0].trim();
     if (forwardedProto === "https") {
@@ -459,7 +461,7 @@ export function getRequestProtocol(
  *
  * If `xForwardedHost` is `true`, it will use the `x-forwarded-host` header if it exists.
  *
- * If `xForwardedProto` is `false`, it will not use the `x-forwarded-proto` header.
+ * If `xForwardedProto` is `true`, it will use the `x-forwarded-proto` header if it exists.
  *
  * @example
  * app.get("/", (event) => {

--- a/test/unit/request.test.ts
+++ b/test/unit/request.test.ts
@@ -91,24 +91,29 @@ describe("requestWithBaseURL", () => {
 });
 
 describe("getRequestProtocol", () => {
-  it("returns https for plain x-forwarded-proto: https", () => {
-    const event = makeEvent({ "x-forwarded-proto": "https" });
-    expect(getRequestProtocol(event)).toBe("https");
-  });
-
-  it("returns http for plain x-forwarded-proto: http", () => {
-    const event = makeEvent({ "x-forwarded-proto": "http" });
+  it("ignores x-forwarded-proto by default (spoofed https)", () => {
+    const event = makeEvent({ "x-forwarded-proto": "https" }, "http://localhost/test");
     expect(getRequestProtocol(event)).toBe("http");
   });
 
-  it("returns first entry of comma-list x-forwarded-proto (https,http)", () => {
-    const event = makeEvent({ "x-forwarded-proto": "https,http" });
-    expect(getRequestProtocol(event)).toBe("https");
+  it("returns https for plain x-forwarded-proto: https when enabled", () => {
+    const event = makeEvent({ "x-forwarded-proto": "https" });
+    expect(getRequestProtocol(event, { xForwardedProto: true })).toBe("https");
   });
 
-  it("returns first entry of comma-list x-forwarded-proto with spaces (https, http)", () => {
+  it("returns http for plain x-forwarded-proto: http when enabled", () => {
+    const event = makeEvent({ "x-forwarded-proto": "http" });
+    expect(getRequestProtocol(event, { xForwardedProto: true })).toBe("http");
+  });
+
+  it("returns first entry of comma-list x-forwarded-proto (https,http) when enabled", () => {
+    const event = makeEvent({ "x-forwarded-proto": "https,http" });
+    expect(getRequestProtocol(event, { xForwardedProto: true })).toBe("https");
+  });
+
+  it("returns first entry of comma-list x-forwarded-proto with spaces (https, http) when enabled", () => {
     const event = makeEvent({ "x-forwarded-proto": "https, http" });
-    expect(getRequestProtocol(event)).toBe("https");
+    expect(getRequestProtocol(event, { xForwardedProto: true })).toBe("https");
   });
 
   it("ignores x-forwarded-proto when xForwardedProto is false", () => {


### PR DESCRIPTION
## Why

`getRequestProtocol` trusts the `x-forwarded-proto` header **by default**, while its siblings `getRequestHost` (`xForwardedHost`) and `getRequestIP` (`xForwardedFor`) default forwarded-header trust to `false`. A directly-exposed app believes a client-spoofed `https` — affecting secure-cookie decisions, canonical/absolute URLs, and cache keys — and the inconsistency between the three siblings is surprising.

## What

- `getRequestProtocol` (and `getRequestURL`, which composes it) now honor `x-forwarded-proto` only when explicitly enabled with `{ xForwardedProto: true }`.
- JSDoc + `docs/2.utils/1.request.md` updated; MIGRATION.md gains an `[!IMPORTANT]` note.

**BREAKING CHANGE:** apps behind a trusted reverse proxy/CDN that rely on `x-forwarded-proto` must now pass `{ xForwardedProto: true }`.

## Tests

New regression test asserts a spoofed `x-forwarded-proto: https` is ignored by default (failed before the fix); existing honored-header tests flipped to explicit opt-in. Full suite green (1441 passed).

> Note: this change was briefly pushed to `main` by mistake and reverted there (5396256); it lands here for review instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated request protocol and URL generation to ignore `x-forwarded-proto` by default.
  * Added explicit opt-in (`{ xForwardedProto: true }`) for trusted reverse proxy/CDN setups.
  * When enabled, uses the first value from comma-separated `x-forwarded-proto` entries (including handling values with spaces).
* **Documentation**
  * Updated `MIGRATION.md` and request docs to reflect the new `x-forwarded-proto` opt-in behavior and security considerations.
* **Tests**
  * Expanded unit tests to verify default ignoring and correct opt-in parsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->