### PR TITLE
feat(validate): support async validation within `defineValidatedHandler`

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -84,9 +84,9 @@ export function defineValidatedHandler<
   }
   return defineHandler({
     ...def,
-    handler: function _validatedHandler(event) {
-      (event as any) /* readonly */.req = validatedRequest(event.req, def.validate!);
-      (event as any) /* readonly */.url = validatedURL(event.url, def.validate!);
+    handler: async function _validatedHandler(event) {
+      (event as any) /* readonly */.req = await validatedRequest(event.req, def.validate!);
+      (event as any) /* readonly */.url = await validatedURL(event.url, def.validate!);
       return def.handler(event as any);
     },
   }) as any;

--- a/src/utils/internal/validate.ts
+++ b/src/utils/internal/validate.ts
@@ -75,7 +75,7 @@ export async function validateData<T>(
 // prettier-ignore
 const reqBodyKeys = /* @__PURE__ */ new Set(["body", "text", "formData", "arrayBuffer"]);
 
-export function validatedRequest<
+export async function validatedRequest<
   RequestBody extends StandardSchemaV1,
   RequestHeaders extends StandardSchemaV1,
 >(
@@ -85,10 +85,10 @@ export function validatedRequest<
     headers?: RequestHeaders;
     onError?: OnValidateError;
   },
-): ServerRequest {
+): Promise<ServerRequest> {
   // Validate Headers
   if (validate.headers) {
-    const validatedheaders = syncValidate(
+    const validatedheaders = await validateSource(
       "headers",
       Object.fromEntries(req.headers.entries()),
       validate.headers as StandardSchemaV1<Record<string, string>>,
@@ -144,18 +144,18 @@ export function validatedRequest<
   });
 }
 
-export function validatedURL(
+export async function validatedURL(
   url: URL,
   validate: {
     query?: StandardSchemaV1;
     onError?: OnValidateError;
   },
-): URL {
+): Promise<URL> {
   if (!validate.query) {
     return url;
   }
 
-  const validatedQuery = syncValidate(
+  const validatedQuery = await validateSource(
     "query",
     Object.fromEntries(url.searchParams.entries()),
     validate.query as StandardSchemaV1<Record<string, string>>,
@@ -169,16 +169,13 @@ export function validatedURL(
   return url;
 }
 
-function syncValidate<Source extends "headers" | "query", T = unknown>(
+async function validateSource<Source extends "headers" | "query", T = unknown>(
   source: Source,
   data: unknown,
   fn: StandardSchemaV1<T>,
   onError?: OnValidateError,
-): T {
-  const result = fn["~standard"].validate(data);
-  if (result instanceof Promise) {
-    throw new TypeError(`Asynchronous validation is not supported for ${source}`);
-  }
+): Promise<T> {
+  const result = await fn["~standard"].validate(data);
   if (result.issues) {
     throw createValidationError(
       onError?.({ _source: source, ...result }) || {

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -301,6 +301,79 @@ describe("handler.ts", () => {
         expect(res.status).toBe(500);
       });
     });
+
+    describe("async validation", () => {
+      const asyncHandler = defineValidatedHandler({
+        validate: {
+          body: z.object({
+            name: z.string().refine(async (name) => name !== "banned", "Name is banned"),
+          }),
+          headers: z.object({
+            "x-token": z.string().refine(async (token) => token.length >= 3, "Token too short"),
+          }),
+          query: z.object({
+            id: z.string().refine(async (id) => id.length >= 3, "Id too short"),
+          }),
+        },
+        handler: async (event) => {
+          return { body: await event.req.json() };
+        },
+      });
+
+      it("valid request", async () => {
+        const res = await asyncHandler.fetch(
+          toRequest("/?id=123", {
+            method: "POST",
+            headers: { "x-token": "abc" },
+            body: JSON.stringify({ name: "tommy" }),
+          }),
+        );
+        expect(res.status).toBe(200);
+        expect(await res.json()).toMatchObject({ body: { name: "tommy" } });
+      });
+
+      it("invalid headers", async () => {
+        const res = await asyncHandler.fetch(
+          toRequest("/?id=123", {
+            method: "POST",
+            headers: { "x-token": "ab" },
+            body: JSON.stringify({ name: "tommy" }),
+          }),
+        );
+        expect(res.status).toBe(400);
+        expect(await res.json()).toMatchObject({
+          data: { issues: [{ path: ["x-token"], message: "Token too short" }] },
+        });
+      });
+
+      it("invalid query", async () => {
+        const res = await asyncHandler.fetch(
+          toRequest("/?id=1", {
+            method: "POST",
+            headers: { "x-token": "abc" },
+            body: JSON.stringify({ name: "tommy" }),
+          }),
+        );
+        expect(res.status).toBe(400);
+        expect(await res.json()).toMatchObject({
+          data: { issues: [{ path: ["id"], message: "Id too short" }] },
+        });
+      });
+
+      it("invalid body", async () => {
+        const res = await asyncHandler.fetch(
+          toRequest("/?id=123", {
+            method: "POST",
+            headers: { "x-token": "abc" },
+            body: JSON.stringify({ name: "banned" }),
+          }),
+        );
+        expect(res.status).toBe(400);
+        expect(await res.json()).toMatchObject({
+          data: { issues: [{ path: ["name"], message: "Name is banned" }] },
+        });
+      });
+    });
   });
 });
 


### PR DESCRIPTION
Discussed in #1437

This is the first PR of hopefully a few related to improving validation strictness and related type support within h3's toolset.

In this change I solely focus on adding async support for query and header validaiton within `defineValidatedHandler` that were previously sync-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for asynchronous validation of request bodies, headers, and query parameters.
  * Async validation results are now correctly awaited before handlers run.

* **Bug Fixes**
  * Invalid asynchronously validated inputs now return the expected validation errors and HTTP 400 responses.
  * Preserved existing custom validation error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->