### PR TITLE
feat(defineValidatedHandler): add params validation

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -16,7 +16,13 @@ import type {
 import type { StandardSchemaV1, InferOutput } from "./utils/internal/standard-schema.ts";
 import type { TypedRequest } from "fetchdts";
 import { NoHandler, type H3Core } from "./h3.ts";
-import { validatedRequest, validatedURL, type OnValidateError } from "./utils/internal/validate.ts";
+import {
+  validatedRequest,
+  validatedURL,
+  validatedParams,
+  type OnValidateError,
+} from "./utils/internal/validate.ts";
+import { chain } from "./utils/internal/promise.ts";
 
 // --- event handler ---
 
@@ -61,6 +67,7 @@ export function defineValidatedHandler<
   RequestBody extends StandardSchemaV1,
   RequestHeaders extends StandardSchemaV1,
   RequestQuery extends StandardSchemaV1,
+  RequestParams extends StandardSchemaV1,
   Res extends EventHandlerResponse = EventHandlerResponse,
 >(
   def: Omit<EventHandlerObject, "handler"> & {
@@ -68,12 +75,15 @@ export function defineValidatedHandler<
       body?: RequestBody;
       headers?: RequestHeaders;
       query?: RequestQuery;
+      params?: RequestParams;
+      decodeParams?: boolean;
       onError?: OnValidateError;
     };
     handler: EventHandler<
       {
         body: InferOutput<RequestBody>;
         query: StringHeaders<InferOutput<RequestQuery>>;
+        routerParams: StringHeaders<InferOutput<RequestParams>>;
       },
       Res
     >;
@@ -85,27 +95,18 @@ export function defineValidatedHandler<
   return defineHandler({
     ...def,
     handler: function _validatedHandler(event) {
-      const withURL = () => {
-        const url = validatedURL(event.url, def.validate!);
-        if (url instanceof Promise) {
-          return url.then((u) => {
-            (event as any) /* readonly */.url = u;
+      const v = def.validate!;
+      // `chain` keeps a fully-sync path from yielding a microtask.
+      // params → headers → query in sequential order
+      return chain(validatedParams(event, v), () =>
+        chain(validatedRequest(event.req, v), (req) => {
+          (event as any) /* readonly */.req = req;
+          return chain(validatedURL(event.url, v), (url) => {
+            (event as any) /* readonly */.url = url;
             return def.handler(event as any);
           });
-        }
-        (event as any) /* readonly */.url = url;
-        return def.handler(event as any);
-      };
-
-      const req = validatedRequest(event.req, def.validate!);
-      if (req instanceof Promise) {
-        return req.then((r) => {
-          (event as any) /* readonly */.req = r;
-          return withURL();
-        });
-      }
-      (event as any) /* readonly */.req = req;
-      return withURL();
+        }),
+      );
     },
   }) as any;
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -56,11 +56,31 @@ export function defineHandler(input: EventHandler | EventHandlerObject): EventHa
   );
 }
 
+// Route params and query values are always strings at runtime, so the inferred
+// handler types are narrowed to their string members. A schema that *coerces* a
+// field to a non-string (e.g. `z.coerce.number()`) therefore infers `never` for
+// that field here — the runtime value is coerced but the type cannot represent
+// it yet. Typing coerced params/query is tracked as a follow-up (#1437).
 type StringsOnly<T> = {
   [K in keyof T]: Extract<T[K], string>;
 };
 
 /**
+ * Define an event handler with Standard-Schema validation for `body`, `headers`,
+ * `query`, and route `params`.
+ *
+ * Validation runs sequentially — `params` → `headers` → `query` — and
+ * short-circuits: a failing step throws before later steps run. Body validation
+ * stays lazy and only runs when the handler reads `event.req.json()`.
+ *
+ * Validated `params` are written back to `event.context.params` (the schema
+ * output *replaces* the raw router params, so keys a strict schema strips are
+ * dropped). This side effect is visible to any downstream middleware, response
+ * hooks, or later `getRouterParams(event)` calls.
+ *
+ * Set `validate.decodeParams: true` to `decodeURIComponent`-decode the matched
+ * route params (via {@link getRouterParams}'s `decode`) *before* validation.
+ *
  * @experimental defineValidatedHandler is an experimental feature and API may change.
  */
 export function defineValidatedHandler<

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -84,10 +84,28 @@ export function defineValidatedHandler<
   }
   return defineHandler({
     ...def,
-    handler: async function _validatedHandler(event) {
-      (event as any) /* readonly */.req = await validatedRequest(event.req, def.validate!);
-      (event as any) /* readonly */.url = await validatedURL(event.url, def.validate!);
-      return def.handler(event as any);
+    handler: function _validatedHandler(event) {
+      const withURL = () => {
+        const url = validatedURL(event.url, def.validate!);
+        if (url instanceof Promise) {
+          return url.then((u) => {
+            (event as any) /* readonly */.url = u;
+            return def.handler(event as any);
+          });
+        }
+        (event as any) /* readonly */.url = url;
+        return def.handler(event as any);
+      };
+
+      const req = validatedRequest(event.req, def.validate!);
+      if (req instanceof Promise) {
+        return req.then((r) => {
+          (event as any) /* readonly */.req = r;
+          return withURL();
+        });
+      }
+      (event as any) /* readonly */.req = req;
+      return withURL();
     },
   }) as any;
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -56,7 +56,7 @@ export function defineHandler(input: EventHandler | EventHandlerObject): EventHa
   );
 }
 
