### PR TITLE
fix(deprecated): correct v1 signatures in the compat shim

### DIFF
--- a/src/_deprecated.ts
+++ b/src/_deprecated.ts
@@ -130,7 +130,7 @@ export const sendNoContent: (event: H3Event, code?: number) => HTTPResponse = (_
   noContent(code);
 
 /** @deprecated Please use `return redirect(event, code)` */
-export const sendRedirect: (event: H3Event, location: string, code: number) => HTTPResponse = (
+export const sendRedirect: (event: H3Event, location: string, code?: number) => HTTPResponse = (
   _,
   loc,
   code,
@@ -242,14 +242,15 @@ export function removeResponseHeader(event: H3Event, name: string): void {
 }
 
 /** @deprecated Please use `event.res.headers.append(name, value)` */
-export function appendResponseHeaders(event: H3Event, headers: string): void {
+export function appendResponseHeaders(event: H3Event, headers: Record<string, string>): void {
   for (const [name, value] of Object.entries(headers)) {
     appendResponseHeader(event, name, value!);
   }
 }
 
 /** @deprecated Please use `event.res.headers.append(name, value)` */
-export const appendHeaders: (event: H3Event, headers: string) => void = appendResponseHeaders;
+export const appendHeaders: (event: H3Event, headers: Record<string, string>) => void =
+  appendResponseHeaders;
 
 /** @deprecated Please use `event.res.headers.delete` */
 export function clearResponseHeaders(event: H3Event, headerNames?: string[]): void {

--- a/test/unit/types.test-d.ts
+++ b/test/unit/types.test-d.ts
@@ -9,7 +9,12 @@ import {
   defineValidatedHandler,
   defineWebSocketHandler,
 } from "../../src/index.ts";
-import { defineEventHandler } from "../../src/_deprecated.ts";
+import {
+  appendHeaders,
+  appendResponseHeaders,
+  defineEventHandler,
+  sendRedirect,
+} from "../../src/_deprecated.ts";
 import { z } from "zod";
 
 describe("types", () => {
@@ -235,5 +240,19 @@ describe("routeRules", () => {
       // How rule modules attach matched rules (see Nitro's generated middleware).
       event.context.routeRules = {} as RouteRules;
     });
+  });
+});
+
+describe("deprecated v1 signatures", () => {
+  // The v1 signature took a headers record; the implementation still iterates one
+  // with `Object.entries`, so the declared `string` makes the export uncallable.
+  it("appendResponseHeaders takes a headers record", () => {
+    expectTypeOf(appendResponseHeaders).toBeCallableWith({} as H3Event, { "x-foo": "bar" });
+    expectTypeOf(appendHeaders).toBeCallableWith({} as H3Event, { "x-foo": "bar" });
+  });
+
+  // v1 defaulted to 302 and the delegated `redirect()` still does, so the status is optional.
+  it("sendRedirect leaves the status code optional", () => {
+    expectTypeOf(sendRedirect).toBeCallableWith({} as H3Event, "/target");
   });
 });


### PR DESCRIPTION
Addresses two of the deprecated-typing items from #1482.

`appendResponseHeaders` (and its `appendHeaders` alias) declares `headers: string`, but the body iterates the argument with `Object.entries`. As typed the export is unusable: passing the record it actually wants is a type error, and passing the declared `string` yields index-keyed garbage headers. Its sibling `setResponseHeaders`/`setHeaders` already takes `Record<string, string>`, so this brings the append pair in line with it.

`sendRedirect` required `code`, but v1 defaulted to 302 and the delegated `redirect()` still has `status = 302`. `sendNoContent` directly above it already declares `code?: number`, so the two are consistent again.

Both changes are type-only — runtime behaviour is untouched and there is no bundle impact.

Type tests are added to `test/unit/types.test-d.ts`. They fail on `main` (`TS2345` on the record argument, twice, and `TS2554` for the missing `code`) and pass with the change. Locally `vitest --run` reports 55 files / 1561 passed with `Type Errors  no errors`, and `oxlint` plus `oxfmt --check` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated deprecated redirect handling to allow the status code to be omitted.
  * Improved deprecated header helpers to accept multiple headers as key-value pairs.
  * Updated type definitions and validation to reflect the revised deprecated API signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->