### PR TITLE
perf(middleware): precompose middleware chains

### DIFF
--- a/src/h3.ts
+++ b/src/h3.ts
@@ -46,7 +46,8 @@ export class H3Core implements H3CoreType {
   "~middleware": Middleware[];
   "~routes": H3Route[] = [];
 
-  // Cached composition of `~middleware` (invalidated by `use()` and `mount()`)
+  // Cached dispatch and `~middleware` composition (invalidated by `use()` and `mount()`)
+  "~dispatch"?: (event: H3Event, route: MatchedRoute<H3Route> | void) => unknown | Promise<unknown>;
   "~composed"?: ComposedMiddleware;
 
   constructor(config: H3CoreConfig = {}) {
@@ -66,29 +67,7 @@ export class H3Core implements H3CoreType {
       event.context.params = route.params;
       event.context.matchedRoute = route.data;
     }
-    if (this["~getMiddleware"] !== H3Core.prototype["~getMiddleware"]) {
-      // Compat: a custom `~getMiddleware` (subclass or instance override, e.g. nitro)
-      // can return per-event middleware, which cannot be precomposed.
-      return callMiddleware(
-        event,
-        this["~getMiddleware"](event, route as unknown as undefined),
-        route?.data.handler || NoHandler,
-      );
-    }
-    let routeHandler: EventHandler = NoHandler;
-    if (route) {
-      const data = route.data;
-      // Route middleware and handler are fixed at registration: compose them once.
-      // The composed pair travels with the route object when copied (mount).
-      routeHandler = data.middleware?.length
-        ? (data["~composed"] ??= composeHandler(data.middleware, data.handler))
-        : data.handler;
-    }
-    const middleware = this["~middleware"];
-    if (middleware.length === 0) {
-      return routeHandler(event);
-    }
-    return (this["~composed"] ??= composeMiddleware(middleware))(event, routeHandler);
+    return (this["~dispatch"] ??= createDispatcher(this))(event, route);
   }
 
   "~request"(request: ServerRequest, context?: H3EventContext): Response | Promise<Response> {
@@ -126,12 +105,48 @@ export class H3Core implements H3CoreType {
     this["~routes"].push(_route);
   }
 
-  // Overriding `~getMiddleware` opts out of the precomposed fast path (see `handler`)
+  // Overriding `~getMiddleware` opts out of the precomposed fast path (see `createDispatcher`)
   "~getMiddleware"(_event: H3Event, route: MatchedRoute<H3Route> | undefined): Middleware[] {
     const routeMiddleware = route?.data.middleware;
     const globalMiddleware = this["~middleware"];
     return routeMiddleware ? [...globalMiddleware, ...routeMiddleware] : globalMiddleware;
   }
+}
+
+/**
+ * Builds the cached per-app dispatch function. The custom `~getMiddleware` check runs
+ * only here — once per composition (first request, or after `use()`/`mount()`
+ * invalidation) — never per request.
+ */
+function createDispatcher(app: H3Core): NonNullable<H3Core["~dispatch"]> {
+  if (app["~getMiddleware"] !== H3Core.prototype["~getMiddleware"]) {
+    // Compat: a custom `~getMiddleware` (subclass or instance override, e.g. nitro)
+    // can return per-event middleware, which cannot be precomposed.
+    return (event, route) =>
+      callMiddleware(
+        event,
+        app["~getMiddleware"](event, route as unknown as undefined),
+        route?.data.handler || NoHandler,
+      );
+  }
+  const middleware = app["~middleware"];
+  if (middleware.length === 0) {
+    return (event, route) => routeHandler(route)(event);
+  }
+  const composed = (app["~composed"] ??= composeMiddleware(middleware));
+  return (event, route) => composed(event, routeHandler(route));
+}
+
+function routeHandler(route: MatchedRoute<H3Route> | void): EventHandler {
+  const data = route?.data;
+  if (!data) {
+    return NoHandler;
+  }
+  // Route middleware and handler are fixed at registration: compose them once.
+  // The composed pair travels with the route object when copied (mount).
+  return data.middleware?.length
+    ? (data["~composed"] ??= composeHandler(data.middleware, data.handler))
+    : data.handler;
 }
 
 export const H3 = /* @__PURE__ */ (() => {
@@ -194,7 +209,7 @@ export const H3 = /* @__PURE__ */ (() => {
               throw err;
             }
           });
-          this["~composed"] = undefined;
+          this["~dispatch"] = this["~composed"] = undefined;
         }
         for (const r of input["~routes"]) {
           this["~addRoute"]({
@@ -264,7 +279,7 @@ export const H3 = /* @__PURE__ */ (() => {
         return this.mount(route || "", fn as unknown as H3Type);
       }
       this["~middleware"].push(normalizeMiddleware(fn as Middleware, { ...opts, route }));
-      this["~composed"] = undefined;
+      this["~dispatch"] = this["~composed"] = undefined;
       return this;
     }
   }

--- a/src/h3.ts
+++ b/src/h3.ts
@@ -2,7 +2,14 @@ import { createRouter, addRoute, findRoute } from "rou3";
 import { H3Event, kMalformedURL } from "./event.ts";
 import { HTTPError } from "./error.ts";
 import { toResponse, kNotFound } from "./response.ts";
-import { callMiddleware, normalizeMiddleware } from "./middleware.ts";
+import {
+  callMiddleware,
+  composeHandler,
+  composeMiddleware,
+  normalizeMiddleware,
+} from "./middleware.ts";
+
+import type { ComposedMiddleware } from "./middleware.ts";
 import { requestWithBaseURL } from "./utils/request.ts";
 import { stripBase } from "./utils/internal/path.ts";
 
@@ -39,6 +46,10 @@ export class H3Core implements H3CoreType {
   "~middleware": Middleware[];
   "~routes": H3Route[] = [];
 
+  // Cached composition of `~middleware` (rebuilt when the array length changes)
+  "~composed"?: ComposedMiddleware;
+  "~composedLength"?: number;
+
   constructor(config: H3CoreConfig = {}) {
     this["~middleware"] = [];
     this.config = config;
@@ -56,11 +67,33 @@ export class H3Core implements H3CoreType {
       event.context.params = route.params;
       event.context.matchedRoute = route.data;
     }
-    const routeHandler = route?.data.handler || NoHandler;
-    const middleware = this["~getMiddleware"](event, route as unknown as undefined);
-    return middleware.length > 0
-      ? callMiddleware(event, middleware, routeHandler)
-      : routeHandler(event);
+    if (this["~getMiddleware"] !== H3Core.prototype["~getMiddleware"]) {
+      // Compat: a custom `~getMiddleware` (subclass or instance override, e.g. nitro)
+      // can return per-event middleware, which cannot be precomposed.
+      return callMiddleware(
+        event,
+        this["~getMiddleware"](event, route as unknown as undefined),
+        route?.data.handler || NoHandler,
+      );
+    }
+    let routeHandler: EventHandler = NoHandler;
+    if (route) {
+      const data = route.data;
+      // Route middleware and handler are fixed at registration: compose them once.
+      // The composed pair travels with the route object when copied (mount).
+      routeHandler = data.middleware?.length
+        ? (data["~composed"] ??= composeHandler(data.middleware, data.handler))
+        : data.handler;
+    }
+    const middleware = this["~middleware"];
+    if (middleware.length === 0) {
+      return routeHandler(event);
+    }
+    if (this["~composedLength"] !== middleware.length) {
+      this["~composedLength"] = middleware.length;
+      this["~composed"] = composeMiddleware(middleware);
+    }
+    return this["~composed"]!(event, routeHandler);
   }
 
   "~request"(request: ServerRequest, context?: H3EventContext): Response | Promise<Response> {
@@ -98,6 +131,7 @@ export class H3Core implements H3CoreType {
     this["~routes"].push(_route);
   }
 
+  // Overriding `~getMiddleware` opts out of the precomposed fast path (see `handler`)
   "~getMiddleware"(_event: H3Event, route: MatchedRoute<H3Route> | undefined): Middleware[] {
     const routeMiddleware = route?.data.middleware;
     const globalMiddleware = this["~middleware"];
@@ -132,6 +166,9 @@ export const H3 = /* @__PURE__ */ (() => {
     mount(base: string, input: FetchHandler | FetchableObject | H3Type) {
       if ("handler" in input) {
         if (input["~middleware"].length > 0) {
+          // Cached composition of the mounted app's middleware (rebuilt if it grows)
+          let composed: ComposedMiddleware;
+          let composedLength: number | undefined;
           this["~middleware"].push((event, next) => {
             const originalPathname = event.url.pathname;
             if (
@@ -148,7 +185,12 @@ export const H3 = /* @__PURE__ */ (() => {
               event.url.pathname = originalPathname;
             };
             try {
-              const result = callMiddleware(event, input["~middleware"], () => {
+              const inputMiddleware = input["~middleware"];
+              if (composedLength !== inputMiddleware.length) {
+                composedLength = inputMiddleware.length;
+                composed = composeMiddleware(inputMiddleware);
+              }
+              const result = composed(event, () => {
                 restore();
                 return next();
               });

--- a/src/h3.ts
+++ b/src/h3.ts
@@ -46,9 +46,8 @@ export class H3Core implements H3CoreType {
   "~middleware": Middleware[];
   "~routes": H3Route[] = [];
 
-  // Cached composition of `~middleware` (rebuilt when the array length changes)
+  // Cached composition of `~middleware` (invalidated by `use()` and `mount()`)
   "~composed"?: ComposedMiddleware;
-  "~composedLength"?: number;
 
   constructor(config: H3CoreConfig = {}) {
     this["~middleware"] = [];
@@ -89,11 +88,7 @@ export class H3Core implements H3CoreType {
     if (middleware.length === 0) {
       return routeHandler(event);
     }
-    if (this["~composedLength"] !== middleware.length) {
-      this["~composedLength"] = middleware.length;
-      this["~composed"] = composeMiddleware(middleware);
-    }
-    return this["~composed"]!(event, routeHandler);
+    return (this["~composed"] ??= composeMiddleware(middleware))(event, routeHandler);
   }
 
   "~request"(request: ServerRequest, context?: H3EventContext): Response | Promise<Response> {
@@ -166,9 +161,6 @@ export const H3 = /* @__PURE__ */ (() => {
     mount(base: string, input: FetchHandler | FetchableObject | H3Type) {
       if ("handler" in input) {
         if (input["~middleware"].length > 0) {
-          // Cached composition of the mounted app's middleware (rebuilt if it grows)
-          let composed: ComposedMiddleware;
-          let composedLength: number | undefined;
           this["~middleware"].push((event, next) => {
             const originalPathname = event.url.pathname;
             if (
@@ -185,11 +177,8 @@ export const H3 = /* @__PURE__ */ (() => {
               event.url.pathname = originalPathname;
             };
             try {
-              const inputMiddleware = input["~middleware"];
-              if (composedLength !== inputMiddleware.length) {
-                composedLength = inputMiddleware.length;
-                composed = composeMiddleware(inputMiddleware);
-              }
+              // Shares the mounted app's own cache (invalidated by its `use()`)
+              const composed = (input["~composed"] ??= composeMiddleware(input["~middleware"]));
               const result = composed(event, () => {
                 restore();
                 return next();
@@ -205,6 +194,7 @@ export const H3 = /* @__PURE__ */ (() => {
               throw err;
             }
           });
+          this["~composed"] = undefined;
         }
         for (const r of input["~routes"]) {
           this["~addRoute"]({
@@ -274,6 +264,7 @@ export const H3 = /* @__PURE__ */ (() => {
         return this.mount(route || "", fn as unknown as H3Type);
       }
       this["~middleware"].push(normalizeMiddleware(fn as Middleware, { ...opts, route }));
+      this["~composed"] = undefined;
       return this;
     }
   }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,6 +1,6 @@
 import type { ServerRequest } from "srvx";
 import { H3Event } from "./event.ts";
-import { callMiddleware } from "./middleware.ts";
+import { composeHandler } from "./middleware.ts";
 import { toResponse } from "./response.ts";
 
 import type {
@@ -44,11 +44,7 @@ export function defineHandler(input: EventHandler | EventHandlerObject): EventHa
 
   return Object.assign(
     handlerWithFetch(
-      input.middleware?.length
-        ? function _handlerMiddleware(event) {
-            return callMiddleware(event, input.middleware!, handler);
-          }
-        : handler,
+      input.middleware?.length ? composeHandler(input.middleware, handler) : handler,
     ),
     input,
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,13 @@ export {
   toEventHandler,
 } from "./handler.ts";
 
-export { defineMiddleware, callMiddleware, toMiddleware } from "./middleware.ts";
+export {
+  defineMiddleware,
+  callMiddleware,
+  composeMiddleware,
+  toMiddleware,
+  type ComposedMiddleware,
+} from "./middleware.ts";
 
 // Response
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -60,17 +60,66 @@ function createMatcher(opts: MiddlewareOptions & { route?: string }) {
   };
 }
 
+/**
+ * Composed middleware chain: calls each middleware in order, then the final `handler`.
+ *
+ * The chain is built once per middleware list (see {@link composeMiddleware}) and the
+ * terminal handler is passed per-call so one composed chain can serve every route.
+ * @internal
+ */
+export type ComposedMiddleware = (
+  event: H3Event,
+  handler: EventHandler,
+) => unknown | Promise<unknown>;
+
+/**
+ * Precompose a middleware list into a single callable chain.
+ *
+ * Unlike {@link callMiddleware}, per-layer dispatch cost is paid once at build time
+ * instead of on every request. Later mutations of the input array are not reflected —
+ * rebuild when the list changes.
+ * @internal
+ */
+export function composeMiddleware(middleware: Middleware[]): ComposedMiddleware {
+  let chain: ComposedMiddleware = (event, handler) => handler(event);
+  for (let i = middleware.length - 1; i >= 0; i--) {
+    const fn = middleware[i];
+    const inner = chain;
+    chain = (event, handler) => callLayer(fn, event, handler, inner);
+  }
+  return chain;
+}
+
+/**
+ * Precompose a middleware list with a fixed terminal handler.
+ * @internal
+ */
+export function composeHandler(middleware: Middleware[], handler: EventHandler): EventHandler {
+  const chain = composeMiddleware(middleware);
+  return function _composedHandler(event) {
+    return chain(event, handler);
+  };
+}
+
 export function callMiddleware(
   event: H3Event,
   middleware: Middleware[],
   handler: EventHandler,
   index: number = 0,
 ): unknown | Promise<unknown> {
-  if (index === middleware.length) {
-    return handler(event);
-  }
-  const fn = middleware[index];
+  return index === middleware.length
+    ? handler(event)
+    : callLayer(middleware[index], event, handler, (_event, _handler) =>
+        callMiddleware(_event, middleware, _handler, index + 1),
+      );
+}
 
+function callLayer(
+  fn: Middleware,
+  event: H3Event,
+  handler: EventHandler,
+  inner: ComposedMiddleware,
+): unknown | Promise<unknown> {
   let nextCalled: undefined | boolean;
   let nextResult: unknown;
 
@@ -79,7 +128,7 @@ export function callMiddleware(
       return nextResult;
     }
     nextCalled = true;
-    nextResult = callMiddleware(event, middleware, handler, index + 1);
+    nextResult = inner(event, handler);
     return nextResult;
   };
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -65,7 +65,6 @@ function createMatcher(opts: MiddlewareOptions & { route?: string }) {
  *
  * The chain is built once per middleware list (see {@link composeMiddleware}) and the
  * terminal handler is passed per-call so one composed chain can serve every route.
- * @internal
  */
 export type ComposedMiddleware = (
   event: H3Event,
@@ -78,7 +77,6 @@ export type ComposedMiddleware = (
  * Unlike {@link callMiddleware}, per-layer dispatch cost is paid once at build time
  * instead of on every request. Later mutations of the input array are not reflected —
  * rebuild when the list changes.
- * @internal
  */
 export function composeMiddleware(middleware: Middleware[]): ComposedMiddleware {
   let chain: ComposedMiddleware = (event, handler) => handler(event);

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -6,6 +6,7 @@ import type { FetchHandler, ServerRequest } from "srvx";
 // import type { MatchedRoute, RouterContext } from "rou3";
 import type { H3Event } from "../event.ts";
 import type { H3Plugin } from "../plugin.ts";
+import type { ComposedMiddleware } from "../middleware.ts";
 
 // Inlined from rou3 for type portability
 export interface RouterContext {
@@ -93,6 +94,12 @@ export declare class H3Core {
 
   /** @internal */
   "~middleware": Middleware[];
+
+  /**
+   * Cached composition of `~middleware` (invalidated by `use()` and `mount()`).
+   * @internal
+   */
+  "~composed"?: ComposedMiddleware;
 
   /** @internal */
   "~routes": H3Route[];

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -130,8 +130,10 @@ export declare class H3Core {
   "~findRoute"(_event: H3Event): MatchedRoute<H3Route> | void;
 
   /**
-   * Returns the middleware chain for an event. Can be overridden by subclasses
-   * to provide dynamic per-event middleware (disables middleware precomposition).
+   * Returns the middleware chain for an event. Can be overridden (subclass method or
+   * instance assignment) to provide dynamic per-event middleware, which disables
+   * middleware precomposition. Override before handling the first request — the
+   * dispatch strategy is cached and only re-evaluated after `use()` or `mount()`.
    * @internal
    */
   "~getMiddleware"(event: H3Event, route: MatchedRoute<H3Route> | undefined): Middleware[];

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -65,6 +65,12 @@ export interface H3Route {
   middleware?: Middleware[];
   meta?: H3RouteMeta;
   handler: EventHandler;
+
+  /**
+   * Cached composition of `middleware` + `handler` (built on first match).
+   * @internal
+   */
+  "~composed"?: EventHandler;
 }
 
 // --- H3 App ---
@@ -116,7 +122,11 @@ export declare class H3Core {
   /** @internal */
   "~findRoute"(_event: H3Event): MatchedRoute<H3Route> | void;
 
-  /** @internal */
+  /**
+   * Returns the middleware chain for an event. Can be overridden by subclasses
+   * to provide dynamic per-event middleware (disables middleware precomposition).
+   * @internal
+   */
   "~getMiddleware"(event: H3Event, route: MatchedRoute<H3Route> | undefined): Middleware[];
 
   /** @internal */

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -18,7 +18,7 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log(`Bundle size (H3): ${bundle.bytes} (gzip: ${bundle.gzipSize})`);
     }
-    expect(bundle.bytes).toBeLessThanOrEqual(18_000); // <18kb
+    expect(bundle.bytes).toBeLessThanOrEqual(18_100); // <18.1kb
     expect(bundle.gzipSize).toBeLessThanOrEqual(6_850); // <6.85kb
   });
 
@@ -35,7 +35,7 @@ describe("benchmark", () => {
       console.log(`Bundle size (H3Core): ${bundle.bytes} (gzip: ${bundle.gzipSize})`);
     }
     expect(bundle.bytes).toBeLessThanOrEqual(7300); // <7.3kb
-    expect(bundle.gzipSize).toBeLessThanOrEqual(2900); // <2.9kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(2950); // <2.95kb
   });
 
   it("bundle size (defineHandler)", async () => {

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -18,8 +18,8 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log(`Bundle size (H3): ${bundle.bytes} (gzip: ${bundle.gzipSize})`);
     }
-    expect(bundle.bytes).toBeLessThanOrEqual(17_400); // <17.4kb
-    expect(bundle.gzipSize).toBeLessThanOrEqual(6_650); // <6.65kb
+    expect(bundle.bytes).toBeLessThanOrEqual(18_000); // <18kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(6_850); // <6.85kb
   });
 
   it("bundle size (H3Core)", async () => {
@@ -34,8 +34,8 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log(`Bundle size (H3Core): ${bundle.bytes} (gzip: ${bundle.gzipSize})`);
     }
-    expect(bundle.bytes).toBeLessThanOrEqual(6800); // <6.8kb
-    expect(bundle.gzipSize).toBeLessThanOrEqual(2730); // <2.73kb
+    expect(bundle.bytes).toBeLessThanOrEqual(7300); // <7.3kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(2900); // <2.9kb
   });
 
   it("bundle size (defineHandler)", async () => {
@@ -50,8 +50,8 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log(`Bundle size (defineHandler): ${bundle.bytes} (gzip: ${bundle.gzipSize})`);
     }
-    expect(bundle.bytes).toBeLessThanOrEqual(6350); // <6.35kb
-    expect(bundle.gzipSize).toBeLessThanOrEqual(2560); // <2.56kb
+    expect(bundle.bytes).toBeLessThanOrEqual(6400); // <6.4kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(2600); // <2.6kb
   });
 });
 

--- a/test/unit/middleware.test.ts
+++ b/test/unit/middleware.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test, vi } from "vitest";
 import { toMiddleware } from "../../src/middleware.ts";
-import { mockEvent } from "../../src/index.ts";
+import { H3, mockEvent } from "../../src/index.ts";
+
+import type { Middleware } from "../../src/types/handler.ts";
 
 describe("toMiddleware", () => {
   test("fetchable", async () => {
@@ -61,5 +63,32 @@ describe("toMiddleware", () => {
     expect(middleware.name).toBe("noopMiddleware");
     await middleware(mockEvent("/"), next);
     expect(next).toHaveBeenCalled();
+  });
+});
+
+describe("~getMiddleware compat", () => {
+  test("instance-level override provides per-event middleware (nitro pattern)", async () => {
+    const app = new H3().get("/test", (event) => `handler:${event.context.order}`);
+    const push = (name: string): Middleware => {
+      return (event, next) => {
+        event.context.order = `${event.context.order || ""}+${name}`;
+        return next();
+      };
+    };
+    app.use(push("global"));
+    // Nitro assigns an instance-level override returning a per-event array:
+    // https://github.com/nitrojs/nitro/blob/main/src/build/virtual/app.ts
+    app["~getMiddleware"] = (event, route) => {
+      const middleware = [...app["~middleware"]];
+      if (event.url.pathname === "/test" && route) {
+        middleware.push(push("extra"));
+      }
+      return middleware;
+    };
+    // Repeated requests: override must run per event (no stale precomposition)
+    for (let i = 0; i < 2; i++) {
+      const res = await app.request("/test");
+      expect(await res.text()).toBe("handler:+global+extra");
+    }
   });
 });

--- a/test/unit/middleware.test.ts
+++ b/test/unit/middleware.test.ts
@@ -66,6 +66,25 @@ describe("toMiddleware", () => {
   });
 });
 
+describe("composed middleware invalidation", () => {
+  test("use() after first request invalidates the composed chain", async () => {
+    const app = new H3().get("/t", () => "ok");
+    app.use((_, next) => next());
+    expect(await (await app.request("/t")).text()).toBe("ok");
+    app.use(() => "intercepted");
+    expect(await (await app.request("/t")).text()).toBe("intercepted");
+  });
+
+  test("use() on a mounted app after first request invalidates its chain", async () => {
+    const child = new H3().get("/t", () => "ok");
+    child.use((_, next) => next());
+    const app = new H3().mount("/sub", child);
+    expect(await (await app.request("/sub/t")).text()).toBe("ok");
+    child.use(() => "intercepted");
+    expect(await (await app.request("/sub/t")).text()).toBe("intercepted");
+  });
+});
+
 describe("~getMiddleware compat", () => {
   test("instance-level override provides per-event middleware (nitro pattern)", async () => {
     const app = new H3().get("/test", (event) => `handler:${event.context.order}`);

--- a/test/unit/package.test.ts
+++ b/test/unit/package.test.ts
@@ -25,6 +25,7 @@ describe("h3 package", () => {
         "callMiddleware",
         "clearResponseHeaders",
         "clearSession",
+        "composeMiddleware",
         "createApp",
         "createError",
         "createEventStream",


### PR DESCRIPTION
### 🔗 Linked issue

_none_

### 📚 Description

Middleware dispatch currently pays a per-request cost that only depends on registration-time state: `~getMiddleware` re-builds the middleware array on every request (an array spread whenever the route has its own middleware), and `callMiddleware` walks it recursively with index bookkeeping through a single megamorphic `fn(event, next)` call site.

Since both the global middleware list and each route's middleware are fixed between registrations, this PR precomposes the chains once and caches them:

- **`composeMiddleware(middleware)`** builds the chain right-to-left into a single `(event, handler) => result` function. Each layer is its own closure, so middleware call sites become monomorphic. The terminal handler is threaded through as an argument (rather than baked in or read from `event.context.matchedRoute`, which a nested app can overwrite mid-chain), so one composed global chain serves every route.
- **Per-route cache**: route middleware + handler are composed on first match and cached on the route object (`~composed`). Only route-local state is baked in, so the cache stays valid when `mount` copies route objects.
- **Per-app cache**: the composed global chain is cached on the app (`~composed`) and explicitly invalidated by `use()` and `mount()`, so middleware added after the first request is picked up. The `mount` wrapper reuses the mounted app's own `~composed` cache, so the child's `use()` invalidates it too.
- `defineHandler({ middleware })` now composes once at definition time instead of re-dispatching per call.

#### Public API

`composeMiddleware` (and the `ComposedMiddleware` type) is exported from `h3` so downstream frameworks (e.g. nitro) can adopt precomposition for their own middleware chains instead of `callMiddleware`. `callMiddleware` remains exported and unchanged.

#### Backward compatibility (`~getMiddleware`)

Existing users extending `H3Core` (e.g. [nitro](https://github.com/nitrojs/nitro/blob/main/src/build/virtual/app.ts#L151-L154)) override `~getMiddleware` — including as an instance-level assignment — to provide **per-event** middleware, which cannot be precomposed. The dispatch strategy is resolved once per app (`~dispatch`, built on first request and invalidated by `use()`/`mount()`): if `~getMiddleware` is overridden (method identity check, run only at dispatcher build time — no per-request cost), dispatch falls back to the previous `callMiddleware` behavior unchanged. Overrides must be in place before the first request (nitro assigns at build time). A regression test covers the nitro pattern.

`next()` memoization semantics (`undefined`/`kNotFound` fall-through, thenable handling) are preserved byte-for-byte; the shared per-layer logic lives in one `callLayer` helper used by both the composed chain and the public `callMiddleware`.

#### Numbers

Isolated dispatch bench (mitata, node 24):

| depth | vs `callMiddleware` | vs spread + `callMiddleware` | allocations |
| ----- | ------------------- | ---------------------------- | ----------- |
| 3     | 1.09x faster        | 1.13x faster                 | −25%        |
| 10    | 1.13x faster        | 1.18x faster                 | −21%        |

App-level `pnpm bench:node` is unchanged (dispatch is sub-µs of a ~31µs iteration dominated by Request/URL work); the win scales with middleware depth and route-middleware usage.

Bundle cost of shipping both the composer and the compat path: H3 +599 B (+191 B gzip), H3Core +539 B (+183 B gzip), defineHandler +103 B (+50 B gzip); budgets in `bundle.test.ts` bumped to match (kept tight).

Known edge (outside documented API): mutating a middleware array in place (a route's `middleware` after its first match, or `~middleware` directly without `use()`) is not picked up live — invalidation is explicit via `use()`/`mount()`. Custom `~getMiddleware` overrides are unaffected.

Possible follow-up: in the `h3-middleware` bench scenario the remaining overhead is dominated by `normalizeMiddleware`'s per-request route regexp matching and the `middlewareParams` spread — baking matchers into composition would be the next lever.

<!-- automd:fixme -->

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added middleware composition utilities (`composeMiddleware` / `composeHandler`) and re-exported `ComposedMiddleware`.
* **Performance Improvements**
  * Reduced per-request middleware/handler overhead by caching precomposed route pipelines and composing mounted middleware once.
  * Updated handler middleware wrapping to use the new composition model.
* **Compatibility**
  * Preserved dynamic, per-event middleware behavior when overriding middleware resolution, with proper cache invalidation after `use()` and `mount()`.
* **Tests**
  * Added coverage for composition invalidation and dynamic middleware overrides.
  * Tightened bundle size benchmark limits and updated export snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


