### PR TITLE
fix(cookie): dedup cookies with leading-dot / mixed-case domains

### DIFF
--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -243,7 +243,9 @@ export function deleteChunkedCookie(
  * @see https://httpwg.org/specs/rfc6265.html#rfc.section.4.1.2
  */
 function _getDistinctCookieKey(name: string, options: { domain?: string; path?: string }) {
-  return [name, options.domain || "", options.path || "/"].join(";");
+  // Domain is case-insensitive and a leading "." is ignored (RFC 6265).
+  const domain = (options.domain || "").replace(/^\./, "").toLowerCase();
+  return [name, domain, options.path || "/"].join(";");
 }
 
 // Maximum number of chunks allowed for chunked cookies.

--- a/test/cookies.test.ts
+++ b/test/cookies.test.ts
@@ -130,6 +130,17 @@ describeMatrix("cookies", (t, { it, expect, describe }) => {
       expect(await result.text()).toBe("200");
     });
 
+    it("deduplicates cookies with leading-dot / mixed-case domains", async () => {
+      t.app.get("/", (event) => {
+        setCookie(event, "foo", "old", { domain: ".Example.com" });
+        setCookie(event, "foo", "new", { domain: ".Example.com" });
+        return "200";
+      });
+      const result = await t.fetch("/");
+      expect(result.headers.getSetCookie()).toEqual(["foo=new; Domain=.Example.com; Path=/"]);
+      expect(await result.text()).toBe("200");
+    });
+
     it("can set multiple different cookies", async () => {
       t.app.get("/", (event) => {
         setCookie(event, "a", "1");


### PR DESCRIPTION
Cookie dedup in `setCookie` keyed new cookies on the raw `options.domain`, but keyed existing cookies on the normalized domain from `parseSetCookie` (leading `.` stripped, lowercased). For domains like `.Example.com` the keys never matched, so two `Set-Cookie` headers were emitted instead of a replacement.

This normalizes the domain (strip leading `.`, lowercase) on both sides in `_getDistinctCookieKey`, per RFC 6265 where Domain is case-insensitive and a leading `.` is ignored. Adds a regression test covering setting the same cookie twice with `domain: ".Example.com"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cookie deduplication by treating domain names consistently, regardless of leading dots or letter casing.
  * Ensured the latest value is retained when equivalent cookies are set multiple times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->