### PR TITLE
fix(html): make raw() trust marker unforgeable and hoist escape map

### DIFF
--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -298,7 +298,9 @@ export interface RawHTML {
   readonly value: string;
 }
 
-const kRawHTML: unique symbol = /* @__PURE__ */ Symbol.for("h3.rawHTML");
+// Module-private, unregistered symbol so the trust marker cannot be forged from
+// outside this module (e.g. via `Symbol.for("h3.rawHTML")` or a second h3 realm).
+const kRawHTML: unique symbol = /* @__PURE__ */ Symbol("h3.rawHTML");
 
 function isRawHTML(value: unknown): value is RawHTML {
   return (
@@ -308,10 +310,15 @@ function isRawHTML(value: unknown): value is RawHTML {
   );
 }
 
+const HTML_ESCAPES: Record<string, string> = {
+  "&": "&amp;",
+  '"': "&quot;",
+  "'": "&#39;",
+  "<": "&lt;",
+  ">": "&gt;",
+};
+
 /** HTML-escape the special characters `& < > " '`. */
 function escapeHtml(str: string): string {
-  return str.replace(
-    /[&"'<>]/g,
-    (c) => ({ "&": "&amp;", '"': "&quot;", "'": "&#39;", "<": "&lt;", ">": "&gt;" })[c]!,
-  );
+  return str.replace(/[&"'<>]/g, (c) => HTML_ESCAPES[c]!);
 }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -55,12 +55,13 @@ describeMatrix("utils", (t, { it, describe, expect }) => {
       expect(await res.text()).not.toContain("<script>");
     });
 
-    it("accepts raw() values from another h3 instance (symbol brand)", async () => {
-      // Simulates raw() from a duplicated copy of h3 via the global symbol registry
-      const foreignRaw = { [Symbol.for("h3.rawHTML")]: true, value: "<b>bold</b>" };
-      t.app.get("/test", () => html`<div>${foreignRaw}</div>`);
+    it("does not accept forged raw() markers via the global symbol registry", async () => {
+      // The trust marker is a module-private, unregistered symbol, so an object
+      // carrying `Symbol.for("h3.rawHTML")` cannot forge trust and is escaped.
+      const forged = { [Symbol.for("h3.rawHTML")]: true, value: "<b>bold</b>" };
+      t.app.get("/test", () => html`<div>${forged}</div>`);
       const res = await t.fetch("/test");
-      expect(await res.text()).toBe("<div><b>bold</b></div>");
+      expect(await res.text()).toBe("<div>[object Object]</div>");
     });
 
     it("escapes plain string usage and warns once", async () => {


### PR DESCRIPTION
Follow-up fixes for the HTML-escaping change in #1459 (`html` / `raw` / `escapeHtml`).

## 1. `raw()` trust marker was globally forgeable (security)

`raw()` tagged trusted HTML with `Symbol.for("h3.rawHTML")` — a key from the **global** symbol registry. Because the key is discoverable, any object carrying it (`Symbol.for("h3.rawHTML")` set to `true`) could forge a trusted `RawHTML` value and be rendered **unescaped** by the `` html`` `` tagged template, re-introducing XSS.

Switched to a module-private, unregistered `Symbol("h3.rawHTML")` so the marker cannot be reproduced outside this module.

This is a defense-in-depth hardening: plain string/JSON user input can't carry symbol keys, so it requires an object bearing the symbol to reach an interpolation — but it's cheap to close.

## 2. `escapeHtml` reallocated the replacement map per matched char (efficiency)

The 5-entry map object literal was built **inside** the `replace` callback, allocating a fresh object for every special character matched. `escapeHtml` runs once per interpolated value on the per-request render path. Hoisted it to a module-level constant. Behavior unchanged.

## Tests

Updated the existing test that asserted the forgeable behavior as a feature — it now asserts a forged `Symbol.for("h3.rawHTML")` object is escaped rather than trusted. Full suite + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML safety by rejecting forged trusted-HTML markers.
  * Ensured untrusted HTML-like objects are escaped rather than rendered as markup.
  * Streamlined HTML escaping for more consistent processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->