### PR TITLE
docs: show reusable middleware factory patterns

### DIFF
--- a/docs/1.guide/1.basics/3.middleware.md
+++ b/docs/1.guide/1.basics/3.middleware.md
@@ -76,6 +76,51 @@ app.get(
 );
 ```
 
+## Reusable middleware factories
+
+Libraries often need one helper that works both as **global middleware** (`app.use(...)`) and as a **per-route wrapper** (file-based Nitro/Nuxt routes). Use `defineMiddleware` for the middleware itself, and `defineHandler` object syntax to attach it to a handler:
+
+```ts
+import { defineHandler, defineMiddleware, type EventHandler } from "h3";
+
+export function withAuth(opts: { role: string }, handler?: EventHandler) {
+  const middleware = defineMiddleware(async (event, next) => {
+    // validate session / role, then:
+    event.context.auth = { role: opts.role };
+    return next();
+  });
+
+  // Pattern A: app-wide — app.use(withAuth({ role: "user" }))
+  if (!handler) {
+    return middleware;
+  }
+
+  // Pattern B: per-route — export default withAuth({ role: "user" }, async (event) => { ... })
+  return defineHandler({
+    middleware: [middleware],
+    handler,
+  });
+}
+```
+
+Usage:
+
+```ts
+// Global
+app.use(withAuth({ role: "user" }));
+
+// Per route (also works for Nitro/Nuxt `server/` files)
+export default withAuth({ role: "admin" }, async (event) => {
+  return event.context.auth;
+});
+```
+
+::note
+For Nitro `server/middleware/` files, exporting a middleware function (or the result of `defineMiddleware`) is fine — Nitro registers those files as middleware. For `server/routes/` / `server/api/` files, export a handler (`defineHandler` or a wrapped handler as in pattern B), not a bare middleware.
+::
+
+:read-more{to="/guide/basics/handler#object-syntax" title="Handler object syntax"}
+
 For convenience, H3 provides middleware factory functions `onRequest`, `onResponse`, and `onError`:
 
 ```js


### PR DESCRIPTION
## Summary

Closes #1374.

Documents how to build a reusable middleware factory that supports both `app.use(middleware)` and per-route wrapping via `defineHandler({ middleware, handler })`, including Nitro `server/middleware` vs `server/routes` export notes.

## Test plan

- [x] Docs-only change
- [x] Matches `defineMiddleware` / handler object syntax APIs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for creating reusable middleware factories.
  * Documented how to use middleware globally or as a per-route wrapper.
  * Added examples covering authentication middleware patterns.
  * Clarified export requirements for middleware, route, and API files.
  * Linked to additional documentation on handler object syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->