### PR TITLE
docs: add H3 ecosystem overview

### DIFF
--- a/docs/1.guide/0.index.md
+++ b/docs/1.guide/0.index.md
@@ -18,6 +18,9 @@ icon: pixel:play
 ⚡ H3 (short for H(TTP), pronounced as /eɪtʃθriː/, like h-3) is a lightweight, fast, and composable server framework for modern JavaScript runtimes. It is based on web standard primitives such as [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request), [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response), [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL), and [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers). You can integrate H3 with any compatible runtime or [mount](/guide/api/h3#h3mount) other web-compatible handlers to H3 with almost no added latency.
 
 H3 is designed to be extendable and composable. Instead of providing one big core, you start with a lightweight [H3 instance](/guide/api/h3) and then import built-in, tree-shakable [utilities](/utils) or bring your own for more functionality.
+
+:read-more{to="/guide/basics/ecosystem" title="H3 ecosystem"}
+
 Composable utilities has several advantages:
 
 - The server only includes used code and runs them exactly where is needed.

--- a/docs/1.guide/1.basics/8.ecosystem.md
+++ b/docs/1.guide/1.basics/8.ecosystem.md
@@ -1,0 +1,63 @@
+---
+icon: ph:tree-structure
+---
+
+# Ecosystem
+
+> How H3 fits into the broader UnJS server stack.
+
+H3 is the HTTP layer: routing, middleware, request/response utilities, and Web Standard APIs. It is intentionally small. Other packages in the ecosystem add deployment, storage, databases, and tooling on top — often without changing the H3 APIs you write handlers with.
+
+## Stack overview
+
+```mermaid
+flowchart TB
+  subgraph app [Your application]
+    H[H3 handlers and middleware]
+  end
+  subgraph nitro [Nitro optional]
+    N[Filesystem routing, presets, build]
+  end
+  subgraph data [Data layer optional]
+    S[unstorage KV]
+    D[db0 SQL]
+  end
+  H --> N
+  N --> S
+  N --> D
+```
+
+You can use H3 alone with `serve()` or `app.fetch`. [Nitro](https://nitro.build) is the recommended full-stack layer when you need filesystem routing, code splitting, deployment presets, and built-in storage or database support.
+
+## Core packages
+
+| Package | Role | Docs |
+|---------|------|------|
+| [H3](https://h3.dev) | HTTP server framework (this project) | [h3.dev](https://h3.dev) |
+| [Nitro](https://nitro.build) | Universal server toolkit built on H3 | [nitro.build](https://nitro.build) |
+| [Rou3](https://github.com/h3js/rou3) | Route matcher used by H3 | [rou3](https://github.com/h3js/rou3) |
+| [Srvx](https://srvx.h3.dev) | Runtime-agnostic server listener (`serve`) | [srvx](https://srvx.h3.dev) |
+
+## Storage and data
+
+| Package | Role | Used by |
+|---------|------|---------|
+| [unstorage](https://unstorage.unjs.io) | Runtime-agnostic key-value storage | Nitro `useStorage()`, H3 apps via direct import |
+| [db0](https://db0.unjs.io) | Lightweight SQL connectors | Nitro `useDatabase()` |
+
+In a Nitro app, prefer [Nitro storage](https://nitro.build/docs/storage) and [Nitro database](https://nitro.build/docs/database) over wiring these libraries manually — Nitro configures drivers from your `nitro.config`.
+
+## Runtime compatibility
+
+| Package | Role |
+|---------|------|
+| [unenv](https://github.com/unjs/unenv) | Node.js compatibility presets for non-Node runtimes |
+| [unimport](https://github.com/unjs/unimport) | Auto-imports (used by Nitro for `defineHandler`, etc.) |
+
+## When to use what
+
+- **H3 only** — microservices, custom servers, embedding HTTP in another tool, or learning the request lifecycle.
+- **Nitro** — full-stack apps, multi-provider deployment, filesystem routing, prerendering, and integrated storage/cache/database.
+- **Nuxt** — Vue full-stack apps; Nuxt uses Nitro as its server engine. Server routes and middleware are H3-compatible.
+
+:read-more{to="https://nitro.build" title="Nitro documentation"}


### PR DESCRIPTION
## Summary

Closes #1104.

Adds /guide/basics/ecosystem with a stack overview, package table, and when-to-use guidance. Links from the getting started page.

## Test plan

- [x] Docs-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an Ecosystem guide explaining H3’s role within the broader UnJS server ecosystem.
  * Documented related packages, storage and database integrations, runtime compatibility tools, and when to choose H3, Nitro, or Nuxt.
  * Added an architecture diagram and links to additional ecosystem documentation.
  * Added a “Read more” link to the new guide from the Getting Started overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->