### PR TITLE
feat(readValidatedBody): support readBody options

### DIFF
--- a/src/utils/body.ts
+++ b/src/utils/body.ts
@@ -101,7 +101,7 @@ export async function readBody<
 export async function readValidatedBody<Event extends HTTPEvent, S extends StandardSchemaV1>(
   event: Event,
   validate: S,
-  options?: { onError?: (result: FailureResult) => ErrorDetails },
+  options?: ReadBodyOptions & { onError?: (result: FailureResult) => ErrorDetails },
 ): Promise<InferOutput<S>>;
 export async function readValidatedBody<
   Event extends HTTPEvent,
@@ -110,7 +110,7 @@ export async function readValidatedBody<
 >(
   event: Event,
   validate: (data: InputT) => ValidateResult<OutputT> | Promise<ValidateResult<OutputT>>,
-  options?: {
+  options?: ReadBodyOptions & {
     onError?: () => ErrorDetails;
   },
 ): Promise<OutputT>;
@@ -167,11 +167,11 @@ export async function readValidatedBody<
 export async function readValidatedBody(
   event: HTTPEvent,
   validate: any,
-  options?: {
+  options?: ReadBodyOptions & {
     onError?: OnValidateError;
   },
 ): Promise<any> {
-  const _body = await readBody(event);
+  const _body = await readBody(event, options);
   return validateData(_body, validate, options);
 }
 

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -112,6 +112,24 @@ describeMatrix("validate", (t, { it, describe, expect }) => {
     });
 
     describe("zod validator", () => {
+      it("Valid multipart form data", async () => {
+        t.app.post("/form-data", (event) =>
+          readValidatedBody(event, zodValidate, { type: "formData" }),
+        );
+
+        const formData = new FormData();
+        formData.set("field", "value");
+        const res = await t.fetch("/form-data", {
+          method: "POST",
+          body: formData,
+        });
+
+        expect(await res.json()).toEqual({
+          field: "value",
+          default: "default",
+        });
+      });
+
       it("Valid", async () => {
         const res = await t.fetch("/zod", {
           method: "POST",


### PR DESCRIPTION
`readValidatedBody` previously called `readBody` without parsing options, so multipart requests could not opt into `{ type: "formData" }` before validation.

Its options now include the existing `ReadBodyOptions` and are forwarded to `readBody`, with a regression test covering multipart form parsing through a Zod validator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `readValidatedBody` now supports body parsing options, including multipart form-data requests.
  * Validation can use parsing settings such as the request body type while preserving existing error handling.

* **Tests**
  * Added coverage for validating multipart form-data and applying schema defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->