-type StringHeaders<T> = {
+type StringsOnly<T> = {
   [K in keyof T]: Extract<T[K], string>;
 };
 
@@ -82,8 +82,8 @@ export function defineValidatedHandler<
     handler: EventHandler<
       {
         body: InferOutput<RequestBody>;
-        query: StringHeaders<InferOutput<RequestQuery>>;
-        routerParams: StringHeaders<InferOutput<RequestParams>>;
+        query: StringsOnly<InferOutput<RequestQuery>>;
+        routerParams: StringsOnly<InferOutput<RequestParams>>;
       },
       Res
     >;

--- a/src/utils/internal/promise.ts
+++ b/src/utils/internal/promise.ts
@@ -2,8 +2,12 @@
  * Continue with `fn` once `value` settles, staying synchronous when it already is.
  *
  * Avoids the `async`/`await` microtask tick on the common sync path while
- * collapsing the repeated `instanceof Promise` branch into one shared helper.
+ * collapsing the repeated thenable check into one shared helper. Duck-types
+ * `then` (instead of `instanceof Promise`) to support cross-realm promises
+ * and custom thenables.
  */
-export function chain<T, R>(value: T | Promise<T>, fn: (value: T) => R): R | Promise<R> {
-  return value instanceof Promise ? value.then(fn) : fn(value);
+export function chain<T, R>(value: T | PromiseLike<T>, fn: (value: T) => R): R | Promise<R> {
+  return typeof (value as PromiseLike<T>)?.then === "function"
+    ? ((value as PromiseLike<T>).then(fn) as Promise<R>)
+    : fn(value as T);
 }

--- a/src/utils/internal/promise.ts
+++ b/src/utils/internal/promise.ts
@@ -1,0 +1,9 @@
+/**
+ * Continue with `fn` once `value` settles, staying synchronous when it already is.
+ *
+ * Avoids the `async`/`await` microtask tick on the common sync path while
+ * collapsing the repeated `instanceof Promise` branch into one shared helper.
+ */
+export function chain<T, R>(value: T | Promise<T>, fn: (value: T) => R): R | Promise<R> {
+  return value instanceof Promise ? value.then(fn) : fn(value);
+}

--- a/src/utils/internal/validate.ts
+++ b/src/utils/internal/validate.ts
@@ -210,6 +210,7 @@ export function validatedParams(
     validate.onError,
   );
 
+  // Replace (not merge): schema output is the source of truth.
   const applyParams = (params: Record<string, string>): Record<string, string> => {
     event.context.params = params;
     return params;

--- a/src/utils/internal/validate.ts
+++ b/src/utils/internal/validate.ts
@@ -1,6 +1,9 @@
 import { type ErrorDetails, HTTPError } from "../../error.ts";
+import { chain } from "./promise.ts";
+import { getRouterParams } from "../request.ts";
 
 import type { ServerRequest } from "srvx";
+import type { H3Event } from "../../event.ts";
 import type {
   StandardSchemaV1,
   FailureResult,
@@ -105,7 +108,7 @@ export function validatedRequest<
       }
       return bodyProxy(req, validate);
     };
-    return validated instanceof Promise ? validated.then(applyHeaders) : applyHeaders(validated);
+    return chain(validated, applyHeaders);
   }
 
   return bodyProxy(req, validate);
@@ -185,10 +188,37 @@ export function validatedURL(
     return url;
   };
 
-  return validated instanceof Promise ? validated.then(applyQuery) : applyQuery(validated);
+  return chain(validated, applyQuery);
 }
 
