### PR TITLE
fix(response): strip HEAD body when merging prepared headers into a mutable Response

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -137,29 +137,31 @@ function prepareResponse(
     preparedHeaders = preparedRes?.[kEventResErrHeaders];
   }
 
-  // Avoid merging if there is nothing to merge or a custom error render is returned from `onError`
-  if (!preparedHeaders || nested) {
-    // Strip the body for HEAD requests (runtimes usually do this, but keep self-consistent)
-    if (event.req.method === "HEAD" && val.body !== null) {
-      return new FastResponse(null, {
+  // Merge prepared headers unless there is nothing to merge or a custom error
+  // render is returned from `onError`.
+  if (preparedHeaders && !nested) {
+    try {
+      mergeHeaders(val.headers, preparedHeaders, val.headers);
+    } catch {
+      // Headers are immutable
+      return new FastResponse(nullBody(event.req.method, val.status) ? null : val.body, {
+        status: val.status,
+        statusText: val.statusText,
+        headers: mergeHeaders(val.headers, preparedHeaders),
+      }) as Response;
+    }
+  }
+
+  // Strip the body for HEAD requests (runtimes usually do this, but keep
+  // self-consistent for web-mode / service-worker consumers). Covers the
+  // in-place merge path above, which previously returned the body intact.
+  return event.req.method === "HEAD" && val.body !== null
+    ? (new FastResponse(null, {
         status: val.status,
         statusText: val.statusText,
         headers: val.headers,
-      }) as Response;
-    }
-    return val; // Fast path: no headers to merge
-  }
-  try {
-    mergeHeaders(val.headers, preparedHeaders, val.headers);
-    return val;
-  } catch {
-    // Headers are immutable
-    return new FastResponse(nullBody(event.req.method, val.status) ? null : val.body, {
-      status: val.status,
-      statusText: val.statusText,
-      headers: mergeHeaders(val.headers, preparedHeaders),
-    }) as Response;
-  }
+      }) as Response)
+    : val;
 }
 
 function mergeHeaders(base: HeadersInit, overrides: Headers, target = new Headers(base)): Headers {

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -380,6 +380,19 @@ describeMatrix("app", (t, { it, expect }) => {
     expect(res.headers.get("x-from-response")).toBe("1");
   });
 
+  it("strips the body for a HEAD request while merging prepared headers into a mutable Response", async () => {
+    t.app.use((event) => {
+      event.res.headers.set("x-from-event", "1");
+      return new Response("hello", {
+        headers: { "x-from-response": "1" },
+      });
+    });
+    const res = await t.fetch("/", { method: "HEAD" });
+    expect(res.headers.get("x-from-event")).toBe("1");
+    expect(res.headers.get("x-from-response")).toBe("1");
+    expect(await res.text()).toBe("");
+  });
+
   it("set headers via event.res + Response (immutable)", async () => {
     t.app.use((event) => {
       event.res.headers.set("x-from-event", "1");


### PR DESCRIPTION
Addresses the "HEAD body stripping misses the in-place merge path" item from #1482.

`prepareResponse` strips the body of a HEAD (or otherwise null-body) response on the fast path (`!preparedHeaders`) and on the immutable-headers catch path, but the in-place header merge path returned the mutable `Response` with its body intact. So when prepared headers are merged into a mutable 2xx `Response` under a HEAD request, `app.fetch` / web-mode / service-worker consumers received a HEAD response carrying a body. Node strips it at the socket, so it only surfaced off-Node.

This merges the prepared headers first, then strips the HEAD body in a single place that also covers the in-place merge path, deduping the HEAD handling that was previously split across two branches. Bundle size is unchanged (the guards in `test/bench/bundle.test.ts` still pass).

Added a regression test in `test/app.test.ts`: it sets a prepared header via `event.res.headers`, returns a mutable `Response` with a body under a HEAD request, and asserts the merged headers are present while the body is empty. It fails on the `web` matrix mode before this change and passes after; the `node` mode passes either way since the runtime strips the body at the socket.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `HEAD` responses so the body is reliably empty in all cases, while response headers remain intact.
  * Improved header handling by correctly merging headers set during request handling with headers from the returned response.
  * Added safer handling for immutable headers during response preparation.
* **Tests**
  * Added coverage to verify that `HEAD` responses include the merged headers but an empty response body.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->