### PR TITLE
fix(cookie): cap chunk count in setChunkedCookie

### DIFF
--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -5,6 +5,7 @@ import { validateData } from "./internal/validate.ts";
 import type { StandardSchemaV1, FailureResult, InferOutput } from "./internal/standard-schema.ts";
 import type { ValidateResult, OnValidateError } from "./internal/validate.ts";
 import type { ErrorDetails } from "../error.ts";
+import { HTTPError } from "../error.ts";
 
 const CHUNKED_COOKIE = "__chunked__";
 
@@ -183,14 +184,26 @@ export function setChunkedCookie(
   const chunkMaxLength = options?.chunkMaxLength || CHUNKS_MAX_LENGTH;
   const chunkCount = Math.ceil(value.length / chunkMaxLength);
 
+  // Reject values that would need more chunks than the reader (`getChunkedCookie`)
+  // supports. Beyond this the reader returns `undefined`, so the write would be
+  // silently unreadable (data loss) and would emit more Set-Cookie headers than
+  // browsers accept.
+  if (chunkCount > MAX_CHUNKED_COOKIE_COUNT) {
+    throw new HTTPError({
+      status: 500,
+      message: `Cannot set chunked cookie "${name}": value needs ${chunkCount} chunks, exceeding the maximum of ${MAX_CHUNKED_COOKIE_COUNT}.`,
+    });
+  }
+
   // delete any prior left over chunks if the cookie is updated
   const previousCookie = getCookie(event, name);
   if (previousCookie?.startsWith(CHUNKED_COOKIE)) {
     const previousChunkCount = getChunkedCookieCount(previousCookie);
-    if (previousChunkCount > chunkCount) {
-      for (let i = chunkCount; i <= previousChunkCount; i++) {
-        deleteCookie(event, chunkCookieName(name, i), options);
-      }
+    // Number of chunk cookies (`name.N`) written for the new value. Values that
+    // fit in a single cookie are stored unchunked, so no chunks are written.
+    const newChunkCount = chunkCount <= 1 ? 0 : chunkCount;
+    for (let i = newChunkCount + 1; i <= previousChunkCount; i++) {
+      deleteCookie(event, chunkCookieName(name, i), options);
     }
   }
 

--- a/test/cookies.test.ts
+++ b/test/cookies.test.ts
@@ -475,6 +475,70 @@ describeMatrix("cookies", (t, { it, expect, describe }) => {
         ]);
         expect(await result.text()).toBe("200");
       });
+
+      it("throws when value exceeds the maximum chunk count", async () => {
+        t.app.get("/", (event) => {
+          // 101 chunks of 1 char each exceeds the cap of 100 that the reader supports.
+          const bigValue = "x".repeat(101);
+          expect(() => setChunkedCookie(event, "session", bigValue, { chunkMaxLength: 1 })).toThrow(
+            /chunk/i,
+          );
+          // Nothing should have been written when the value is rejected.
+          expect(event.res.headers.getSetCookie()).toEqual([]);
+          return "200";
+        });
+        const result = await t.fetch("/");
+        expect(await result.text()).toBe("200");
+      });
+
+      it("allows a value at exactly the maximum chunk count and it stays readable", async () => {
+        t.app.get("/", (event) => {
+          const value = "x".repeat(100); // exactly 100 chunks
+          setChunkedCookie(event, "session", value, { chunkMaxLength: 1 });
+          // main cookie + 100 chunks
+          expect(event.res.headers.getSetCookie().length).toBe(101);
+          return "200";
+        });
+        const result = await t.fetch("/");
+        expect(await result.text()).toBe("200");
+
+        // Round-trip: the written value must be re-readable (count is within the reader cap).
+        const cookieHeader = result.headers
+          .getSetCookie()
+          .map((c) => c.split(";")[0])
+          .join("; ");
+        t.app.get("/read", (event) => getChunkedCookie(event, "session") ?? "MISSING");
+        const readResult = await t.fetch("/read", {
+          headers: { Cookie: cookieHeader },
+        });
+        expect(await readResult.text()).toBe("x".repeat(100));
+      });
+
+      it("removes all previous chunks when reducing to a single non-chunked value", async () => {
+        t.app.get("/", (event) => {
+          // New value fits in one cookie, so it is stored unchunked with no `session.N`.
+          setChunkedCookie(event, "session", "tiny", { chunkMaxLength: 10 });
+          return "200";
+        });
+        const result = await t.fetch("/", {
+          headers: {
+            Cookie: [
+              `session=${CHUNKED_COOKIE}3`,
+              "session.1=aaa",
+              "session.2=bbb",
+              "session.3=ccc",
+            ].join("; "),
+          },
+        });
+        // All three previous chunks (including `session.1`) must be deleted.
+        expect(result.headers.getSetCookie()).toEqual([
+          "session.1=; Max-Age=0; Path=/",
+          "session.2=; Max-Age=0; Path=/",
+          "session.3=; Max-Age=0; Path=/",
+          "session=tiny; Path=/",
+        ]);
+        expect(await result.text()).toBe("200");
+      });
     });
 
     describe("deleteChunkedCookie", () => {


### PR DESCRIPTION
`setChunkedCookie` had no upper bound on chunk count, but the reader `getChunkedCookie` caps at `MAX_CHUNKED_COOKIE_COUNT` (100) and returns `undefined` above it — so an oversized value (e.g. a large sealed session) was written yet never re-readable, silently losing data and emitting more `Set-Cookie` headers than browsers accept. It now throws when a value would exceed the cap so the set and get sides agree.

This also fixes an off-by-one in the stale-chunk cleanup loop (it re-deleted the last overlapping chunk), keeping cleanup correct when a value shrinks to a single non-chunked cookie. Regression tests cover the cap (throw + boundary round-trip) and the cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented oversized chunked cookies from being written when they exceed the supported limit.
  * Improved cleanup when replacing chunked cookies with smaller or single-cookie values.
  * Ensured cookies at the maximum supported size remain readable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->