-function validateSource<Source extends "headers" | "query", T = unknown>(
+export function validatedParams(
+  event: H3Event,
+  validate: {
+    params?: StandardSchemaV1;
+    decodeParams?: boolean;
+    onError?: OnValidateError;
+  },
+): Record<string, string> | undefined | Promise<Record<string, string>> {
+  if (!validate.params) {
+    return event.context.params;
+  }
+
+  const validated = validateSource(
+    "params",
+    getRouterParams(event, { decode: validate.decodeParams }),
+    validate.params as StandardSchemaV1<Record<string, string>>,
+    validate.onError,
+  );
+
+  const applyParams = (params: Record<string, string>): Record<string, string> => {
+    event.context.params = params;
+    return params;
+  };
+
+  return chain(validated, applyParams);
+}
+
+function validateSource<Source extends "headers" | "query" | "params", T = unknown>(
   source: Source,
   data: unknown,
   fn: StandardSchemaV1<T>,
@@ -206,8 +236,7 @@ function validateSource<Source extends "headers" | "query", T = unknown>(
     return result.value;
   };
 
-  const result = fn["~standard"].validate(data);
-  return result instanceof Promise ? result.then(finish) : finish(result);
+  return chain(fn["~standard"].validate(data), finish);
 }
 
 function createValidationError(cause: Error | HTTPError | ErrorDetails | FailureResult) {

--- a/src/utils/internal/validate.ts
+++ b/src/utils/internal/validate.ts
@@ -1,7 +1,13 @@
 import { type ErrorDetails, HTTPError } from "../../error.ts";
 
 import type { ServerRequest } from "srvx";
-import type { StandardSchemaV1, FailureResult, InferOutput, Issue } from "./standard-schema.ts";
+import type {
+  StandardSchemaV1,
+  FailureResult,
+  InferOutput,
+  Issue,
+  Result,
+} from "./standard-schema.ts";
 
 export type ValidateResult<T> = T | true | false | void;
 
@@ -75,7 +81,7 @@ export async function validateData<T>(
 // prettier-ignore
 const reqBodyKeys = /* @__PURE__ */ new Set(["body", "text", "formData", "arrayBuffer"]);
 
-export async function validatedRequest<
+export function validatedRequest<
   RequestBody extends StandardSchemaV1,
   RequestHeaders extends StandardSchemaV1,
 >(
@@ -85,20 +91,30 @@ export async function validatedRequest<
     headers?: RequestHeaders;
     onError?: OnValidateError;
   },
-): Promise<ServerRequest> {
-  // Validate Headers
+): ServerRequest | Promise<ServerRequest> {
   if (validate.headers) {
-    const validatedheaders = await validateSource(
+    const validated = validateSource(
       "headers",
       Object.fromEntries(req.headers.entries()),
       validate.headers as StandardSchemaV1<Record<string, string>>,
       validate.onError,
     );
-    for (const [key, value] of Object.entries(validatedheaders)) {
-      req.headers.set(key, value);
-    }
+    const applyHeaders = (headers: Record<string, string>): ServerRequest => {
+      for (const [key, value] of Object.entries(headers)) {
+        req.headers.set(key, value);
+      }
+      return bodyProxy(req, validate);
+    };
+    return validated instanceof Promise ? validated.then(applyHeaders) : applyHeaders(validated);
   }
 
+  return bodyProxy(req, validate);
+}
+
+function bodyProxy(
+  req: ServerRequest,
+  validate: { body?: StandardSchemaV1; onError?: OnValidateError },
+): ServerRequest {
   if (!validate.body) {
     return req;
   }
@@ -144,47 +160,54 @@ export async function validatedRequest<
   });
 }
 
-export async function validatedURL(
+export function validatedURL(
   url: URL,
   validate: {
     query?: StandardSchemaV1;
     onError?: OnValidateError;
   },
-): Promise<URL> {
+): URL | Promise<URL> {
   if (!validate.query) {
     return url;
   }
 
-  const validatedQuery = await validateSource(
+  const validated = validateSource(
     "query",
     Object.fromEntries(url.searchParams.entries()),
     validate.query as StandardSchemaV1<Record<string, string>>,
     validate.onError,
   );
 
-  for (const [key, value] of Object.entries(validatedQuery)) {
-    url.searchParams.set(key, value);
-  }
+  const applyQuery = (query: Record<string, string>): URL => {
+    for (const [key, value] of Object.entries(query)) {
+      url.searchParams.set(key, value);
+    }
+    return url;
+  };
 
-  return url;
+  return validated instanceof Promise ? validated.then(applyQuery) : applyQuery(validated);
 }
 
-async function validateSource<Source extends "headers" | "query", T = unknown>(
+function validateSource<Source extends "headers" | "query", T = unknown>(
   source: Source,
   data: unknown,
   fn: StandardSchemaV1<T>,
   onError?: OnValidateError,
-): Promise<T> {
-  const result = await fn["~standard"].validate(data);
-  if (result.issues) {
-    throw createValidationError(
-      onError?.({ _source: source, ...result }) || {
-        message: VALIDATION_FAILED,
-        issues: result.issues,
-      },
-    );
-  }
-  return result.value;
+): T | Promise<T> {
+  const finish = (result: Result<T>): T => {
+    if (result.issues) {
+      throw createValidationError(
+        onError?.({ _source: source, ...result }) || {
+          message: VALIDATION_FAILED,
+          issues: result.issues,
+        },
+      );
+    }
+    return result.value;
+  };
+
+  const result = fn["~standard"].validate(data);
+  return result instanceof Promise ? result.then(finish) : finish(result);
 }
 
 function createValidationError(cause: Error | HTTPError | ErrorDetails | FailureResult) {

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -179,10 +179,11 @@ export function getValidatedQuery(
  *   const params = getRouterParams(event); // { key: "value" }
  * });
  */
-export function getRouterParams(
-  event: HTTPEvent,
-  opts: { decode?: boolean } = {},
-): NonNullable<H3Event["context"]["params"]> {
+export function getRouterParams<
+  T,
+  Event extends H3Event | HTTPEvent = HTTPEvent,
+  _T = Exclude<InferEventInput<"routerParams", Event, T>, undefined>,
+>(event: Event, opts: { decode?: boolean } = {}): _T {
   // Fallback object needs to be returned in case router is not used (#149)
   const context = getEventContext<H3EventContext>(event);
   let params = (context.params || {}) as NonNullable<H3Event["context"]["params"]>;
@@ -192,7 +193,7 @@ export function getRouterParams(
       params[key] = decodeRouterParam(params[key]);
     }
   }
-  return params;
+  return params as _T;
 }
 
 // Percent-encoded path separators (`%2f` → `/`, `%5c` → `\`) at any `%25`-nesting

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -190,7 +190,10 @@ export function getRouterParams<
   if (opts.decode) {
     params = { ...params };
     for (const key in params) {
-      params[key] = decodeRouterParam(params[key]);
+      // Validated params hold schema output, which may be non-string (coerced)
+      if (typeof params[key] === "string") {
+        params[key] = decodeRouterParam(params[key]);
+      }
     }
   }
   return params as _T;

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -449,6 +449,34 @@ describe("handler.ts", () => {
         });
       });
 
+      // The schema output replaces `context.params` entirely: params it strips
+      // are intentionally dropped so non-validated data never leaks through.
+      it("drops router params stripped by the schema", async () => {
+        const partialHandler = defineValidatedHandler({
+          validate: {
+            params: z.object({ id: z.string().min(3) }),
+          },
+          handler: (event) => getRouterParams(event),
+        });
+        const app = mount("/users/:id/posts/:postId", partialHandler);
+        const res = await app.request("/users/123/posts/456");
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ id: "123" });
+      });
+
+      it("keeps extra router params with a loose schema", async () => {
+        const looseHandler = defineValidatedHandler({
+          validate: {
+            params: z.looseObject({ id: z.string().min(3) }),
+          },
+          handler: (event) => getRouterParams(event),
+        });
+        const app = mount("/users/:id/posts/:postId", looseHandler);
+        const res = await app.request("/users/123/posts/456");
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ id: "123", postId: "456" });
+      });
+
       describe("decode", () => {
         const decodeHandler = defineValidatedHandler({
           validate: {

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -502,6 +502,19 @@ describe("handler.ts", () => {
           const res = await app.request("/files/foo%40bar");
           expect(res.status).toBe(400);
         });
+
+        // Regression: after a coercing schema, `context.params` may hold
+        // non-strings — caller-side decode must skip them, not crash.
+        it("decode:true after coercion skips non-string values", async () => {
+          const coerceHandler = defineValidatedHandler({
+            validate: { params: z.object({ id: z.coerce.number() }) },
+            handler: (event) => getRouterParams(event, { decode: true }),
+          });
+          const app = mount("/n/:id", coerceHandler);
+          const res = await app.request("/n/42");
+          expect(res.status).toBe(200);
+          expect(await res.json()).toEqual({ id: 42 });
+        });
       });
 
       describe("async", () => {

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -374,6 +374,47 @@ describe("handler.ts", () => {
         });
       });
     });
+
+    // Regression: async header validation must short-circuit query validation.
+    // A racing `Promise.all` would run the query schema even when headers
+    // already failed, and let its error win nondeterministically.
+    describe("async validation ordering", () => {
+      const querySpy = vi.fn(async (id: string) => id.length >= 3);
+      const orderingHandler = defineValidatedHandler({
+        validate: {
+          body: z.object({ name: z.string() }),
+          headers: z.object({
+            "x-token": z.string().refine(async (token) => token.length >= 3, "Token too short"),
+          }),
+          query: z.object({
+            id: z.string().refine(querySpy, "Id too short"),
+          }),
+        },
+        handler: async () => "ok",
+      });
+
+      it("runs query validation once headers pass", async () => {
+        querySpy.mockClear();
+        const res = await orderingHandler.fetch(
+          toRequest("/?id=123", { headers: { "x-token": "abc" } }),
+        );
+        expect(res.status).toBe(200);
+        expect(querySpy).toHaveBeenCalled();
+      });
+
+      it("skips query validation and reports the headers error when headers fail", async () => {
+        querySpy.mockClear();
+        const res = await orderingHandler.fetch(
+          // query would also be invalid, yet the headers error must surface
+          toRequest("/?id=1", { headers: { "x-token": "ab" } }),
+        );
+        expect(res.status).toBe(400);
+        expect(await res.json()).toMatchObject({
+          data: { issues: [{ path: ["x-token"], message: "Token too short" }] },
+        });
+        expect(querySpy).not.toHaveBeenCalled();
+      });
+    });
   });
 });
 

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -5,6 +5,8 @@ import {
   dynamicEventHandler,
   defineLazyEventHandler,
   defineValidatedHandler,
+  getRouterParams,
+  H3,
 } from "../src/index.ts";
 import type { ValidateIssues } from "../src/utils/internal/validate.ts";
 
