### PR TITLE
docs: add CORS guide and improve example

### DIFF
--- a/docs/4.examples/0.index.md
+++ b/docs/4.examples/0.index.md
@@ -12,6 +12,7 @@ Check [`examples/` dir](https://github.com/h3js/h3/tree/main/examples) for more 
 
 **Examples:**
 
+- [CORS](/examples/handle-cors)
 - [Cookies](/examples/handle-cookie)
 - [HTTP QUERY Method](/examples/handle-query)
 - [Session](/examples/handle-session)

--- a/docs/4.examples/handle-cors.md
+++ b/docs/4.examples/handle-cors.md
@@ -1,0 +1,87 @@
+---
+icon: ph:globe-hemisphere-west
+---
+
+# CORS
+
+> Handle cross-origin requests with H3.
+
+Cross-Origin Resource Sharing (CORS) lets a browser page on one origin call your API on another. Browsers enforce CORS: your server must send the right `Access-Control-*` headers, and many requests also require a successful `OPTIONS` preflight.
+
+H3 provides [`handleCors`](/utils/security#handlecorsevent-options) to append headers and answer preflights. Call it at the start of a handler or in middleware **before** your route logic runs.
+
+## Basic usage
+
+The recommended pattern is to call `handleCors` first and return early when it handles a preflight:
+
+```ts
+import { H3, serve, handleCors } from "h3";
+
+const app = new H3();
+
+app.use((event) => {
+  if (handleCors(event, { origin: "*" })) {
+    return;
+  }
+});
+
+app.post("/api/data", async (event) => {
+  const body = await event.req.json();
+  return { ok: true, body };
+});
+
+serve(app);
+```
+
+`handleCors` returns a response when the request is handled (typically a `204` for `OPTIONS` preflight). When it returns `false`, continue with your handler.
+
+:read-more{to="/utils/security#cors" title="CORS utilities"}
+
+## Per-route CORS
+
+You can also call `handleCors` inside a single route:
+
+```ts
+app.get("/hello", (event) => {
+  if (handleCors(event, { origin: "https://app.example.com" })) {
+    return;
+  }
+  return "Hello World!";
+});
+```
+
+## Common pitfalls
+
+### Preflight requests
+
+Browsers send an `OPTIONS` request before many cross-origin calls — for example `POST` with `Content-Type: application/json`. If `handleCors` is not called for that path and method, the preflight fails and the browser reports a CORS error even when your `POST` handler would have worked.
+
+Use middleware (as in the basic example) when several routes need CORS, especially POST-only APIs.
+
+### Simple vs non-simple requests
+
+`GET` requests without custom headers are often [CORS-simple](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests) and may not preflight. Adding headers like `Content-Type: application/json` or `Authorization` triggers a preflight.
+
+### Error responses
+
+When a handler throws, prepared response headers may be dropped. `handleCors` sets both normal and error headers so CORS still applies on failure responses.
+
+:read-more{to="/guide/basics/error" title="Error handling"}
+
+## Using Nitro or Nuxt
+
+In [Nitro](https://nitro.build) apps you can enable CORS with a [`cors` route rule](/docs/routing#cors). Route rules add headers but still require an `OPTIONS` handler for preflight — see the Nitro routing guide for a catch-all example.
+
+In Nuxt, set `routeRules` in `nuxt.config.ts`:
+
+```ts
+export default defineNuxtConfig({
+  routeRules: {
+    "/api/**": { cors: true },
+  },
+});
+```
+
+## Example
+
+See the full runnable example in [`examples/cors.mjs`](https://github.com/h3js/h3/blob/main/examples/cors.mjs).

--- a/examples/cors.mjs
+++ b/examples/cors.mjs
@@ -2,11 +2,18 @@ import { H3, serve, handleCors } from "h3";
 
 export const app = new H3();
 
-app.get("/hello", (event) => {
+// Answer CORS preflights and add headers for all routes
+app.use((event) => {
   if (handleCors(event, { origin: "*" })) {
     return;
   }
-  return "Hello World!";
+});
+
+app.get("/hello", () => "Hello World!");
+
+app.post("/api/data", async (event) => {
+  const body = await event.req.json();
+  return { ok: true, body };
 });
 
 serve(app);


### PR DESCRIPTION
## Summary

Closes #902.

Adds a CORS example guide (preflight pitfalls, middleware pattern, Nitro/Nuxt notes) and updates examples/cors.mjs to use global middleware with POST support.

## Test plan

- [x] Docs and example only
- [x] Pattern matches handleCors JSDoc in security utils

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a runnable CORS example with global CORS handling, preflight support, and a JSON POST endpoint.
* **Documentation**
  * Added guidance for configuring CORS, including middleware usage, per-route handling, preflight requests, error responses, and Nitro/Nuxt route rules.
  * Added the CORS example to the examples index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->