### PR TITLE
fix(event): keep `event.context` and `req.context` as one reference

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -80,7 +80,11 @@ export class H3Event<
   static __is_event__ = true;
 
   constructor(req: ServerRequest, context?: H3EventContext, app?: H3Core) {
-    this.context = context || req.context || new EmptyObject();
+    // Keep `event.context` and `req.context` as the same reference so utilities
+    // reading `event.req.context` (e.g. getRequestIP) observe writes to
+    // `event.context`. Without the write-back, an explicit `context` or an
+    // unset `req.context` leaves the two objects diverged.
+    this.context = req.context = context || req.context || new EmptyObject();
     this.req = req;
     this.app = app;
     // Parsed URL can be provided by srvx (node) and other runtimes

--- a/test/unit/event.test.ts
+++ b/test/unit/event.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { FastURL } from "srvx";
 import { H3Event } from "../../src/event.ts";
+import { getRequestIP } from "../../src/utils/request.ts";
 import { decodePathname } from "../../src/utils/internal/path.ts";
 
 describe("H3Event URL normalization", () => {
@@ -39,6 +40,37 @@ describe("H3Event URL normalization", () => {
     const second = new H3Event(req);
     expect(second.url.pathname).toBe("/a%2541-A");
     expect(((req as any)._url as URL).pathname).toBe("/a%2541-%41");
+  });
+});
+
+describe("H3Event context reference", () => {
+  it("shares one reference with req.context when neither is provided", () => {
+    const req = new Request("http://localhost/");
+    const event = new H3Event(req as any);
+    expect(event.context).toBe(event.req.context);
+  });
+
+  it("shares one reference with req.context when an explicit context is passed", () => {
+    const req = new Request("http://localhost/");
+    const context = {} as any;
+    const event = new H3Event(req as any, context);
+    expect(event.context).toBe(context);
+    expect(event.req.context).toBe(context);
+  });
+
+  it("reuses a pre-populated req.context", () => {
+    const req = new Request("http://localhost/") as any;
+    req.context = { clientAddress: "1.1.1.1" };
+    const event = new H3Event(req);
+    expect(event.context).toBe(req.context);
+    expect(event.context.clientAddress).toBe("1.1.1.1");
+  });
+
+  it("getRequestIP observes clientAddress written to event.context", () => {
+    const req = new Request("http://localhost/");
+    const event = new H3Event(req as any);
+    event.context.clientAddress = "9.9.9.9";
+    expect(getRequestIP(event)).toBe("9.9.9.9");
   });
 });
 


### PR DESCRIPTION
## Problem

`getRequestIP` silently ignores `event.context.clientAddress`. Writing to the documented type surface — `clientAddress` is declared on `H3EventContext` (`src/types/context.ts:27`) — never reaches the reader at `src/utils/request.ts:542`, which reads `event.req.context?.clientAddress`. The call falls through to `event.req.ip` instead.

```js
app.get("/", (event) => {
  event.context.clientAddress = "9.9.9.9";
  return getRequestIP(event); // undefined (expected "9.9.9.9")
});
```

## Root cause

The invariant `event.context === event.req.context` is supposed to hold, but the constructor never established it. Two adjacent PRs conspired:

- **#1194** changed the ctor to `this.context = context || req.context || new EmptyObject()` — reading `req.context` as a fallback *source*, but never writing the resolved value *back* to `req.context`.
- **#1195** then moved the `getRequestIP` reader from `event.context.clientAddress` onto `event.req.context?.clientAddress`, assuming the two were always the same object.

They only coincide when the runtime pre-populated `req.context` — and srvx does not do so by default, so the common path diverges. The `?.` masked the breakage as a silent `undefined`.

## Fix

Assign the resolved context back to `req.context` so both point at one object across all three construction paths (explicit `context`, inherited `req.context`, fresh fallback):

```ts
this.context = req.context = context || req.context || new EmptyObject();
```

## Tests

Added regression tests in `test/unit/event.test.ts`:
- `event.context === event.req.context` when neither is provided
- same reference when an explicit `context` is passed
- pre-populated `req.context` is reused
- `getRequestIP` observes `clientAddress` written to `event.context`

All three failing-before assertions pass after the fix; full suite (1581 tests) + lint/typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured request and event context consistently reference the same object.
  * Preserved existing request context or applied the provided context when available.
  * Improved client IP retrieval when the address is stored in the event context.

* **Tests**
  * Added coverage for context sharing, reuse, and client IP behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->