### PR TITLE
fix(auth): decode Basic-auth credentials as UTF-8

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -58,7 +58,10 @@ export async function requireBasicAuth(event: HTTPEvent, opts: BasicAuthOptions)
   }
   let authDecoded: string;
   try {
-    authDecoded = atob(b64auth);
+    // RFC 7617: credentials are base64-encoded and may use UTF-8 (charset="UTF-8").
+    authDecoded = new TextDecoder("utf-8", { fatal: false }).decode(
+      Uint8Array.from(atob(b64auth), (c) => c.charCodeAt(0)),
+    );
   } catch {
     throw authFailed(event, opts?.realm);
   }
@@ -109,7 +112,7 @@ function authFailed(event: HTTPEvent, realm: string = "") {
     status: 401,
     statusText: "Authentication required",
     headers: {
-      "www-authenticate": `Basic realm=${JSON.stringify(realm)}`,
+      "www-authenticate": `Basic realm=${JSON.stringify(realm)}, charset="UTF-8"`,
     },
   });
 }

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -58,12 +58,17 @@ export async function requireBasicAuth(event: HTTPEvent, opts: BasicAuthOptions)
   }
   let authDecoded: string;
   try {
-    // RFC 7617: credentials are base64-encoded and may use UTF-8 (charset="UTF-8").
-    authDecoded = new TextDecoder("utf-8", { fatal: false }).decode(
-      Uint8Array.from(atob(b64auth), (c) => c.charCodeAt(0)),
-    );
+    authDecoded = atob(b64auth);
   } catch {
     throw authFailed(event, opts?.realm);
+  }
+  try {
+    // RFC 7617: modern clients send credentials as UTF-8 (charset="UTF-8").
+    authDecoded = new TextDecoder("utf-8", { fatal: true }).decode(
+      Uint8Array.from(authDecoded, (c) => c.charCodeAt(0)),
+    );
+  } catch {
+    // Not valid UTF-8: keep the Latin-1 interpretation for legacy clients.
   }
   const colonIndex = authDecoded.indexOf(":");
   if (colonIndex === -1) {

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -253,6 +253,29 @@ describeMatrix("auth", (t, { it, expect }) => {
     expect(result.status).toBe(200);
   });
 
+  it("authenticates credentials with a non-ASCII (UTF-8) password", async () => {
+    const utf8Auth = basicAuth({ username: "tëst", password: "pä$$wörd🔒" });
+    t.app.get("/utf8", () => "UTF-8 ok!", { middleware: [utf8Auth] });
+
+    const result = await t.fetch("/utf8", {
+      method: "GET",
+      headers: {
+        Authorization: `Basic ${Buffer.from("tëst:pä$$wörd🔒", "utf8").toString("base64")}`,
+      },
+    });
+
+    expect(await result.text()).toBe("UTF-8 ok!");
+    expect(result.status).toBe(200);
+  });
+
+  it("advertises charset=UTF-8 in the WWW-Authenticate challenge", async () => {
+    t.app.get("/challenge", () => "Hello, world!", { middleware: [auth] });
+    const result = await t.fetch("/challenge", { method: "GET" });
+
+    expect(result.status).toBe(401);
+    expect(result.headers.get("www-authenticate")).toContain('charset="UTF-8"');
+  });
+
   it("throws error when neither password nor validate is provided", async () => {
     const invalidAuth = basicAuth({} as any);
     t.app.get("/no-auth-config", () => "Should not reach!", {

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -268,6 +268,22 @@ describeMatrix("auth", (t, { it, expect }) => {
     expect(result.status).toBe(200);
   });
 
+  it("authenticates legacy clients sending Latin-1 encoded credentials", async () => {
+    // Pre-RFC 7617 clients used Latin-1; 0xE4 ("ä") is invalid as UTF-8.
+    const latin1Auth = basicAuth({ username: "admin", password: "pä$$word" });
+    t.app.get("/latin1", () => "Latin-1 ok!", { middleware: [latin1Auth] });
+
+    const result = await t.fetch("/latin1", {
+      method: "GET",
+      headers: {
+        Authorization: `Basic ${Buffer.from("admin:pä$$word", "latin1").toString("base64")}`,
+      },
+    });
+
+    expect(await result.text()).toBe("Latin-1 ok!");
+    expect(result.status).toBe(200);
+  });
+
   it("advertises charset=UTF-8 in the WWW-Authenticate challenge", async () => {
     t.app.get("/challenge", () => "Hello, world!", { middleware: [auth] });
     const result = await t.fetch("/challenge", { method: "GET" });


### PR DESCRIPTION
### Bug

`requireBasicAuth` decoded the base64 `Authorization` header with `atob()`, which returns a Latin-1 string. UTF-8 credential bytes were therefore never decoded, so a user with a non-ASCII password (RFC 7617 `charset="UTF-8"`) could never authenticate — the server compares against `TextEncoder`/UTF-8 values, guaranteeing a mismatch.

### Fix

Decode the base64 payload through `TextDecoder("utf-8")` so multi-byte credentials round-trip correctly, and advertise `charset="UTF-8"` in the `WWW-Authenticate` challenge per RFC 7617. Added regression tests covering a non-ASCII password and the challenge header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)