### PR TITLE
types: canonical `RouteRules` interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,7 @@ export {
 // Routing
 
 export { type RouteDefinition, defineRoute, removeRoute } from "./utils/route.ts";
+export type { RouteRules } from "./types/route-rules.ts";
 
 // Request
 

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -1,5 +1,6 @@
 import type { Session } from "../utils/session.ts";
 import type { H3Route } from "./h3.ts";
+import type { RouteRules } from "./route-rules.ts";
 import type { ServerRequestContext } from "srvx";
 
 export interface H3EventContext extends ServerRequestContext {
@@ -18,6 +19,9 @@ export interface H3EventContext extends ServerRequestContext {
 
   /* Cached session data */
   sessions?: Record<string, Session>;
+
+  /* Rules matched for the current route */
+  routeRules?: Readonly<RouteRules>;
 
   /* Trusted IP Address of client */
   clientAddress?: string;

--- a/src/types/route-rules.ts
+++ b/src/types/route-rules.ts
@@ -1,0 +1,23 @@
+/**
+ * Rules matched for the current route.
+ *
+ * This interface is intentionally empty. It is the canonical extension point for
+ * route rules in the h3 ecosystem: modules that implement or consume route rules
+ * (such as `h3-rules` or Nitro) augment it via declaration merging, so that a single
+ * type describes the rules of any h3 app regardless of which module declared them.
+ *
+ * Matched rules are exposed to handlers via `event.context.routeRules`, where they
+ * are typed as `Readonly` — matchers are commonly memoized, so a matched object can
+ * be shared between requests and must not be mutated in place.
+ *
+ * @example
+ * ```ts
+ * declare module "h3" {
+ *   interface RouteRules {
+ *     swr?: number | boolean;
+ *     redirect?: string | { to: string; status?: number };
+ *   }
+ * }
+ * ```
+ */
+export interface RouteRules {}

--- a/test/unit/types.test-d.ts
+++ b/test/unit/types.test-d.ts
@@ -1,4 +1,4 @@
-import type { H3Event, WebSocketResponse } from "../../src/index.ts";
+import type { H3Event, RouteRules, WebSocketResponse } from "../../src/index.ts";
 import { describe, it, expectTypeOf } from "vitest";
 import {
   defineHandler,
@@ -192,6 +192,48 @@ describe("types", () => {
       // And the resolved value still exposes `crossws` with no cast.
       const awaited = await res;
       expectTypeOf(awaited).toHaveProperty("crossws");
+    });
+  });
+});
+
+// Route rules are declared empty by h3 and filled in by modules
+// (`h3-rules`, Nitro, ...) through declaration merging.
+declare module "../../src/index.ts" {
+  interface RouteRules {
+    swr?: number | boolean;
+  }
+}
+
+describe("routeRules", () => {
+  it("augmented keys merge into the interface used by the event context", () => {
+    defineHandler((event) => {
+      // The augmentation reaches `RouteRules` through h3's re-export, so the
+      // key keeps its declared type rather than widening to `any`/`unknown`.
+      expectTypeOf(event.context.routeRules?.swr).toEqualTypeOf<number | boolean | undefined>();
+    });
+  });
+
+  it("stays closed for keys nobody declared", () => {
+    defineHandler((event) => {
+      // @ts-expect-error unknown rule keys are a compile error until augmented
+      event.context.routeRules?.notDeclaredAnywhere;
+    });
+  });
+
+  it("exposes matched rules as readonly", () => {
+    defineHandler((event) => {
+      // Matchers are typically memoized, so a matched object can be shared
+      // between requests. Rules are readonly even though augmenters declare
+      // their keys as mutable.
+      // @ts-expect-error matched rules must not be mutated in place
+      event.context.routeRules.swr = 60;
+    });
+  });
+
+  it("allows replacing the whole object", () => {
+    defineHandler((event) => {
+      // How rule modules attach matched rules (see Nitro's generated middleware).
+      event.context.routeRules = {} as RouteRules;
     });
   });
 });


### PR DESCRIPTION
Route rules are implemented outside of h3 — by Nitro, and now by [`h3-rules`](https://github.com/h3js/h3-rules). The behaviour lives outside core, but the *type* describing it currently has no canonical home: it is declared by whichever package implements the rules.

That means the module you augment depends on which package you happen to depend on. Nitro apps today augment `h3-rules`, and previously `NitroRouteRules`. If another module wants to read or contribute a rule, it has to pick one of those packages and take on a dependency for a type alone.

This PR moves the declaration to the one package everyone in the chain already depends on.

## What's added

An empty `RouteRules` interface, exported from `h3`, as the canonical extension point:

```ts
declare module "h3" {
  interface RouteRules {
    swr?: number | boolean;
    redirect?: string | { to: string; status?: number };
  }
}
```

h3 itself declares no rules and implements no behaviour — it only owns the name, so that every module merges into the same interface.

Matched rules are also typed where rule modules already put them:

```ts
export interface H3EventContext {
  routeRules?: Readonly<RouteRules>;
}
```

Nitro's generated middleware already assigns `event.context.routeRules`, so this types a field that exists today rather than introducing one.

## Notes

**The interface is closed until augmented.** With no augmentation, `event.context.routeRules?.swr` is a compile error rather than `unknown` — so typos in rule names are caught. Modules that want open-ended keys can add an index signature via augmentation.

**Rules are exposed as `Readonly`.** Rule matchers are commonly memoized (Nitro's is), so a single matched object can be shared across requests and mutating it in place would leak between them. Readonly is applied at the consumption site rather than asked of each augmenter, so existing augmentations get it for free and a future one can't forget it. Replacing the whole object still works, so how rule modules attach rules is unaffected. Note this is shallow: nested rule objects are not deeply frozen by the type.

## For rule modules

Augmentations keep merging through h3's re-export, so `h3-rules` can re-export h3's interface and Nitro's existing `declare module "h3-rules"` augmentation continues to reach it — `NitroRouteRules` needs no change.

## Test plan

- Type tests in `test/unit/types.test-d.ts` cover that an augmentation merges into the interface used by `event.context`, that undeclared keys stay an error, that matched rules are readonly, and that whole-object assignment still compiles.
- Verified against the built `dist/` types that a downstream `declare module "h3"` resolves through the entry re-exports, so the extension point works for real consumers and not just in-repo.
- `pnpm lint` and the full suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for defining and extending route rules with TypeScript.
  - Matched route rules are now available through the request context for route handlers.
  - Route rule values are exposed as read-only, helping prevent accidental changes during request handling.
- **Documentation**
  - Added guidance for extending route rule types with custom application-specific settings.
- **Tests**
  - Added type checks covering custom rules, read-only behavior, and invalid rule access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->