@@ -413,6 +415,102 @@ describe("handler.ts", () => {
           data: { issues: [{ path: ["x-token"], message: "Token too short" }] },
         });
         expect(querySpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("params validation", () => {
+      // `defineValidatedHandler`'s TypedRequest return type isn't assignable to `app.get` (pre-exisitng)
+      const mount = (route: string, handler: unknown) => new H3().get(route, handler as any);
+
+      const paramsHandler = defineValidatedHandler({
+        validate: {
+          params: z.object({
+            id: z.string().min(3),
+            role: z.string().default("user"),
+          }),
+        },
+        handler: (event) => getRouterParams(event),
+      });
+
+      it("valid params, validated output written back to context", async () => {
+        const app = mount("/users/:id", paramsHandler);
+        const res = await app.request("/users/123");
+        expect(res.status).toBe(200);
+        // the `role` default proves the validated output lands in context.params
+        expect(await res.json()).toMatchObject({ id: "123", role: "user" });
+      });
+
+      it("invalid params", async () => {
+        const app = mount("/users/:id", paramsHandler);
+        const res = await app.request("/users/1");
+        expect(res.status).toBe(400);
+        expect(await res.json()).toMatchObject({
+          data: { issues: [{ path: ["id"] }] },
+        });
+      });
+
+      describe("decode", () => {
+        const decodeHandler = defineValidatedHandler({
+          validate: {
+            params: z.object({ name: z.literal("foo@bar") }),
+            decodeParams: true,
+          },
+          handler: (event) => getRouterParams(event),
+        });
+        const noDecodeHandler = defineValidatedHandler({
+          validate: { params: z.object({ name: z.literal("foo@bar") }) },
+          handler: (event) => getRouterParams(event),
+        });
+
+        it("decodes params before validation when decode:true", async () => {
+          const app = mount("/files/:name", decodeHandler);
+          const res = await app.request("/files/foo%40bar");
+          expect(res.status).toBe(200);
+          expect(await res.json()).toMatchObject({ name: "foo@bar" });
+        });
+
+        it("leaves params encoded by default", async () => {
+          const app = mount("/files/:name", noDecodeHandler);
+          const res = await app.request("/files/foo%40bar");
+          expect(res.status).toBe(400);
+        });
+      });
+
+      describe("async", () => {
+        const headerSpy = vi.fn(async (token: string) => token.length >= 3);
+        const asyncParamsHandler = defineValidatedHandler({
+          validate: {
+            params: z.object({
+              id: z.string().refine(async (id) => id.length >= 3, "Id too short"),
+            }),
+            headers: z.object({
+              "x-token": z.string().refine(headerSpy, "Token too short"),
+            }),
+          },
+          handler: async () => "ok",
+        });
+
+        it("validates async params", async () => {
+          headerSpy.mockClear();
+          const app = mount("/users/:id", asyncParamsHandler);
+          const res = await app.request("/users/1", { headers: { "x-token": "abc" } });
+          expect(res.status).toBe(400);
+          expect(await res.json()).toMatchObject({
+            data: { issues: [{ path: ["id"], message: "Id too short" }] },
+          });
+        });
+
+        it("short-circuits header validation when params fail", async () => {
+          headerSpy.mockClear();
+          const app = mount("/users/:id", asyncParamsHandler);
+          // header would also be invalid, yet params validation runs first
+          const res = await app.request("/users/1", { headers: { "x-token": "ab" } });
+          expect(res.status).toBe(400);
+          expect(await res.json()).toMatchObject({
+            data: { issues: [{ path: ["id"], message: "Id too short" }] },
+          });
+          expect(headerSpy).not.toHaveBeenCalled();
+        });
       });
     });
   });

