### PR TITLE
fix(proxy): forwardHeaders must not override framing headers

### DIFF
--- a/src/utils/internal/proxy.ts
+++ b/src/utils/internal/proxy.ts
@@ -22,6 +22,24 @@ export const ignoredHeaders: Set<string> = /* @__PURE__ */ new Set([
 ]);
 
 /**
+ * The subset of `ignoredHeaders` carrying true hop-by-hop framing/connection
+ * semantics (RFC 9110 §7.6.1). Unlike the "soft" drops (`host`,
+ * `accept-encoding`), forwarding these upstream can desync request framing or
+ * leak the inbound proxy's credentials — so `forwardHeaders` must never
+ * override them.
+ */
+export const framingHeaders: Set<string> = /* @__PURE__ */ new Set([
+  "connection",
+  "keep-alive",
+  "transfer-encoding",
+  "te",
+  "trailer",
+  "upgrade",
+  "proxy-authorization",
+  "proxy-connection",
+]);
+
+/**
  * Parse a `Connection` header value into a lowercased set of the field names it
  * nominates as hop-by-hop (RFC 9110 §7.6.1). Those fields must not be relayed
  * across the proxy in either direction.

--- a/src/utils/internal/proxy.ts
+++ b/src/utils/internal/proxy.ts
@@ -24,7 +24,7 @@ export const ignoredHeaders: Set<string> = /* @__PURE__ */ new Set([
 /**
  * The subset of `ignoredHeaders` carrying true hop-by-hop framing/connection
  * semantics (RFC 9110 §7.6.1). Unlike the "soft" drops (`host`,
- * `accept-encoding`), forwarding these upstream can desync request framing or
+ * `accept-encoding`, `expect`), forwarding these upstream can desync request framing or
  * leak the inbound proxy's credentials — so `forwardHeaders` must never
  * override them.
  */

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -27,8 +27,8 @@ export interface ProxyOptions {
    * header the proxy would otherwise drop — e.g. `forwardHeaders: ["host"]`
    * forwards the client's `host` verbatim. `filterHeaders` still wins over it.
    *
-   * Only the "soft" drops (`host`, `accept-encoding`) can be overridden this
-   * way. It can **never** force-forward a true hop-by-hop framing header
+   * Only the "soft" drops (`host`, `accept-encoding`, `expect`) can be
+   * overridden this way. It can **never** force-forward a true hop-by-hop framing header
    * (`connection`, `keep-alive`, `transfer-encoding`, `te`, `trailer`,
    * `upgrade`, `proxy-authorization`, `proxy-connection`) or a field the
    * incoming `Connection` header nominates — forwarding those could desync

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -5,6 +5,7 @@ import {
   abortable,
   applyXForwardedHeaders,
   connectionTokens,
+  framingHeaders,
   ignoredHeaders,
   ignoredResponseHeaders,
   mergeHeaders,
@@ -18,13 +19,21 @@ import { HTTPResponse } from "../response.ts";
 export interface ProxyOptions {
   headers?: HeadersInit;
   /**
-   * Header names allowed to bypass the built-in hop-by-hop denylist. Matched
+   * Header names allowed to bypass the built-in denylist. Matched
    * case-insensitively.
    *
    * This is **not** an exclusive allowlist: all ordinary request headers are
    * still forwarded regardless. It only lists exceptions that force-forward a
    * header the proxy would otherwise drop — e.g. `forwardHeaders: ["host"]`
    * forwards the client's `host` verbatim. `filterHeaders` still wins over it.
+   *
+   * Only the "soft" drops (`host`, `accept-encoding`) can be overridden this
+   * way. It can **never** force-forward a true hop-by-hop framing header
+   * (`connection`, `keep-alive`, `transfer-encoding`, `te`, `trailer`,
+   * `upgrade`, `proxy-authorization`, `proxy-connection`) or a field the
+   * incoming `Connection` header nominates — forwarding those could desync
+   * request framing or leak the inbound proxy's credentials upstream, so they
+   * are always dropped.
    */
   forwardHeaders?: string[];
   /**
@@ -453,9 +462,17 @@ export function getProxyRequestHeaders(
       continue;
     }
 
-    // An explicit `forwardHeaders` entry is a deliberate escape hatch, so it
-    // wins over both the static denylist and `Connection` nominations.
-    if (forwardHeaders?.includes(name)) {
+    // An explicit `forwardHeaders` entry is a deliberate escape hatch over the
+    // "soft" denylist drops (e.g. `host`, `accept-encoding`). It must never
+    // force-forward a true hop-by-hop framing header (`connection`,
+    // `transfer-encoding`, ...) or a field the incoming `Connection` header
+    // nominates — doing so could desync request framing or leak the inbound
+    // proxy's credentials upstream.
+    if (
+      forwardHeaders?.includes(name) &&
+      !framingHeaders.has(name) &&
+      !connectionNominated.has(name)
+    ) {
       headers[name] = value;
       continue;
     }

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -327,6 +327,59 @@ describeMatrix("proxy", (t, { it, expect, describe }) => {
         expect(result.headers["x-both"]).toBeUndefined();
       });
 
+      it("still force-forwards a soft-drop header (accept-encoding) via forwardHeaders", async () => {
+        t.app.all("/debug", (event) => {
+          return { headers: Object.fromEntries(event.req.headers.entries()) };
+        });
+        t.app.all("/", (event) =>
+          proxyRequest(event, "/debug", {
+            // A "soft" drop like `accept-encoding` may still be force-forwarded.
+            forwardHeaders: ["accept-encoding"],
+          }),
+        );
+
+        const result = await t
+          .fetch("/", { headers: { "accept-encoding": "zstd, br, gzip" } })
+          .then((r) => r.json());
+
+        expect(result.headers["accept-encoding"]).toBe("zstd, br, gzip");
+      });
+
+      // Node's transport layer manages framing headers, so they only survive
+      // the round-trip on the web target.
+      it.runIf(t.target === "web")(
+        "does not force-forward hop-by-hop framing headers via forwardHeaders",
+        async () => {
+          t.app.all("/debug", (event) => {
+            return { headers: Object.fromEntries(event.req.headers.entries()) };
+          });
+          t.app.all("/", (event) =>
+            proxyRequest(event, "/debug", {
+              // `forwardHeaders` must never override the true hop-by-hop framing
+              // set — doing so could desync request framing upstream.
+              forwardHeaders: ["transfer-encoding", "connection", "keep-alive"],
+            }),
+          );
+
+          const result = await t
+            .fetch("/", {
+              headers: {
+                "transfer-encoding": "chunked",
+                connection: "keep-alive",
+                "keep-alive": "timeout=5",
+                "x-keep": "kept",
+              },
+            })
+            .then((r) => r.json());
+
+          expect(result.headers["transfer-encoding"]).toBeUndefined();
+          expect(result.headers["connection"]).toBeUndefined();
+          expect(result.headers["keep-alive"]).toBeUndefined();
+          // A normal header is still forwarded.
+          expect(result.headers["x-keep"]).toBe("kept");
+        },
+      );
+
       it("strips hop-by-hop headers from the proxied response", async () => {
         t.app.all("/debug", (event) => {
           // Hop-by-hop response headers that must not leak to the client.


### PR DESCRIPTION
`forwardHeaders` is documented as an escape hatch for the "soft" denylist drops (`host`, `accept-encoding`), but it previously won over the *entire* hop-by-hop denylist and `Connection` nominations. That let a caller force-forward true framing headers (`connection`, `keep-alive`, `transfer-encoding`, `te`, `trailer`, `upgrade`, `proxy-authorization`, `proxy-connection`) upstream, which can desync request framing or leak the inbound proxy's credentials.

This partitions the denylist into a dedicated `framingHeaders` set: `forwardHeaders` may now only override the soft drops, never the framing set or `Connection`-nominated tokens. The `forwardHeaders` JSDoc is updated to document the constraint, and regression tests cover both that framing headers stay dropped and that soft drops (e.g. `accept-encoding`) still forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy header forwarding to prevent unsafe hop-by-hop framing headers from being forwarded.
  * Preserved the ability to explicitly forward permitted headers, such as `Accept-Encoding`.
  * Added safeguards for `Transfer-Encoding`, `Connection`, and `Keep-Alive` while continuing to forward valid headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->