### PR TITLE
feat(context): per-event typed H3EventContext

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -1,4 +1,4 @@
-import type { ServerRequest, ServerRuntimeContext } from "srvx";
+import type { ServerRequest, ServerRequestContext, ServerRuntimeContext } from "srvx";
 import type { H3EventContext } from "./types/context.ts";
 
 import { EmptyObject } from "./utils/internal/obj.ts";
@@ -29,6 +29,7 @@ export interface HTTPEvent<_RequestT extends EventHandlerRequest = EventHandlerR
 
 export class H3Event<
   _RequestT extends EventHandlerRequest = EventHandlerRequest,
+  _ContextT extends ServerRequestContext = H3EventContext,
 > implements HTTPEvent<_RequestT> {
   /**
    * Access to the H3 application instance.
@@ -72,19 +73,19 @@ export class H3Event<
   /**
    * Event context.
    */
-  readonly context: H3EventContext;
+  readonly context: _ContextT;
 
   /**
    * @internal
    */
   static __is_event__ = true;
 
-  constructor(req: ServerRequest, context?: H3EventContext, app?: H3Core) {
+  constructor(req: ServerRequest, context?: _ContextT, app?: H3Core) {
     // Keep `event.context` and `req.context` as the same reference so utilities
     // reading `event.req.context` (e.g. getRequestIP) observe writes to
     // `event.context`. Without the write-back, an explicit `context` or an
     // unset `req.context` leaves the two objects diverged.
-    this.context = req.context = context || req.context || new EmptyObject();
+    this.context = req.context = (context || req.context || new EmptyObject()) as _ContextT;
     this.req = req;
     this.app = app;
     // Parsed URL can be provided by srvx (node) and other runtimes

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -16,7 +16,13 @@ import type {
 import type { StandardSchemaV1, InferOutput } from "./utils/internal/standard-schema.ts";
 import type { TypedRequest } from "fetchdts";
 import { NoHandler, type H3Core } from "./h3.ts";
-import { validatedRequest, validatedURL, type OnValidateError } from "./utils/internal/validate.ts";
+import {
+  validatedRequest,
+  validatedURL,
+  validatedParams,
+  type OnValidateError,
+} from "./utils/internal/validate.ts";
+import { chain } from "./utils/internal/promise.ts";
 
 // --- event handler ---
 
@@ -61,6 +67,7 @@ export function defineValidatedHandler<
   RequestBody extends StandardSchemaV1,
   RequestHeaders extends StandardSchemaV1,
   RequestQuery extends StandardSchemaV1,
+  RequestParams extends StandardSchemaV1,
   Res extends EventHandlerResponse = EventHandlerResponse,
 >(
   def: Omit<EventHandlerObject, "handler"> & {
@@ -68,12 +75,15 @@ export function defineValidatedHandler<
       body?: RequestBody;
       headers?: RequestHeaders;
       query?: RequestQuery;
+      params?: RequestParams;
+      decodeParams?: boolean;
       onError?: OnValidateError;
     };
     handler: EventHandler<
       {
         body: InferOutput<RequestBody>;
         query: StringHeaders<InferOutput<RequestQuery>>;
+        routerParams: StringHeaders<InferOutput<RequestParams>>;
       },
       Res
     >;
@@ -85,27 +95,18 @@ export function defineValidatedHandler<
   return defineHandler({
     ...def,
     handler: function _validatedHandler(event) {
-      const withURL = () => {
-        const url = validatedURL(event.url, def.validate!);
-        if (url instanceof Promise) {
-          return url.then((u) => {
-            (event as any) /* readonly */.url = u;
+      const v = def.validate!;
+      // `chain` keeps a fully-sync path from yielding a microtask.
+      // params → headers → query in sequential order
+      return chain(validatedParams(event, v), () =>
+        chain(validatedRequest(event.req, v), (req) => {
+          (event as any) /* readonly */.req = req;
+          return chain(validatedURL(event.url, v), (url) => {
+            (event as any) /* readonly */.url = url;
             return def.handler(event as any);
           });
-        }
-        (event as any) /* readonly */.url = url;
-        return def.handler(event as any);
-      };
-
-      const req = validatedRequest(event.req, def.validate!);
-      if (req instanceof Promise) {
-        return req.then((r) => {
-          (event as any) /* readonly */.req = r;
-          return withURL();
-        });
-      }
-      (event as any) /* readonly */.req = req;
-      return withURL();
+        }),
+      );
     },
   }) as any;
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -84,10 +84,28 @@ export function defineValidatedHandler<
   }
   return defineHandler({
     ...def,
-    handler: async function _validatedHandler(event) {
-      (event as any) /* readonly */.req = await validatedRequest(event.req, def.validate!);
-      (event as any) /* readonly */.url = await validatedURL(event.url, def.validate!);
-      return def.handler(event as any);
+    handler: function _validatedHandler(event) {
+      const withURL = () => {
+        const url = validatedURL(event.url, def.validate!);
+        if (url instanceof Promise) {
+          return url.then((u) => {
+            (event as any) /* readonly */.url = u;
+            return def.handler(event as any);
+          });
+        }
+        (event as any) /* readonly */.url = url;
+        return def.handler(event as any);
+      };
+
+      const req = validatedRequest(event.req, def.validate!);
+      if (req instanceof Promise) {
+        return req.then((r) => {
+          (event as any) /* readonly */.req = r;
+          return withURL();
+        });
+      }
+      (event as any) /* readonly */.req = req;
+      return withURL();
     },
   }) as any;
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -56,7 +56,7 @@ export function defineHandler(input: EventHandler | EventHandlerObject): EventHa
   );
 }
 
-type StringHeaders<T> = {
+type StringsOnly<T> = {
   [K in keyof T]: Extract<T[K], string>;
 };
 
@@ -82,8 +82,8 @@ export function defineValidatedHandler<
     handler: EventHandler<
       {
         body: InferOutput<RequestBody>;
-        query: StringHeaders<InferOutput<RequestQuery>>;
-        routerParams: StringHeaders<InferOutput<RequestParams>>;
+        query: StringsOnly<InferOutput<RequestQuery>>;
+        routerParams: StringsOnly<InferOutput<RequestParams>>;
       },
       Res
     >;

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -14,6 +14,7 @@ import type {
   HTTPHandler,
 } from "./types/handler.ts";
 import type { StandardSchemaV1, InferOutput } from "./utils/internal/standard-schema.ts";
+import type { TypedH3EventContext } from "./types/context.ts";
 import type { TypedRequest } from "fetchdts";
 import { NoHandler, type H3Core } from "./h3.ts";
 import {
@@ -67,7 +68,9 @@ export function defineValidatedHandler<
   RequestBody extends StandardSchemaV1,
   RequestHeaders extends StandardSchemaV1,
   RequestQuery extends StandardSchemaV1,
-  RequestParams extends StandardSchemaV1,
+  // `undefined` default marks "no params schema" so the context override below
+  // only applies (and makes `params` required) when one is actually declared.
+  RequestParams extends StandardSchemaV1 | undefined = undefined,
   Res extends EventHandlerResponse = EventHandlerResponse,
 >(
   def: Omit<EventHandlerObject, "handler"> & {
@@ -83,14 +86,17 @@ export function defineValidatedHandler<
       {
         body: InferOutput<RequestBody>;
         query: StringsOnly<InferOutput<RequestQuery>>;
-        routerParams: StringsOnly<InferOutput<RequestParams>>;
       },
-      Res
+      Res,
+      TypedH3EventContext<
+        RequestParams extends StandardSchemaV1 ? { params: InferOutput<RequestParams> } : {}
+      >
     >;
   },
 ): EventHandlerWithFetch<TypedRequest<InferOutput<RequestBody>, InferOutput<RequestHeaders>>, Res> {
   if (!def.validate) {
-    return defineHandler(def) as any;
+    // context-typed handler narrows the event param (contravariant) — safe at runtime
+    return defineHandler(def as any) as any;
   }
   return defineHandler({
     ...def,

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export { definePlugin } from "./plugin.ts";
 
 // Event
 
-export type { H3EventContext } from "./types/context.ts";
+export type { H3EventContext, TypedH3EventContext } from "./types/context.ts";
 export { H3Event, type HTTPEvent } from "./event.ts";
 export { isEvent, isHTTPEvent, mockEvent, getEventContext } from "./utils/event.ts";
 

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -4,7 +4,7 @@ import type { RouteRules } from "./route-rules.ts";
 import type { ServerRequestContext } from "srvx";
 
 export interface H3EventContext extends ServerRequestContext {
-  /* Matched router parameters */
+  /* Matched router parameters (typed/coerced when validated) */
   params?: Record<string, string>;
 
   /* Matched middleware parameters */
@@ -36,3 +36,15 @@ export interface H3EventContext extends ServerRequestContext {
   /* Server-Timing entries collected via setServerTiming / withServerTiming */
   timing?: Array<{ name: string } & Record<string, unknown>>;
 }
+
+/**
+ * Typed view over {@link H3EventContext} with specific fields replaced.
+ *
+ * Overridden keys become required and fully typed (e.g. schema-coerced params in
+ * `defineValidatedHandler`); every other field — including `declare module`
+ * augmentations — keeps its base type. The mapped form (instead of `Omit`)
+ * preserves literal keys next to `ServerRequestContext`'s index signature.
+ */
+export type TypedH3EventContext<Overrides = {}> = {
+  [K in keyof H3EventContext as K extends keyof Overrides ? never : K]: H3EventContext[K];
+} & Overrides;

--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -1,6 +1,7 @@
-import type { ServerRequest } from "srvx";
+import type { ServerRequest, ServerRequestContext } from "srvx";
 import type { TypedRequest, TypedResponse, ResponseHeaderMap } from "fetchdts";
 import type { H3Event, HTTPEvent } from "../event.ts";
+import type { H3EventContext } from "./context.ts";
 import type { MaybePromise } from "./_utils.ts";
 import type { H3RouteMeta } from "./h3.ts";
 import type { H3Core } from "../h3.ts";
@@ -12,8 +13,9 @@ export type HTTPHandler = EventHandler | FetchableObject | H3Core;
 export interface EventHandler<
   _RequestT extends EventHandlerRequest = EventHandlerRequest,
   _ResponseT extends EventHandlerResponse = EventHandlerResponse,
+  _ContextT extends ServerRequestContext = H3EventContext,
 > {
-  (event: H3Event<_RequestT>): _ResponseT;
+  (event: H3Event<_RequestT, _ContextT>): _ResponseT;
   meta?: H3RouteMeta;
 }
 

--- a/src/utils/internal/promise.ts
+++ b/src/utils/internal/promise.ts
@@ -2,8 +2,12 @@
  * Continue with `fn` once `value` settles, staying synchronous when it already is.
  *
  * Avoids the `async`/`await` microtask tick on the common sync path while
- * collapsing the repeated `instanceof Promise` branch into one shared helper.
+ * collapsing the repeated thenable check into one shared helper. Duck-types
+ * `then` (instead of `instanceof Promise`) to support cross-realm promises
+ * and custom thenables.
  */
-export function chain<T, R>(value: T | Promise<T>, fn: (value: T) => R): R | Promise<R> {
-  return value instanceof Promise ? value.then(fn) : fn(value);
+export function chain<T, R>(value: T | PromiseLike<T>, fn: (value: T) => R): R | Promise<R> {
+  return typeof (value as PromiseLike<T>)?.then === "function"
+    ? ((value as PromiseLike<T>).then(fn) as Promise<R>)
+    : fn(value as T);
 }

--- a/src/utils/internal/promise.ts
+++ b/src/utils/internal/promise.ts
@@ -1,0 +1,9 @@
+/**
+ * Continue with `fn` once `value` settles, staying synchronous when it already is.
+ *
+ * Avoids the `async`/`await` microtask tick on the common sync path while
+ * collapsing the repeated `instanceof Promise` branch into one shared helper.
+ */
+export function chain<T, R>(value: T | Promise<T>, fn: (value: T) => R): R | Promise<R> {
+  return value instanceof Promise ? value.then(fn) : fn(value);
+}

--- a/src/utils/internal/validate.ts
+++ b/src/utils/internal/validate.ts
@@ -210,6 +210,7 @@ export function validatedParams(
     validate.onError,
   );
 
+  // Replace (not merge): schema output is the source of truth.
   const applyParams = (params: Record<string, string>): Record<string, string> => {
     event.context.params = params;
     return params;

--- a/src/utils/internal/validate.ts
+++ b/src/utils/internal/validate.ts
@@ -1,6 +1,9 @@
 import { type ErrorDetails, HTTPError } from "../../error.ts";
+import { chain } from "./promise.ts";
+import { getRouterParams } from "../request.ts";
 
 import type { ServerRequest } from "srvx";
+import type { H3Event } from "../../event.ts";
 import type {
   StandardSchemaV1,
   FailureResult,
@@ -105,7 +108,7 @@ export function validatedRequest<
       }
       return bodyProxy(req, validate);
     };
-    return validated instanceof Promise ? validated.then(applyHeaders) : applyHeaders(validated);
+    return chain(validated, applyHeaders);
   }
 
   return bodyProxy(req, validate);
@@ -185,10 +188,37 @@ export function validatedURL(
     return url;
   };
 
-  return validated instanceof Promise ? validated.then(applyQuery) : applyQuery(validated);
+  return chain(validated, applyQuery);
 }
 
-function validateSource<Source extends "headers" | "query", T = unknown>(
+export function validatedParams(
+  event: H3Event,
+  validate: {
+    params?: StandardSchemaV1;
+    decodeParams?: boolean;
+    onError?: OnValidateError;
+  },
+): Record<string, string> | undefined | Promise<Record<string, string>> {
+  if (!validate.params) {
+    return event.context.params;
+  }
+
+  const validated = validateSource(
+    "params",
+    getRouterParams(event, { decode: validate.decodeParams }),
+    validate.params as StandardSchemaV1<Record<string, string>>,
+    validate.onError,
+  );
+
+  const applyParams = (params: Record<string, string>): Record<string, string> => {
+    event.context.params = params;
+    return params;
+  };
+
+  return chain(validated, applyParams);
+}
+
+function validateSource<Source extends "headers" | "query" | "params", T = unknown>(
   source: Source,
   data: unknown,
   fn: StandardSchemaV1<T>,
@@ -206,8 +236,7 @@ function validateSource<Source extends "headers" | "query", T = unknown>(
     return result.value;
   };
 
-  const result = fn["~standard"].validate(data);
-  return result instanceof Promise ? result.then(finish) : finish(result);
+  return chain(fn["~standard"].validate(data), finish);
 }
 
 function createValidationError(cause: Error | HTTPError | ErrorDetails | FailureResult) {

--- a/src/utils/internal/validate.ts
+++ b/src/utils/internal/validate.ts
@@ -1,7 +1,13 @@
 import { type ErrorDetails, HTTPError } from "../../error.ts";
 
 import type { ServerRequest } from "srvx";
-import type { StandardSchemaV1, FailureResult, InferOutput, Issue } from "./standard-schema.ts";
+import type {
+  StandardSchemaV1,
+  FailureResult,
+  InferOutput,
+  Issue,
+  Result,
+} from "./standard-schema.ts";
 
 export type ValidateResult<T> = T | true | false | void;
 
@@ -75,7 +81,7 @@ export async function validateData<T>(
 // prettier-ignore
 const reqBodyKeys = /* @__PURE__ */ new Set(["body", "text", "formData", "arrayBuffer"]);
 
-export async function validatedRequest<
+export function validatedRequest<
   RequestBody extends StandardSchemaV1,
   RequestHeaders extends StandardSchemaV1,
 >(
@@ -85,20 +91,30 @@ export async function validatedRequest<
     headers?: RequestHeaders;
     onError?: OnValidateError;
   },
-): Promise<ServerRequest> {
-  // Validate Headers
+): ServerRequest | Promise<ServerRequest> {
   if (validate.headers) {
-    const validatedheaders = await validateSource(
+    const validated = validateSource(
       "headers",
       Object.fromEntries(req.headers.entries()),
       validate.headers as StandardSchemaV1<Record<string, string>>,
       validate.onError,
     );
-    for (const [key, value] of Object.entries(validatedheaders)) {
-      req.headers.set(key, value);
-    }
+    const applyHeaders = (headers: Record<string, string>): ServerRequest => {
+      for (const [key, value] of Object.entries(headers)) {
+        req.headers.set(key, value);
+      }
+      return bodyProxy(req, validate);
+    };
+    return validated instanceof Promise ? validated.then(applyHeaders) : applyHeaders(validated);
   }
 
+  return bodyProxy(req, validate);
+}
+
+function bodyProxy(
+  req: ServerRequest,
+  validate: { body?: StandardSchemaV1; onError?: OnValidateError },
+): ServerRequest {
   if (!validate.body) {
     return req;
   }
@@ -144,47 +160,54 @@ export async function validatedRequest<
   });
 }
 
-export async function validatedURL(
+export function validatedURL(
   url: URL,
   validate: {
     query?: StandardSchemaV1;
     onError?: OnValidateError;
   },
-): Promise<URL> {
+): URL | Promise<URL> {
   if (!validate.query) {
     return url;
   }
 
-  const validatedQuery = await validateSource(
+  const validated = validateSource(
     "query",
     Object.fromEntries(url.searchParams.entries()),
     validate.query as StandardSchemaV1<Record<string, string>>,
     validate.onError,
   );
 
-  for (const [key, value] of Object.entries(validatedQuery)) {
-    url.searchParams.set(key, value);
-  }
+  const applyQuery = (query: Record<string, string>): URL => {
+    for (const [key, value] of Object.entries(query)) {
+      url.searchParams.set(key, value);
+    }
+    return url;
+  };
 
-  return url;
+  return validated instanceof Promise ? validated.then(applyQuery) : applyQuery(validated);
 }
 
-async function validateSource<Source extends "headers" | "query", T = unknown>(
+function validateSource<Source extends "headers" | "query", T = unknown>(
   source: Source,
   data: unknown,
   fn: StandardSchemaV1<T>,
   onError?: OnValidateError,
-): Promise<T> {
-  const result = await fn["~standard"].validate(data);
-  if (result.issues) {
-    throw createValidationError(
-      onError?.({ _source: source, ...result }) || {
-        message: VALIDATION_FAILED,
-        issues: result.issues,
-      },
-    );
-  }
-  return result.value;
+): T | Promise<T> {
+  const finish = (result: Result<T>): T => {
+    if (result.issues) {
+      throw createValidationError(
+        onError?.({ _source: source, ...result }) || {
+          message: VALIDATION_FAILED,
+          issues: result.issues,
+        },
+      );
+    }
+    return result.value;
+  };
+
+  const result = fn["~standard"].validate(data);
+  return result instanceof Promise ? result.then(finish) : finish(result);
 }
 
 function createValidationError(cause: Error | HTTPError | ErrorDetails | FailureResult) {

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -179,10 +179,11 @@ export function getValidatedQuery(
  *   const params = getRouterParams(event); // { key: "value" }
  * });
  */
-export function getRouterParams(
-  event: HTTPEvent,
-  opts: { decode?: boolean } = {},
-): NonNullable<H3Event["context"]["params"]> {
+export function getRouterParams<
+  T,
+  Event extends H3Event | HTTPEvent = HTTPEvent,
+  _T = Exclude<InferEventInput<"routerParams", Event, T>, undefined>,
+>(event: Event, opts: { decode?: boolean } = {}): _T {
   // Fallback object needs to be returned in case router is not used (#149)
   const context = getEventContext<H3EventContext>(event);
   let params = (context.params || {}) as NonNullable<H3Event["context"]["params"]>;
@@ -192,7 +193,7 @@ export function getRouterParams(
       params[key] = decodeRouterParam(params[key]);
     }
   }
-  return params;
+  return params as _T;
 }
 
 // Percent-encoded path separators (`%2f` → `/`, `%5c` → `\`) at any `%25`-nesting

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -182,11 +182,16 @@ export function getValidatedQuery(
 export function getRouterParams<
   T,
   Event extends H3Event | HTTPEvent = HTTPEvent,
-  _T = Exclude<InferEventInput<"routerParams", Event, T>, undefined>,
+  // Explicit `T` wins (mirroring `getQuery`), otherwise infer from the event's context type
+  _T = void extends T
+    ? Event extends { context: { params?: infer P } }
+      ? NonNullable<P>
+      : Record<string, string>
+    : T,
 >(event: Event, opts: { decode?: boolean } = {}): _T {
   // Fallback object needs to be returned in case router is not used (#149)
   const context = getEventContext<H3EventContext>(event);
-  let params = (context.params || {}) as NonNullable<H3Event["context"]["params"]>;
+  let params = (context.params || {}) as Record<string, string>;
   if (opts.decode) {
     params = { ...params };
     for (const key in params) {
@@ -335,13 +340,13 @@ export function getValidatedRouterParams(
  *   const param = getRouterParam(event, "key");
  * });
  */
-export function getRouterParam(
-  event: HTTPEvent,
-  name: string,
-  opts: { decode?: boolean } = {},
-): string | undefined {
+export function getRouterParam<
+  Event extends H3Event | HTTPEvent = HTTPEvent,
+  _P = Event extends { context: { params?: infer P } } ? NonNullable<P> : Record<string, string>,
+  Name extends keyof _P & string = keyof _P & string,
+>(event: Event, name: Name, opts: { decode?: boolean } = {}): _P[Name] | undefined {
   const params = getRouterParams(event, opts);
-  return params[name];
+  return (params as _P)[name];
 }
 
 /**

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -190,7 +190,10 @@ export function getRouterParams<
   if (opts.decode) {
     params = { ...params };
     for (const key in params) {
-      params[key] = decodeRouterParam(params[key]);
+      // Validated params hold schema output, which may be non-string (coerced)
+      if (typeof params[key] === "string") {
+        params[key] = decodeRouterParam(params[key]);
+      }
     }
   }
   return params as _T;

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -449,6 +449,34 @@ describe("handler.ts", () => {
         });
       });
 
+      // The schema output replaces `context.params` entirely: params it strips
+      // are intentionally dropped so non-validated data never leaks through.
+      it("drops router params stripped by the schema", async () => {
+        const partialHandler = defineValidatedHandler({
+          validate: {
+            params: z.object({ id: z.string().min(3) }),
+          },
+          handler: (event) => getRouterParams(event),
+        });
+        const app = mount("/users/:id/posts/:postId", partialHandler);
+        const res = await app.request("/users/123/posts/456");
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ id: "123" });
+      });
+
+      it("keeps extra router params with a loose schema", async () => {
+        const looseHandler = defineValidatedHandler({
+          validate: {
+            params: z.looseObject({ id: z.string().min(3) }),
+          },
+          handler: (event) => getRouterParams(event),
+        });
+        const app = mount("/users/:id/posts/:postId", looseHandler);
+        const res = await app.request("/users/123/posts/456");
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ id: "123", postId: "456" });
+      });
+
       describe("decode", () => {
         const decodeHandler = defineValidatedHandler({
           validate: {

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -6,6 +6,7 @@ import {
   defineLazyEventHandler,
   defineValidatedHandler,
   getRouterParams,
+  getRouterParam,
   H3,
 } from "../src/index.ts";
 import type { ValidateIssues } from "../src/utils/internal/validate.ts";
@@ -475,6 +476,26 @@ describe("handler.ts", () => {
         const res = await app.request("/users/123/posts/456");
         expect(res.status).toBe(200);
         expect(await res.json()).toEqual({ id: "123", postId: "456" });
+      });
+
+      it("coerces params at runtime; every getter returns the coerced value", async () => {
+        const coerceHandler = defineValidatedHandler({
+          validate: { params: z.object({ id: z.coerce.number() }) },
+          handler: (event) => ({
+            viaParams: typeof getRouterParams(event).id,
+            viaParam: typeof getRouterParam(event, "id"),
+            viaContext: typeof event.context.params?.id,
+            value: getRouterParams(event).id,
+          }),
+        });
+        const res = await mount("/n/:id", coerceHandler).request("/n/42");
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({
+          viaParams: "number",
+          viaParam: "number",
+          viaContext: "number",
+          value: 42,
+        });
       });
 
       describe("decode", () => {

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -502,6 +502,19 @@ describe("handler.ts", () => {
           const res = await app.request("/files/foo%40bar");
           expect(res.status).toBe(400);
         });
+
+        // Regression: after a coercing schema, `context.params` may hold
+        // non-strings — caller-side decode must skip them, not crash.
+        it("decode:true after coercion skips non-string values", async () => {
+          const coerceHandler = defineValidatedHandler({
+            validate: { params: z.object({ id: z.coerce.number() }) },
+            handler: (event) => getRouterParams(event, { decode: true }),
+          });
+          const app = mount("/n/:id", coerceHandler);
+          const res = await app.request("/n/42");
+          expect(res.status).toBe(200);
+          expect(await res.json()).toEqual({ id: 42 });
+        });
       });
 
       describe("async", () => {

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -374,6 +374,47 @@ describe("handler.ts", () => {
         });
       });
     });
+
+    // Regression: async header validation must short-circuit query validation.
+    // A racing `Promise.all` would run the query schema even when headers
+    // already failed, and let its error win nondeterministically.
+    describe("async validation ordering", () => {
+      const querySpy = vi.fn(async (id: string) => id.length >= 3);
+      const orderingHandler = defineValidatedHandler({
+        validate: {
+          body: z.object({ name: z.string() }),
+          headers: z.object({
+            "x-token": z.string().refine(async (token) => token.length >= 3, "Token too short"),
+          }),
+          query: z.object({
+            id: z.string().refine(querySpy, "Id too short"),
+          }),
+        },
+        handler: async () => "ok",
+      });
+
+      it("runs query validation once headers pass", async () => {
+        querySpy.mockClear();
+        const res = await orderingHandler.fetch(
+          toRequest("/?id=123", { headers: { "x-token": "abc" } }),
+        );
+        expect(res.status).toBe(200);
+        expect(querySpy).toHaveBeenCalled();
+      });
+
+      it("skips query validation and reports the headers error when headers fail", async () => {
+        querySpy.mockClear();
+        const res = await orderingHandler.fetch(
+          // query would also be invalid, yet the headers error must surface
+          toRequest("/?id=1", { headers: { "x-token": "ab" } }),
+        );
+        expect(res.status).toBe(400);
+        expect(await res.json()).toMatchObject({
+          data: { issues: [{ path: ["x-token"], message: "Token too short" }] },
+        });
+        expect(querySpy).not.toHaveBeenCalled();
+      });
+    });
   });
 });
 

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -5,6 +5,8 @@ import {
   dynamicEventHandler,
   defineLazyEventHandler,
   defineValidatedHandler,
+  getRouterParams,
+  H3,
 } from "../src/index.ts";
 import type { ValidateIssues } from "../src/utils/internal/validate.ts";
 
@@ -413,6 +415,102 @@ describe("handler.ts", () => {
           data: { issues: [{ path: ["x-token"], message: "Token too short" }] },
         });
         expect(querySpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("params validation", () => {
+      // `defineValidatedHandler`'s TypedRequest return type isn't assignable to `app.get` (pre-exisitng)
+      const mount = (route: string, handler: unknown) => new H3().get(route, handler as any);
+
+      const paramsHandler = defineValidatedHandler({
+        validate: {
+          params: z.object({
+            id: z.string().min(3),
+            role: z.string().default("user"),
+          }),
+        },
+        handler: (event) => getRouterParams(event),
+      });
+
+      it("valid params, validated output written back to context", async () => {
+        const app = mount("/users/:id", paramsHandler);
+        const res = await app.request("/users/123");
+        expect(res.status).toBe(200);
+        // the `role` default proves the validated output lands in context.params
+        expect(await res.json()).toMatchObject({ id: "123", role: "user" });
+      });
+
+      it("invalid params", async () => {
+        const app = mount("/users/:id", paramsHandler);
+        const res = await app.request("/users/1");
+        expect(res.status).toBe(400);
+        expect(await res.json()).toMatchObject({
+          data: { issues: [{ path: ["id"] }] },
+        });
+      });
+
+      describe("decode", () => {
+        const decodeHandler = defineValidatedHandler({
+          validate: {
+            params: z.object({ name: z.literal("foo@bar") }),
+            decodeParams: true,
+          },
+          handler: (event) => getRouterParams(event),
+        });
+        const noDecodeHandler = defineValidatedHandler({
+          validate: { params: z.object({ name: z.literal("foo@bar") }) },
+          handler: (event) => getRouterParams(event),
+        });
+
+        it("decodes params before validation when decode:true", async () => {
+          const app = mount("/files/:name", decodeHandler);
+          const res = await app.request("/files/foo%40bar");
+          expect(res.status).toBe(200);
+          expect(await res.json()).toMatchObject({ name: "foo@bar" });
+        });
+
+        it("leaves params encoded by default", async () => {
+          const app = mount("/files/:name", noDecodeHandler);
+          const res = await app.request("/files/foo%40bar");
+          expect(res.status).toBe(400);
+        });
+      });
+
+      describe("async", () => {
+        const headerSpy = vi.fn(async (token: string) => token.length >= 3);
+        const asyncParamsHandler = defineValidatedHandler({
+          validate: {
+            params: z.object({
+              id: z.string().refine(async (id) => id.length >= 3, "Id too short"),
+            }),
+            headers: z.object({
+              "x-token": z.string().refine(headerSpy, "Token too short"),
+            }),
+          },
+          handler: async () => "ok",
+        });
+
+        it("validates async params", async () => {
+          headerSpy.mockClear();
+          const app = mount("/users/:id", asyncParamsHandler);
+          const res = await app.request("/users/1", { headers: { "x-token": "abc" } });
+          expect(res.status).toBe(400);
+          expect(await res.json()).toMatchObject({
+            data: { issues: [{ path: ["id"], message: "Id too short" }] },
+          });
+        });
+
+        it("short-circuits header validation when params fail", async () => {
+          headerSpy.mockClear();
+          const app = mount("/users/:id", asyncParamsHandler);
+          // header would also be invalid, yet params validation runs first
+          const res = await app.request("/users/1", { headers: { "x-token": "ab" } });
+          expect(res.status).toBe(400);
+          expect(await res.json()).toMatchObject({
+            data: { issues: [{ path: ["id"], message: "Id too short" }] },
+          });
+          expect(headerSpy).not.toHaveBeenCalled();
+        });
       });
     });
   });

--- a/test/unit/types.test-d.ts
+++ b/test/unit/types.test-d.ts
@@ -1,9 +1,16 @@
-import type { H3Event, RouteRules, WebSocketResponse } from "../../src/index.ts";
+import type {
+  H3Event,
+  H3EventContext,
+  EventHandlerRequest,
+  RouteRules,
+  WebSocketResponse,
+} from "../../src/index.ts";
 import { describe, it, expectTypeOf } from "vitest";
 import {
   defineHandler,
   getQuery,
   getRouterParams,
+  getRouterParam,
   readBody,
   readValidatedBody,
   getValidatedQuery,
@@ -78,6 +85,7 @@ describe("types", () => {
           }),
           params: z.object({
             userId: z.string(),
+            n: z.coerce.number(),
           }),
         },
         async handler(event) {
@@ -85,10 +93,21 @@ describe("types", () => {
           expectTypeOf(query.search).not.toBeAny();
           expectTypeOf(query.search).toEqualTypeOf<string | undefined>();
 
-          // params are string-typed, mirroring query (coercion deferred)
+          // params carry the FULL coerced schema output (core-typed, not StringsOnly)
           const params = getRouterParams(event);
           expectTypeOf(params).not.toBeAny();
-          expectTypeOf(params).toEqualTypeOf<{ userId: string }>();
+          expectTypeOf(params).toEqualTypeOf<{ userId: string; n: number }>();
+
+          // direct context access is coerced AND required: validation guarantees
+          // `context.params` is set before the handler runs, so no `?.` needed
+          expectTypeOf(event.context.params).toEqualTypeOf<{ userId: string; n: number }>();
+
+          // non-overridden context fields keep their base types
+          expectTypeOf(event.context.clientAddress).toEqualTypeOf<string | undefined>();
+
+          // singular helper is coerced and key-checked
+          expectTypeOf(getRouterParam(event, "n")).toEqualTypeOf<number | undefined>();
+          expectTypeOf(getRouterParam(event, "userId")).toEqualTypeOf<string | undefined>();
 
           // TODO:
           // type PossibleParams = Parameters<typeof event.url.searchParams.get>[0]
@@ -100,6 +119,39 @@ describe("types", () => {
           const body = await readBody(event);
           expectTypeOf(body).not.toBeAny();
           expectTypeOf(body).toEqualTypeOf<{ id: string } | undefined>();
+        },
+      });
+    });
+
+    it("non-validated handler keeps Record<string, string> defaults", () => {
+      defineHandler((event) => {
+        expectTypeOf(getRouterParams(event)).toEqualTypeOf<Record<string, string>>();
+        expectTypeOf(getRouterParam(event, "x")).toEqualTypeOf<string | undefined>();
+        // explicit generic override wins, mirroring getQuery
+        expectTypeOf(getRouterParams<{ custom: string }>(event)).toEqualTypeOf<{
+          custom: string;
+        }>();
+      });
+    });
+
+    it("H3Event's second generic types the whole context (no `declare module` needed)", () => {
+      type MyContext = H3EventContext & { user: { id: number } };
+      const event = {} as H3Event<EventHandlerRequest, MyContext>;
+      expectTypeOf(event.context.user).toEqualTypeOf<{ id: number }>();
+      // built-in context fields still typed as before
+      expectTypeOf(event.context.params).toEqualTypeOf<Record<string, string> | undefined>();
+    });
+
+    it("`declare module` augmentation reaches plain and validated contexts", () => {
+      defineHandler((event) => {
+        expectTypeOf(event.context.augmentedUser).toEqualTypeOf<{ id: number } | undefined>();
+      });
+      defineValidatedHandler({
+        validate: { params: z.object({ id: z.string() }) },
+        // TypedH3EventContext is a mapped view — augmented fields must pass through
+        handler: (event) => {
+          expectTypeOf(event.context.augmentedUser).toEqualTypeOf<{ id: number } | undefined>();
+          expectTypeOf(event.context.params).toEqualTypeOf<{ id: string }>();
         },
       });
     });
@@ -215,6 +267,10 @@ describe("types", () => {
 declare module "../../src/index.ts" {
   interface RouteRules {
     swr?: number | boolean;
+  }
+  // Ecosystem invariant (nitro/nuxt-style): H3EventContext must stay augmentable.
+  interface H3EventContext {
+    augmentedUser?: { id: number };
   }
 }
 

--- a/test/unit/types.test-d.ts
+++ b/test/unit/types.test-d.ts
@@ -3,6 +3,7 @@ import { describe, it, expectTypeOf } from "vitest";
 import {
   defineHandler,
   getQuery,
+  getRouterParams,
   readBody,
   readValidatedBody,
   getValidatedQuery,
@@ -75,11 +76,19 @@ describe("types", () => {
           query: z.object({
             search: z.string().optional(),
           }),
+          params: z.object({
+            userId: z.string(),
+          }),
         },
         async handler(event) {
           const query = getQuery(event);
           expectTypeOf(query.search).not.toBeAny();
           expectTypeOf(query.search).toEqualTypeOf<string | undefined>();
+
+          // params are string-typed, mirroring query (coercion deferred)
+          const params = getRouterParams(event);
+          expectTypeOf(params).not.toBeAny();
+          expectTypeOf(params).toEqualTypeOf<{ userId: string }>();
 
           // TODO:
           // type PossibleParams = Parameters<typeof event.url.searchParams.get>[0]


### PR DESCRIPTION
Draft based on exploration of #1501 (includes those commits, as I still have to git good). Also proposed in https://github.com/h3js/h3/issues/1437#issuecomment-5025050049

Commit ad5fcba essentially adds a second param to H3Event that consists in a typed H3EventContext, as well as adds a type argument to the latter for customizing internals.

One such use case is properly typing `params` in something like `defineValidatedHandler`, which might have also coerced its data (eg: an id being number instead) keeping the parity between runtime and types.

This also adds room of improvements for other validated data for `defineValidatedHandler` such as headers and queries which they currently simply gets mutaded in place, going back to their string form instead. A clear followup for this would be to introduce also `event.context.{headers,query}` with the coerced data and type output of the validation schemas (also reducing the number of operations performed by the forward and back mutation).

Leaving as draft till #1501 is merged and this concept is approved, @pi0 no further work is needed in this PR other than your own changes or if you want me to also add the `event.context.{headers,query}` logic or defer to next PR