### PR TITLE
fix(exports): export kNotFound and kHandled symbols from src/index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ export {
 
 // Response
 
-export { toResponse, HTTPResponse } from "./response.ts";
+export { toResponse, HTTPResponse, kNotFound, kHandled } from "./response.ts";
 
 // Error
 

--- a/test/unit/package.test.ts
+++ b/test/unit/package.test.ts
@@ -92,6 +92,8 @@ describe("h3 package", () => {
         "isMethod",
         "isPreflightRequest",
         "iterable",
+        "kHandled",
+        "kNotFound",
         "lazyEventHandler",
         "mockEvent",
         "noContent",


### PR DESCRIPTION
Addresses the "`kNotFound` / `kHandled` not exported from `src/index.ts`" item from #1482.

## Problem

The documented handler return contract (AGENTS.md, `src/response.ts` doc comment) says handlers can `return kNotFound` for a 404 or `return kHandled` when a response was already sent (SSE, WebSocket, Node stream handoff, etc.). Both symbols are defined and exported from `src/response.ts`, and used internally throughout `src/h3.ts`, `src/middleware.ts`, and `src/adapters.ts` — but `src/index.ts` never re-exported them, so the only way for a consumer to get a reference matching h3's internal symbol is the indirect `Symbol.for("h3.notFound")` / `Symbol.for("h3.handled")` route.

## Fix

Re-export `kNotFound` and `kHandled` from `src/index.ts` alongside the existing `toResponse`/`HTTPResponse` response exports, and update the inline package-export snapshot test to include the two new names.

## Validation

- `pnpm lint` → `oxlint` + `oxfmt --check` clean
- `pnpm build` (obuild) → succeeds; bundle export list for every entry now includes `kHandled, kNotFound`
- `pnpm vitest run test/unit/types.test-d.ts` → 19/19 passed, no type errors
- `pnpm vitest run` (full suite) → 1557 passed / 43 skipped; only pre-existing/environment-dependent failure is an IP-address regex assertion in `test/utils.test.ts` (`getRequestIP`) unrelated to this change, which also fails identically on `main` before this patch in this sandbox (no other test regresses)
- Updated the `test/unit/package.test.ts` inline snapshot to reflect the two newly exported names

No runtime behavior changes — this is purely a missing re-export.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `kHandled` and `kNotFound` to the package’s publicly available exports, making these response constants accessible to consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->