### PR TITLE
fix(validate): convert malformed JSON to 400 in validated-handler path

### DIFF
--- a/src/utils/internal/validate.ts
+++ b/src/utils/internal/validate.ts
@@ -113,6 +113,13 @@ export function validatedRequest<
         return function _validatedJson() {
           return req
             .json()
+            .catch(() => {
+              throw new HTTPError({
+                status: 400,
+                statusText: "Bad Request",
+                message: "Invalid JSON body",
+              });
+            })
             .then((data) => validate.body!["~standard"].validate(data))
             .then((result) => {
               if (result.issues) {

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -214,6 +214,21 @@ describe("handler.ts", () => {
       expect(res.status).toBe(400);
     });
 
+    it("malformed JSON body", async () => {
+      const res = await handler.fetch(
+        toRequest("/?id=123", {
+          method: "POST",
+          headers: { "x-token": "abc" },
+          body: "{ not json ",
+        }),
+      );
+      expect(res.status).toBe(400);
+      expect(await res.json()).toMatchObject({
+        status: 400,
+        message: "Invalid JSON body",
+      });
+    });
+
     it("invalid query", async () => {
       const res = await handler.fetch(
         toRequest("/?id=", {


### PR DESCRIPTION
A rejected `req.json()` in the validated-request proxy (`_validatedJson`) was not caught, so a malformed JSON body sent to a `defineValidatedHandler` surfaced as an unhandled **500** — inconsistent with `readBody`, which returns a **400** "Invalid JSON body".

This wraps the `.json()` call so a parse failure becomes a `400` `HTTPError` with message "Invalid JSON body". Adds a regression test covering malformed JSON to a validated handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)