--- a/test/unit/types.test-d.ts
+++ b/test/unit/types.test-d.ts
@@ -3,6 +3,7 @@ import { describe, it, expectTypeOf } from "vitest";
 import {
   defineHandler,
   getQuery,
+  getRouterParams,
   readBody,
   readValidatedBody,
   getValidatedQuery,
@@ -75,11 +76,19 @@ describe("types", () => {
           query: z.object({
             search: z.string().optional(),
           }),
+          params: z.object({
+            userId: z.string(),
+          }),
         },
         async handler(event) {
           const query = getQuery(event);
           expectTypeOf(query.search).not.toBeAny();
           expectTypeOf(query.search).toEqualTypeOf<string | undefined>();
+
+          // params are string-typed, mirroring query (coercion deferred)
+          const params = getRouterParams(event);
+          expectTypeOf(params).not.toBeAny();
+          expectTypeOf(params).toEqualTypeOf<{ userId: string }>();
 
           // TODO:
           // type PossibleParams = Parameters<typeof event.url.searchParams.get>[0]


### PR DESCRIPTION
Followup for #1491, discussed in #1437

This adds params validation in `defineValidatedHandler`, while also chaining promises as discussed in the prior PR, fast-tracking for sync operations.

The only limitation of this is that types do not actually rappresent what `event.context.params` are, since they are hardcoded into `Record<string, string>`. For this I would propose a followup PR which would also allow to properly type the `H3EventContext` and add room for future improvement that I've suggested in https://github.com/h3js/h3/issues/1437#issuecomment-5025050049

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added route `params` validation to validated handlers, including optional `decodeParams` to decode values before validation.
  * Strengthened handler typing by exposing validated `routerParams`, and standardizing query string typing.
* **Bug Fixes**
  * Validation now executes in a deterministic sequence (params → request → URL/query) and reliably short-circuits later async validations when earlier ones fail.
* **Tests**
  * Added regression and unit/type coverage for params defaults, strict vs loose params retention, decoding behavior, and async short-circuit ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->