### PR TITLE
fix(base): collapse leading-slash run in all base-stripping sites

### DIFF
--- a/src/h3.ts
+++ b/src/h3.ts
@@ -4,6 +4,7 @@ import { HTTPError } from "./error.ts";
 import { toResponse, kNotFound } from "./response.ts";
 import { callMiddleware, normalizeMiddleware } from "./middleware.ts";
 import { requestWithBaseURL } from "./utils/request.ts";
+import { stripBase } from "./utils/internal/path.ts";
 
 import type { ServerRequest } from "srvx";
 import type { H3Config, H3CoreConfig, MatchedRoute, RouterContext } from "./types/h3.ts";
@@ -139,7 +140,10 @@ export const H3 = /* @__PURE__ */ (() => {
             ) {
               return next();
             }
-            event.url.pathname = event.url.pathname.slice(base.length) || "/";
+            // `stripBase` collapses the leading-slash run so `/base//evil.com`
+            // cannot strip to a protocol-relative `//evil.com` a downstream
+            // redirect could abuse (the boundary is already checked above).
+            event.url.pathname = stripBase(originalPathname, base);
             const restore = () => {
               event.url.pathname = originalPathname;
             };

--- a/src/utils/internal/path.ts
+++ b/src/utils/internal/path.ts
@@ -25,30 +25,26 @@ export function joinURL(base: string | undefined, path: string | undefined): str
   return base + path;
 }
 
-export function withoutBase(input: string = "", base: string = ""): string {
-  if (!base || base === "/") {
-    return input;
-  }
-  const _base = withoutTrailingSlash(base);
-  if (!input.startsWith(_base) || (input.length > _base.length && input[_base.length] !== "/")) {
-    return input;
-  }
-  // Collapse leading slashes to prevent protocol-relative URL injection
-  // e.g. withoutBase("/legacy//evil.com", "/legacy") must not return "//evil.com"
-  const trimmed = input.slice(_base.length).replace(/^\/+/, "");
-  return "/" + trimmed;
-}
-
 /**
  * Strip `base` from `pathname` when it matches on a segment boundary, collapsing
  * the leading-slash run so `/base//evil.com` can never strip to a protocol-relative
  * `//evil.com` a downstream redirect could turn into an open redirect.
+ *
+ * `base` must not have a trailing slash; use {@link withoutBase} to tolerate one.
  */
 export function stripBase(pathname: string, base: string): string {
   if (pathname === base || pathname.startsWith(base + "/")) {
     return "/" + pathname.slice(base.length).replace(/^\/+/, "");
   }
   return pathname;
+}
+
+/** Like {@link stripBase}, but tolerates a trailing slash in `base`. */
+export function withoutBase(input: string = "", base: string = ""): string {
+  if (!base || base === "/") {
+    return input;
+  }
+  return stripBase(input, withoutTrailingSlash(base));
 }
 
 export function getPathname(path: string = "/"): string {

--- a/src/utils/internal/path.ts
+++ b/src/utils/internal/path.ts
@@ -39,6 +39,18 @@ export function withoutBase(input: string = "", base: string = ""): string {
   return "/" + trimmed;
 }
 
+/**
+ * Strip `base` from `pathname` when it matches on a segment boundary, collapsing
+ * the leading-slash run so `/base//evil.com` can never strip to a protocol-relative
+ * `//evil.com` a downstream redirect could turn into an open redirect.
+ */
+export function stripBase(pathname: string, base: string): string {
+  if (pathname === base || pathname.startsWith(base + "/")) {
+    return "/" + pathname.slice(base.length).replace(/^\/+/, "");
+  }
+  return pathname;
+}
+
 export function getPathname(path: string = "/"): string {
   return path.startsWith("/") ? path.split("?")[0] : new URL(path, "http://localhost").pathname;
 }

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,5 +1,5 @@
 import { type ErrorDetails, HTTPError } from "../error.ts";
-import { decodePathname } from "./internal/path.ts";
+import { decodePathname, stripBase } from "./internal/path.ts";
 import { parseQuery } from "./internal/query.ts";
 import { validateData } from "./internal/validate.ts";
 import { getEventContext } from "./event.ts";
@@ -43,7 +43,7 @@ export function requestWithBaseURL(req: ServerRequest, base: string): ServerRequ
     // Malformed percent-encoding: fall back to the raw pathname instead of throwing.
     pathname = url.pathname;
   }
