### PR TITLE
fix(event-stream): correct stream teardown on close and client disconnect

### DIFF
--- a/src/utils/internal/event-stream.ts
+++ b/src/utils/internal/event-stream.ts
@@ -12,6 +12,8 @@ export class EventStream {
   private readonly _writer: WritableStreamDefaultWriter;
   private readonly _encoder: TextEncoder = new TextEncoder();
 
+  private readonly _closeCallbacks: (() => any)[] = [];
+
   private _writerIsClosed = false;
   private _paused = false;
   private _unsentData: undefined | string;
@@ -25,8 +27,20 @@ export class EventStream {
   constructor(event: H3Event, opts: EventStreamOptions = {}) {
     this._event = event;
     this._writer = this._transformStream.writable.getWriter();
+    // `closed` rejects when the readable side is cancelled (client disconnect)
+    // and resolves on a graceful `close()`. Both mean the stream is over.
     this._writer.closed.catch(_noop).finally(() => {
       this._writerIsClosed = true;
+      if (opts.autoclose !== false) {
+        this._disposed = true;
+      }
+      for (const cb of this._closeCallbacks.splice(0)) {
+        try {
+          cb();
+        } catch {
+          // Ignore
+        }
+      }
     });
     if (opts.autoclose !== false) {
       this._event.runtime?.node?.res?.once("close", () => this.close());
@@ -159,11 +173,21 @@ export class EventStream {
   }
 
   /**
-   * Triggers callback when the writable stream is closed.
-   * It is also triggered after calling the `close()` method.
+   * Triggers callback when the stream is closed, either by calling the
+   * `close()` method or when the client disconnects.
    */
   onClosed(cb: () => any): void {
-    this._writer.closed.then(cb).catch(_noop);
+    if (this._writerIsClosed) {
+      queueMicrotask(() => {
+        try {
+          cb();
+        } catch {
+          // Ignore
+        }
+      });
+      return;
+    }
+    this._closeCallbacks.push(cb);
   }
 
   async send(): Promise<BodyInit> {

--- a/src/utils/internal/event-stream.ts
+++ b/src/utils/internal/event-stream.ts
@@ -35,11 +35,7 @@ export class EventStream {
         this._disposed = true;
       }
       for (const cb of this._closeCallbacks.splice(0)) {
-        try {
-          cb();
-        } catch {
-          // Ignore
-        }
+        _invokeCloseCallback(cb);
       }
     });
     if (opts.autoclose !== false) {
@@ -178,13 +174,7 @@ export class EventStream {
    */
   onClosed(cb: () => any): void {
     if (this._writerIsClosed) {
-      queueMicrotask(() => {
-        try {
-          cb();
-        } catch {
-          // Ignore
-        }
-      });
+      queueMicrotask(() => _invokeCloseCallback(cb));
       return;
     }
     this._closeCallbacks.push(cb);
@@ -195,6 +185,19 @@ export class EventStream {
     this._event.res.status = 200;
     this._handled = true;
     return this._transformStream.readable;
+  }
+}
+
+// Close callbacks are user code: never let a sync throw or a rejected async
+// callback escape (the documented `onClosed` example is async).
+function _invokeCloseCallback(cb: () => any): void {
+  try {
+    const res = cb();
+    if (res instanceof Promise) {
+      res.catch(_noop);
+    }
+  } catch {
+    // Ignore
   }
 }
 

--- a/src/utils/internal/event-stream.ts
+++ b/src/utils/internal/event-stream.ts
@@ -159,6 +159,10 @@ export class EventStream {
       return;
     }
     if (!this._isClosed) {
+      // Data buffered while paused is still owed to the client. `flush()`
+      // short-circuits once closed, so this is the last chance to send it.
+      this._paused = false;
+      await this.flush();
       try {
         await this._writer.close();
       } catch {

--- a/test/sse.test.ts
+++ b/test/sse.test.ts
@@ -86,6 +86,31 @@ describeMatrix("sse", (t, { it, expect }) => {
     expect(closed).toBe(true);
   });
 
+  it("does not leak rejections from async onClosed callbacks", async () => {
+    let secondRan = false;
+    const done = new Promise<void>((resolve) => {
+      t.app.get("/sse-throwing-onClosed", (event) => {
+        const eventStream = createEventStream(event);
+        eventStream.onClosed(async () => {
+          throw new Error("cleanup failed");
+        });
+        eventStream.onClosed(() => {
+          secondRan = true;
+          resolve();
+        });
+        setTimeout(() => eventStream.close());
+        return eventStream.send();
+      });
+    });
+
+    const res = await t.fetch("/sse-throwing-onClosed");
+    await res.text();
+    await done;
+    // A rejected async callback must not take down the process,
+    // nor prevent later callbacks from running.
+    expect(secondRan).toBe(true);
+  });
+
   it("ignores pushes after close", async () => {
     t.app.get("/sse-after-close", async (event) => {
       const eventStream = createEventStream(event);

--- a/test/sse.test.ts
+++ b/test/sse.test.ts
@@ -127,4 +127,22 @@ describeMatrix("sse", (t, { it, expect }) => {
     expect(res.status).toBe(200);
     expect(await res.text()).toBe("data: before close\n\n");
   });
+
+  it("flushes data buffered while paused on close", async () => {
+    t.app.get("/sse-paused-close", (event) => {
+      const eventStream = createEventStream(event);
+      setTimeout(async () => {
+        await eventStream.push("sent");
+        eventStream.pause();
+        await eventStream.push("buffered");
+        // Closing while paused must not drop the queued message.
+        await eventStream.close();
+      });
+      return eventStream.send();
+    });
+
+    const res = await t.fetch("/sse-paused-close");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("data: sent\n\ndata: buffered\n\n");
+  });
 });

--- a/test/sse.test.ts
+++ b/test/sse.test.ts
@@ -58,6 +58,34 @@ describeMatrix("sse", (t, { it, expect }) => {
     expect(messages).toEqual(expected);
   });
 
+  it("calls onClosed when the client disconnects", async () => {
+    let closed = false;
+    const onClosed = new Promise<void>((resolve) => {
+      t.app.get("/sse-disconnect", (event) => {
+        const eventStream = createEventStream(event);
+        const interval = setInterval(() => eventStream.push("tick"), 5);
+        eventStream.onClosed(() => {
+          closed = true;
+          clearInterval(interval);
+          resolve();
+        });
+        return eventStream.send();
+      });
+    });
+
+    const res = await t.fetch("/sse-disconnect");
+    const reader = res.body!.getReader();
+    await reader.read();
+    expect(closed).toBe(false);
+    await reader.cancel();
+
+    await Promise.race([
+      onClosed,
+      new Promise((_, reject) => setTimeout(() => reject(new Error("onClosed never fired")), 2000)),
+    ]);
+    expect(closed).toBe(true);
+  });
+
   it("ignores pushes after close", async () => {
     t.app.get("/sse-after-close", async (event) => {
       const eventStream = createEventStream(event);

--- a/test/unit/sse.test.ts
+++ b/test/unit/sse.test.ts
@@ -7,6 +7,11 @@ import {
 } from "../../src/utils/internal/event-stream.ts";
 import { mockEvent } from "../../src/index.ts";
 
+/** Drain a readable stream to a string. */
+async function _readAll(readable: ReadableStream<Uint8Array>): Promise<string> {
+  return new Response(readable).text();
+}
+
 describe("sse (unit)", () => {
   it("properly formats sse comments", () => {
     const result = formatEventStreamComment("hello world");
@@ -209,6 +214,21 @@ describe("sse (unit)", () => {
       writeSpy.mockClear();
       await stream.push([{ data: "msg3" }]);
       expect(writeSpy).not.toHaveBeenCalled();
+    });
+
+    it("flushes data buffered while paused on close", async () => {
+      const event = mockEvent("/");
+      const stream = new EventStream(event);
+      const readable = (await stream.send()) as ReadableStream<Uint8Array>;
+      // Drain concurrently: `close()` waits for the queue, so reading only
+      // afterwards would deadlock on backpressure.
+      const read = _readAll(readable);
+
+      stream.pause();
+      await stream.push("buffered");
+      await stream.close();
+
+      expect(await read).toBe("data: buffered\n\n");
     });
 
     it("marks writer as closed on flush write failure", async () => {


### PR DESCRIPTION
Fixes #1478

## Problem

`onClosed` was implemented as:

```ts
this._writer.closed.then(cb).catch(_noop);
```

When the client disconnects, the readable side of the `TransformStream` is **cancelled**, which puts the writable side into an **errored** state — so `writer.closed` **rejects** and the callback is routed into `.catch(_noop)`, never running. It only fired on a graceful `close()`.

Autoclose was additionally wired exclusively to the Node runtime (`runtime?.node?.res?.once("close", ...)`), so on web-standard runtimes (Deno, Bun, Workerd, service workers, plain `app.fetch()` consumers) a client disconnect neither closed the stream nor ran cleanup. Timers, DB handles, and generator loops leaked per connection.

## Fix

- Close callbacks are queued and fired from the single `_writer.closed.catch(_noop).finally(...)` handler, so they run for **both** graceful close and cancellation-induced rejection.
- That handler marks the stream disposed when `autoclose !== false`, so a disconnect stops further pushes on every runtime, not just Node.
- `onClosed` registered after the stream already closed now fires on a microtask instead of silently never running.
- Callback throws stay swallowed, matching the previous `.catch(_noop)` behavior.
- The Node `res` listener is kept as a belt-and-braces signal for the Node path.

## Also in this PR

Two adjacent defects in the same teardown path, each with its own commit:

**Async `onClosed` callbacks leaked rejections.** Swallowing only synchronous throws left an `async` callback that rejects to surface as an unhandled rejection, and it aborted the remaining callbacks in the queue. Callbacks are now invoked through a helper that absorbs both, so one bad callback can no longer take down the process or starve the ones behind it.

**`close()` dropped data buffered while paused.** `close()` never flushed `_unsentData`, and `flush()` short-circuits once the stream is closed — so anything queued by a `push()` during `pause()` was unrecoverable. A handler that paused for backpressure, queued a final message and then closed left the client with a cleanly ended stream and a silently missing message. `close()` now unpauses and flushes before closing the writer. This adds no new blocking, since `_writer.close()` already awaited the queue draining.

## Test

`test/sse.test.ts` — the client reads one chunk, cancels the reader, and asserts `onClosed` fires. Under `describeMatrix` it failed on `web` and passed on `node` before the fix (exactly the reported asymmetry); both pass now.

The two follow-up fixes are covered by their own regression tests — an integration test per matrix target plus a unit test for the paused-close flush, all failing before their respective commits. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-sent event (SSE) stream cleanup and lifecycle handling on client disconnects.
  * `onClosed` handlers now fire consistently, including after disconnects and when closing a paused stream.
  * Callbacks registered after the stream is already closed run promptly, even if earlier handlers throw or reject.
  * Closing a paused SSE stream now flushes buffered output so no messages are missed.
* **Tests**
  * Added/updated SSE and unit tests covering disconnect behavior, paused-close flushing, and `onClosed` error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
