### PR TITLE
fix(auth): harden basic-auth realm handling and credential timing

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -16,6 +16,11 @@ type _BasicAuthOptions = {
 
   /**
    * Custom validation function for basic auth.
+   *
+   * When provided, the built-in non-empty check is skipped and this function
+   * receives the decoded `username`/`password` as-is, including empty strings
+   * (RFC 7617 permits an empty user-id and/or password). It must return `false`
+   * to reject empty or otherwise invalid credentials.
    */
   validate: (username: string, password: string) => boolean | Promise<boolean>;
 
@@ -52,30 +57,30 @@ export async function requireBasicAuth(event: HTTPEvent, opts: BasicAuthOptions)
 
   const authHeader = event.req.headers.get("authorization");
   if (!authHeader) {
-    throw authFailed(event, realm);
+    throw await authFailed(event, realm);
   }
   // RFC 9110: credentials = auth-scheme [ 1*SP token68 ]; allow one or more spaces.
   const b64auth = /^basic +(.+)$/i.exec(authHeader)?.[1];
   if (!b64auth) {
-    throw authFailed(event, realm);
+    throw await authFailed(event, realm);
   }
   let authDecoded: string;
   try {
     authDecoded = atob(b64auth);
   } catch {
-    throw authFailed(event, realm);
+    throw await authFailed(event, realm);
   }
   const colonIndex = authDecoded.indexOf(":");
   if (colonIndex === -1) {
     // RFC 7617: credentials must be "user-id ":" password"; reject if missing.
-    throw authFailed(event, realm);
+    throw await authFailed(event, realm);
   }
   const username = authDecoded.slice(0, colonIndex);
   const password = authDecoded.slice(colonIndex + 1);
   // RFC 7617 allows empty user-id/password; only enforce non-empty when no
   // custom validate function is provided (i.e. plain username/password check).
   if (!opts.validate && (!username || !password)) {
-    throw authFailed(event, realm);
+    throw await authFailed(event, realm);
   }
 
   // Evaluate all comparisons unconditionally so failure timing does not
@@ -84,8 +89,7 @@ export async function requireBasicAuth(event: HTTPEvent, opts: BasicAuthOptions)
   const passwordOk = !opts.password || timingSafeEqual(password, opts.password);
   const validateOk = !opts.validate || (await opts.validate(username, password));
   if (!usernameOk || !passwordOk || !validateOk) {
-    await randomJitter();
-    throw authFailed(event, realm);
+    throw await authFailed(event, realm);
   }
 
   const context = getEventContext<H3EventContext>(event);
@@ -110,7 +114,10 @@ export function basicAuth(opts: BasicAuthOptions): Middleware {
   };
 }
 