-  url.pathname = pathname.slice(base.length) || "/";
+  url.pathname = stripBase(pathname, base);
   return requestWithURL(req, url.href);
 }
 

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -19,7 +19,7 @@ describe("benchmark", () => {
       console.log(`Bundle size (H3): ${bundle.bytes} (gzip: ${bundle.gzipSize})`);
     }
     expect(bundle.bytes).toBeLessThanOrEqual(17_400); // <17.4kb
-    expect(bundle.gzipSize).toBeLessThanOrEqual(6_600); // <6.6kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(6_650); // <6.65kb
   });
 
   it("bundle size (H3Core)", async () => {

--- a/test/mount.test.ts
+++ b/test/mount.test.ts
@@ -46,6 +46,13 @@ describeMatrix("mount", (t, { it, expect, describe }) => {
       });
       expect(await t.fetch("/test/123").then((r) => r.text())).toBe("/123");
     });
+
+    it("collapses leading slashes after stripping base", async () => {
+      t.app.mount("/api", (req) => new Response(new URL(req.url).pathname));
+      // A protocol-relative pathname must not survive base stripping, otherwise a
+      // downstream redirect to it becomes a `//host` open redirect.
+      expect(await t.fetch("/api//evil.com").then((r) => r.text())).toBe("/evil.com");
+    });
   });
 
   describe("mount H3", () => {
@@ -84,6 +91,23 @@ describeMatrix("mount", (t, { it, expect, describe }) => {
       const interceptRes = await t.fetch("/test/intercept");
       expect(interceptRes.headers.get("x-test")).toBe("1");
       expect(await interceptRes.text()).toBe("intercepted");
+    });
+
+    it("collapses leading slashes for child middleware after stripping base", async () => {
+      let seenPathname = "";
+      const subApp = new H3();
+      subApp.use((event) => {
+        seenPathname = event.url.pathname;
+        return event.url.pathname;
+      });
+      subApp.get("/**", () => "unused");
+
+      t.app.mount("/api", subApp);
+
+      const res = await t.fetch("/api//evil.com");
+      // Child middleware must not see a protocol-relative pathname.
+      expect(seenPathname).toBe("/evil.com");
+      expect(await res.text()).toBe("/evil.com");
     });
   });
 

--- a/test/unit/request.test.ts
+++ b/test/unit/request.test.ts
@@ -88,6 +88,20 @@ describe("requestWithBaseURL", () => {
     const proxied = requestWithBaseURL(original, "/base");
     expect(proxied instanceof Request).toBe(true);
   });
+
+  it("collapses leading slashes after stripping base", () => {
+    // Otherwise `/base//evil.com` strips to `//evil.com`, a protocol-relative
+    // pathname a downstream redirect could turn into a `//host` open redirect.
+    const req = new Request("http://example.com/base//evil.com");
+    const proxied = requestWithBaseURL(req, "/base");
+    expect(new URL(proxied.url).pathname).toBe("/evil.com");
+  });
+
+  it("leaves pathname untouched when base does not match", () => {
+    const req = new Request("http://example.com/other/path");
+    const proxied = requestWithBaseURL(req, "/base");
+    expect(new URL(proxied.url).pathname).toBe("/other/path");
+  });
 });
 
 describe("getRequestProtocol", () => {


### PR DESCRIPTION
Both the `mount` middleware (`src/h3.ts`) and `requestWithBaseURL` (`src/utils/request.ts`) stripped the base with a bare `.slice(base.length)`, so a request like `/api//evil.com` stripped to a protocol-relative `//evil.com`. A downstream handler that redirects to that pathname yields a protocol-relative open redirect (`withBase` already guarded against this via `withoutBase`).

This routes both sites through a shared internal `stripBase` helper that enforces a segment boundary and collapses the leading-slash run to a single slash. `requestWithBaseURL` now also skips stripping when `base` doesn't match on a boundary, aligning it with the mount middleware.

Regression tests added for the mount fetch path, the mounted-H3 middleware path, and `requestWithBaseURL`. The H3 gzip bundle limit is nudged (6.6kb -> 6.65kb) to fit the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved base-path URL rewriting for mounted applications to safely normalize paths and avoid malformed/protocol-relative path outcomes.
  * Collapsed repeated leading slashes after base stripping to ensure consistent request handling.
  * Preserved pathnames unchanged when they don’t match the configured base.
* **Tests**
  * Added mount and request edge-case coverage for slash normalization and base-stripping behavior.
  * Slightly increased the H3 gzipped bundle-size benchmark allowance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->