### PR TITLE
fix(json-rpc): use `-32600` for valid-JSON non-object bodies

### DIFF
--- a/src/utils/json-rpc.ts
+++ b/src/utils/json-rpc.ts
@@ -205,8 +205,10 @@ async function processJsonRpcBody<C extends H3Event | WebSocketPeer>(
   context: C,
 ): Promise<JsonRpcResponse | JsonRpcResponse[] | undefined> {
   // Body must be a non-null object or array.
+  // Note: parsing already succeeded here, so a primitive body is not a Parse
+  // error (§5.1 reserves -32700 for invalid JSON) but an Invalid Request.
   if (!body || typeof body !== "object") {
-    return createJsonRpcError(null, PARSE_ERROR, "Parse error");
+    return createJsonRpcError(null, INVALID_REQUEST, "Invalid Request");
   }
 
   const requests = Array.isArray(body) ? body : [body];

--- a/test/json-rpc-ws.test.ts
+++ b/test/json-rpc-ws.test.ts
@@ -178,16 +178,19 @@ describe("defineJsonRpcWebSocketHandler", () => {
       });
     });
 
-    it("should return Parse error for non-object body", async () => {
-      const { sent } = await sendMessage('"just a string"');
+    it.each(['"just a string"', "123", "true", "null"])(
+      "should return Invalid Request for non-object body: %s",
+      async (body) => {
+        const { sent } = await sendMessage(body);
 
-      expect(sent).toHaveLength(1);
-      expect(JSON.parse(sent[0])).toEqual({
-        jsonrpc: "2.0",
-        id: null,
-        error: { code: -32_700, message: "Parse error" },
-      });
-    });
+        expect(sent).toHaveLength(1);
+        expect(JSON.parse(sent[0])).toEqual({
+          jsonrpc: "2.0",
+          id: null,
+          error: { code: -32_600, message: "Invalid Request" },
+        });
+      },
+    );
 
     it("should return Invalid Request for wrong jsonrpc version", async () => {
       const { sent } = await sendMessage({

--- a/test/json-rpc.test.ts
+++ b/test/json-rpc.test.ts
@@ -385,6 +385,21 @@ describeMatrix("json-rpc", (t, { describe, it, expect }) => {
       });
     });
 
+    it("should return Invalid Request for valid-JSON primitive bodies", async () => {
+      t.app.post("/json-rpc", eventHandler);
+      for (const body of ["123", '"str"', "true", "null"]) {
+        const result = await t.fetch("/json-rpc", { method: "POST", body });
+        expect(await result.json(), body).toEqual({
+          jsonrpc: "2.0",
+          id: null,
+          error: {
+            code: -32_600,
+            message: "Invalid Request",
+          },
+        });
+      }
+    });
+
     it("should safely handle a constructor method with constructor params", async () => {
       t.app.post("/json-rpc", eventHandler);
       const result = await t.fetch("/json-rpc", {


### PR DESCRIPTION
Closes #1480

`processJsonRpcBody()` returned `-32700 Parse error` for any body that was not an object, but by that point `JSON.parse` had already succeeded. Per JSON-RPC 2.0 §5.1, `-32700` is reserved for *"Invalid JSON was received by the server"*; a body of `123`, `"str"`, `true` or `null` is well-formed JSON that simply is not a valid Request object, which is `-32600 Invalid Request`.

Truly malformed JSON still returns `-32700` — that path is the `catch` around `req.json()` / `message.json()` and is untouched.

Regression tests added on both the HTTP and WebSocket handlers; both fail before the change (6 failures) and pass after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Valid JSON values that aren’t objects or arrays now return the correct JSON-RPC **“Invalid Request”** error instead of **“Parse error.”**
  - Improved consistency across HTTP and WebSocket request handling, including strings, numbers, booleans, and `null`.
- **Tests**
  - Added coverage for multiple non-object JSON request bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->