-function authFailed(event: HTTPEvent, realm: string = "auth") {
+async function authFailed(event: HTTPEvent, realm: string) {
+  // Jitter every 401 path uniformly so response timing does not distinguish a
+  // malformed/absent header from a well-formed but wrong credential.
+  await randomJitter();
   return new HTTPError({
     status: 401,
     statusText: "Authentication required",

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -48,42 +48,48 @@ export async function requireBasicAuth(event: HTTPEvent, opts: BasicAuthOptions)
     });
   }
 
+  const realm = opts?.realm ?? "auth";
+
   const authHeader = event.req.headers.get("authorization");
   if (!authHeader) {
-    throw authFailed(event);
+    throw authFailed(event, realm);
   }
-  const [authType, b64auth] = authHeader.split(" ");
-  if (!b64auth || authType.toLowerCase() !== "basic") {
-    throw authFailed(event, opts?.realm);
+  // RFC 9110: credentials = auth-scheme [ 1*SP token68 ]; allow one or more spaces.
+  const b64auth = /^basic\s+(.+)$/i.exec(authHeader)?.[1];
+  if (!b64auth) {
+    throw authFailed(event, realm);
   }
   let authDecoded: string;
   try {
     authDecoded = atob(b64auth);
   } catch {
-    throw authFailed(event, opts?.realm);
+    throw authFailed(event, realm);
   }
   const colonIndex = authDecoded.indexOf(":");
   if (colonIndex === -1) {
     // RFC 7617: credentials must be "user-id ":" password"; reject if missing.
-    throw authFailed(event, opts?.realm);
+    throw authFailed(event, realm);
   }
   const username = authDecoded.slice(0, colonIndex);
   const password = authDecoded.slice(colonIndex + 1);
-  if (!username || !password) {
-    throw authFailed(event, opts?.realm);
+  // RFC 7617 allows empty user-id/password; only enforce non-empty when no
+  // custom validate function is provided (i.e. plain username/password check).
+  if (!opts.validate && (!username || !password)) {
+    throw authFailed(event, realm);
   }
 
-  if (
-    (opts.username && !timingSafeEqual(username, opts.username)) ||
-    (opts.password && !timingSafeEqual(password, opts.password)) ||
-    (opts.validate && !(await opts.validate(username, password)))
-  ) {
+  // Evaluate all comparisons unconditionally so failure timing does not
+  // distinguish an unknown user from a wrong password.
+  const usernameOk = !opts.username || timingSafeEqual(username, opts.username);
+  const passwordOk = !opts.password || timingSafeEqual(password, opts.password);
+  const validateOk = !opts.validate || (await opts.validate(username, password));
+  if (!usernameOk || !passwordOk || !validateOk) {
     await randomJitter();
-    throw authFailed(event, opts?.realm);
+    throw authFailed(event, realm);
   }
 
   const context = getEventContext<H3EventContext>(event);
-  context.basicAuth = { username, password, realm: opts.realm };
+  context.basicAuth = { username, password, realm };
 
   return true;
 }
@@ -104,12 +110,23 @@ export function basicAuth(opts: BasicAuthOptions): Middleware {
   };
 }
 
-function authFailed(event: HTTPEvent, realm: string = "") {
+function authFailed(event: HTTPEvent, realm: string = "auth") {
   return new HTTPError({
     status: 401,
     statusText: "Authentication required",
     headers: {
-      "www-authenticate": `Basic realm=${JSON.stringify(realm)}`,
+      "www-authenticate": `Basic realm="${quoteRealm(realm)}"`,
     },
   });
+}
+
+/**
+ * Sanitize a realm into an RFC 9110 §5.6.4 quoted-string body.
+ *
+ * Drops characters outside the qdtext/obs-text charset (control chars and
+ * non-Latin-1 code points that would throw when set as a header value) and
+ * escapes DQUOTE and backslash as quoted-pairs.
+ */
+function quoteRealm(realm: string): string {
+  return realm.replace(/[^\t\x20-\x7E\x80-\xFF]/g, "").replace(/["\\]/g, "\\$&");
 }

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -55,7 +55,7 @@ export async function requireBasicAuth(event: HTTPEvent, opts: BasicAuthOptions)
     throw authFailed(event, realm);
   }
   // RFC 9110: credentials = auth-scheme [ 1*SP token68 ]; allow one or more spaces.
-  const b64auth = /^basic\s+(.+)$/i.exec(authHeader)?.[1];
+  const b64auth = /^basic +(.+)$/i.exec(authHeader)?.[1];
   if (!b64auth) {
     throw authFailed(event, realm);
   }

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -253,6 +253,34 @@ describeMatrix("auth", (t, { it, expect }) => {
     expect(result.status).toBe(200);
   });
 
+  it("includes the configured realm in the first challenge (missing header)", async () => {
+    const realmAuth = basicAuth({ password: "123!", realm: "my-realm" });
+    t.app.get("/realm-missing", () => "ok", { middleware: [realmAuth] });
+    const result = await t.fetch("/realm-missing", { method: "GET" });
+    expect(result.status).toBe(401);
+    expect(result.headers.get("www-authenticate")).toBe('Basic realm="my-realm"');
+  });
+
+  it("accepts multiple spaces between scheme and credentials", async () => {
+    t.app.get("/multi-space", () => "Hello, world!", { middleware: [auth] });
+    const result = await t.fetch("/multi-space", {
+      method: "GET",
+      headers: {
+        Authorization: `Basic   ${Buffer.from("test:123!").toString("base64")}`,
+      },
+    });
+    expect(await result.text()).toBe("Hello, world!");
+    expect(result.status).toBe(200);
+  });
+
+  it("does not throw for a non-Latin-1 realm", async () => {
+    const unicodeAuth = basicAuth({ password: "123!", realm: "領域" });
+    t.app.get("/unicode-realm", () => "ok", { middleware: [unicodeAuth] });
+    const result = await t.fetch("/unicode-realm", { method: "GET" });
+    expect(result.status).toBe(401);
+    expect(() => result.headers.get("www-authenticate")).not.toThrow();
+  });
+
   it("throws error when neither password nor validate is provided", async () => {
     const invalidAuth = basicAuth({} as any);
     t.app.get("/no-auth-config", () => "Should not reach!", {


### PR DESCRIPTION
Hardens `requireBasicAuth`/`basicAuth` for realm consistency and timing defense-in-depth. The first challenge (missing `Authorization` header) now carries the configured realm, and the documented `"auth"` default is applied consistently to both the challenge and `event.context.basicAuth.realm`. Username and password comparisons are now evaluated unconditionally so failure timing no longer distinguishes an unknown user from a wrong password, and empty user-id/password are permitted when a custom `validate` function is supplied (RFC 7617).

Parsing nits: accept `1*SP` between the `Basic` scheme and token (RFC 9110), and sanitize the realm to the RFC 9110 §5.6.4 quoted-string charset instead of `JSON.stringify`, which previously threw on non-Latin-1 realms. Added regression tests for all three observable behaviors; full suite and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Basic Authentication challenges by always using the configured realm, safely escaping it for the `WWW-Authenticate` header.
  * Refined custom credential validation so empty usernames/passwords are handled correctly when a validator is provided.
  * Enhanced authentication failure handling and robustness, including support for non-Latin realm values.
  * Accepted `Authorization` headers that include extra spaces between the scheme and credentials.
* **Tests**
  * Added authentication coverage for realm in challenges, spacing variations, and non-Latin realm values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->