### PR TITLE
fix(cors): set single-valued CORS headers instead of appending

### DIFF
--- a/src/utils/cors.ts
+++ b/src/utils/cors.ts
@@ -115,10 +115,7 @@ export function appendCorsPreflightHeaders(event: H3Event, options: CorsOptions)
   if (varyValues.length > 0) {
     headers.vary = varyValues.join(", ");
   }
-  for (const [key, value] of Object.entries(headers)) {
-    event.res.headers.append(key, value);
-    event.res.errHeaders.append(key, value);
-  }
+  setCorsHeaders(event, headers);
 }
 
 /**
@@ -130,9 +127,25 @@ export function appendCorsHeaders(event: H3Event, options: CorsOptions): void {
     ...createCredentialsHeaders(options),
     ...createExposeHeaders(options),
   };
+  setCorsHeaders(event, headers);
+}
+
+/**
+ * Apply CORS response headers.
+ *
+ * CORS headers are single-valued, so use `.set` to avoid invalid duplicated
+ * values (e.g. `*, *`) when CORS is applied more than once (middleware + handler).
+ * The `vary` header is legitimately multi-valued and is appended instead.
+ */
+function setCorsHeaders(event: H3Event, headers: Record<string, string>): void {
   for (const [key, value] of Object.entries(headers)) {
-    event.res.headers.append(key, value);
-    event.res.errHeaders.append(key, value);
+    if (key === "vary") {
+      event.res.headers.append(key, value);
+      event.res.errHeaders.append(key, value);
+    } else {
+      event.res.headers.set(key, value);
+      event.res.errHeaders.set(key, value);
+    }
   }
 }
 

--- a/test/unit/cors.test.ts
+++ b/test/unit/cors.test.ts
@@ -729,6 +729,31 @@ describe("cors (unit)", () => {
         expect(vary).toContain("access-control-request-headers");
       }
     });
+
+    it("does not duplicate single-valued headers when applied twice", () => {
+      // Applying preflight CORS headers more than once must not produce invalid
+      // values like `*, *` for single-valued headers.
+      const eventMock = mockEvent("/", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://example.com",
+          "access-control-request-method": "GET",
+        },
+      });
+      const options: CorsOptions = {
+        origin: "*",
+        methods: "*",
+        credentials: false,
+        maxAge: "12345",
+      };
+
+      appendCorsPreflightHeaders(eventMock, options);
+      appendCorsPreflightHeaders(eventMock, options);
+
+      expect(eventMock.res.headers.get("access-control-allow-origin")).toEqual("*");
+      expect(eventMock.res.headers.get("access-control-allow-methods")).toEqual("*");
+      expect(eventMock.res.headers.get("access-control-max-age")).toEqual("12345");
+    });
   });
 
   describe("appendCorsHeaders", () => {
@@ -823,6 +848,28 @@ describe("cors (unit)", () => {
 
       expect(eventMock.res.headers.has("access-control-allow-origin")).toEqual(false);
       expect(eventMock.res.headers.get("vary")).toEqual("origin");
+    });
+
+    it("does not duplicate single-valued headers when applied twice", () => {
+      // Applying CORS more than once (e.g. middleware + handler) must not produce
+      // invalid values like `*, *` for single-valued headers.
+      const eventMock = mockEvent("/", {
+        method: "GET",
+        headers: {
+          origin: "https://example.com",
+        },
+      });
+      const options: CorsOptions = {
+        origin: "*",
+        exposeHeaders: "*",
+        credentials: false,
+      };
+
+      appendCorsHeaders(eventMock, options);
+      appendCorsHeaders(eventMock, options);
+
+      expect(eventMock.res.headers.get("access-control-allow-origin")).toEqual("*");
+      expect(eventMock.res.headers.get("access-control-expose-headers")).toEqual("*");
     });
   });
 


### PR DESCRIPTION
Applying CORS headers more than once (e.g. middleware plus handler) duplicated single-valued response headers, producing invalid values like `*, *` for `access-control-allow-origin`, `access-control-allow-methods`, `access-control-max-age`, and `access-control-allow-credentials`.

This switches `appendCorsHeaders`/`appendCorsPreflightHeaders` to use `.set` for CORS response headers, keeping `.append` only for the legitimately multi-valued `vary` header. Added regression tests that apply CORS twice and assert single values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CORS responses to prevent duplicate single-value headers when headers are applied more than once.
  * Preserved multiple `Vary` header values correctly for preflight and standard requests.

* **Tests**
  * Added coverage verifying consistent CORS headers across repeated applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->