### PR TITLE
fix(cors): warn on credentials with `null` origin

### DIFF
--- a/src/utils/cors.ts
+++ b/src/utils/cors.ts
@@ -20,6 +20,10 @@ export interface CorsOptions {
    * If an array of strings or regular expressions, it can be used with origin matching.
    * If a custom function, it's used to validate the origin. It takes the origin as an argument and returns `true` if allowed.
    *
+   * Avoid `"null"` together with `credentials: true`. Sandboxed iframes, `data:`/`file:` documents,
+   * and other opaque origins all send `Origin: null`, so allowing it with credentials would share
+   * them across untrusted contexts.
+   *
    * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
    * @default "*"
    */

--- a/src/utils/internal/cors.ts
+++ b/src/utils/internal/cors.ts
@@ -44,6 +44,12 @@ export function resolveCorsOptions(options: CorsOptions = {}): ResolvedCorsOptio
     );
   }
 
+  if (resolved.credentials && resolved.origin === "null") {
+    warnOnce(
+      '[h3] CORS: `credentials: true` with `origin: "null"` is dangerous. Any sandboxed iframe, `data:`/`file:` document, or opaque origin sends `Origin: null`, so credentials would be shared across untrusted contexts.',
+    );
+  }
+
   if (resolved.credentials && resolved.exposeHeaders === "*") {
     warnOnce(
       "[h3] CORS: `credentials: true` with wildcard `exposeHeaders` has no effect. Browsers treat `*` literally on credentialed requests — list the headers explicitly.",

--- a/src/utils/internal/cors.ts
+++ b/src/utils/internal/cors.ts
@@ -44,9 +44,13 @@ export function resolveCorsOptions(options: CorsOptions = {}): ResolvedCorsOptio
     );
   }
 
-  if (resolved.credentials && resolved.origin === "null") {
+  if (
+    resolved.credentials &&
+    (resolved.origin === "null" ||
+      (Array.isArray(resolved.origin) && resolved.origin.includes("null")))
+  ) {
     warnOnce(
-      '[h3] CORS: `credentials: true` with `origin: "null"` is dangerous. Any sandboxed iframe, `data:`/`file:` document, or opaque origin sends `Origin: null`, so credentials would be shared across untrusted contexts.',
+      '[h3] CORS: `credentials: true` with a `"null"` origin is dangerous. Any sandboxed iframe, `data:`/`file:` document, or opaque origin sends `Origin: null`, so credentials would be shared across untrusted contexts.',
     );
   }
 

--- a/test/unit/cors.test.ts
+++ b/test/unit/cors.test.ts
@@ -94,6 +94,23 @@ describe("cors (unit)", () => {
         warnSpy.mockRestore();
       });
 
+      it('warns when credentials is used with an origin array containing `"null"`', () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        // `"null"` in an array is a live hazard too: the array path does an
+        // exact string comparison, so an `Origin: null` request matches and
+        // is reflected with credentials.
+        resolveCorsOptions({
+          credentials: true,
+          origin: ["https://example.com", "null"],
+          exposeHeaders: ["X-Custom"],
+        });
+        expect(warnSpy).toHaveBeenCalledOnce();
+        expect(warnSpy.mock.calls[0][0]).toContain("null");
+
+        warnSpy.mockRestore();
+      });
+
       it("warns when credentials is used with default wildcard exposeHeaders", () => {
         const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 

--- a/test/unit/cors.test.ts
+++ b/test/unit/cors.test.ts
@@ -80,6 +80,20 @@ describe("cors (unit)", () => {
         warnSpy.mockRestore();
       });
 
+      it('warns when credentials is used with `"null"` origin', () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        resolveCorsOptions({
+          credentials: true,
+          origin: "null",
+          exposeHeaders: ["X-Custom"],
+        });
+        expect(warnSpy).toHaveBeenCalledOnce();
+        expect(warnSpy.mock.calls[0][0]).toContain("null");
+
+        warnSpy.mockRestore();
+      });
+
       it("warns when credentials is used with default wildcard exposeHeaders", () => {
         const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 


### PR DESCRIPTION
`origin: "null"` combined with `credentials: true` is dangerous: sandboxed iframes, `data:`/`file:` documents, and other opaque origins all send `Origin: null`, so credentials would be shared across untrusted contexts. This adds a warn-once message in `resolveCorsOptions`, mirroring the existing wildcard-origin and wildcard-`exposeHeaders` warnings. The hazard is also documented on the `origin` option JSDoc, and a unit test asserts the warning fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the security risks of combining credentialed CORS requests with `origin: "null"`.

* **Bug Fixes**
  * Added warnings when credentialed CORS configuration allows opaque origins, including direct or list-based `"null"` origins.
  * Warnings are deduplicated to avoid repeated notifications.

* **Tests**
  * Added coverage verifying warnings for both supported `"null"` origin configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->