### PR TITLE
refactor(event-stream)!: drop `autoclose` option

### DIFF
--- a/src/utils/event-stream.ts
+++ b/src/utils/event-stream.ts
@@ -1,14 +1,12 @@
 import type { H3Event } from "../event.ts";
 import { EventStream } from "./internal/event-stream.ts";
 
-export interface EventStreamOptions {
-  /**
-   * Automatically close the writable stream when the request is closed
-   *
-   * Default is `true`
-   */
-  autoclose?: boolean;
-}
+/**
+ * Options for {@link createEventStream}.
+ *
+ * Currently empty — reserved for future configuration.
+ */
+export interface EventStreamOptions {}
 
 /**
  * See https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#fields

--- a/src/utils/internal/event-stream.ts
+++ b/src/utils/internal/event-stream.ts
@@ -25,26 +25,22 @@ export class EventStream {
     return this._writerIsClosed || this._disposed;
   }
 
-  constructor(event: H3Event, opts: EventStreamOptions = {}) {
+  constructor(event: H3Event, _opts: EventStreamOptions = {}) {
     this._event = event;
     this._writer = this._transformStream.writable.getWriter();
     // `closed` rejects when the readable side is cancelled (client disconnect)
     // and resolves on a graceful `close()`. Both mean the stream is over.
     this._writer.closed.catch(_noop).finally(() => {
       this._writerIsClosed = true;
-      if (opts.autoclose !== false) {
-        this._disposed = true;
-      }
+      this._disposed = true;
       for (const cb of this._closeCallbacks.splice(0)) {
         _invokeCloseCallback(cb);
       }
     });
-    if (opts.autoclose !== false) {
-      // End-of-event covers every runtime: normal end, client disconnect, and
-      // a stream that is created but never `send()`-ed (the response completed
-      // without it) all converge here.
-      onDispose(this._event, () => this.close());
-    }
+    // End-of-event covers every runtime: normal end, client disconnect, and
+    // a stream that is created but never `send()`-ed (the response completed
+    // without it) all converge here.
+    onDispose(this._event, () => this.close());
   }
 
   /**


### PR DESCRIPTION
Closes #1489

## What

Removes the `autoclose` option from `EventStream`. The `EventStreamOptions` interface and the `createEventStream(event, opts?)` signature are **kept** (options object is now empty) for future configuration and signature compatibility.

## Why

`autoclose` (default `true`) existed in v1 to opt out of Node.js event listeners. The v2 rewrite plus the `onDispose` hook replaced that whole mechanism, leaving the option vestigial:

- **No practical effect** — `autoclose: false` did not keep the stream writable after client disconnect; the transport layer fails regardless.
- **Silent leak** — a stream created with `autoclose: false` but never `send()`-ed never fired its `onClosed` callbacks, with no user-recoverable workaround.
- **Untested** — no test exercised the `false` path.

Auto-close via `onDispose` is now always on, which was already the effective default.

## Changes

- `src/utils/event-stream.ts` — drop the `autoclose` field from `EventStreamOptions` (interface kept, now empty); `createEventStream(event, opts?)` signature unchanged.
- `src/utils/internal/event-stream.ts` — drop the `autoclose` branches; always register `onDispose` cleanup and mark disposed on writer close. Constructor still accepts an (unused) options arg.
- `src/index.ts` — `EventStreamOptions` export retained.

## Notes

Breaking only for callers passing `autoclose` (the SSE API is `@experimental` and this lands before v2 stable). The public signature and exported types are otherwise unchanged. Existing SSE tests (including client-disconnect auto-close) pass unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event stream cleanup when connections close, including cases where no events were sent.
  * Ensured queued close callbacks run consistently when the underlying connection ends.
  * Removed the configurable automatic-close option in favor of consistent stream lifecycle handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->