### PR TITLE
fix(response): route synchronous prepareResponse throws through the error pipeline

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -139,7 +139,8 @@ function prepareResponse(
     const { onError } = config;
     const errHeaders: Headers | undefined = (event as any)[kEventRes]?.[kEventResErrHeaders];
     return onError && !nested
-      ? Promise.resolve(onError(error, event))
+      ? Promise.resolve()
+          .then(() => onError(error, event))
           .catch((error) => error)
           .then((newVal) => prepareResponse(newVal ?? val, event, config, true))
       : errorResponse(error, config.debug, errHeaders);

--- a/src/response.ts
+++ b/src/response.ts
@@ -25,9 +25,6 @@ export function toResponse(
   try {
     response = prepareResponse(val, event, config);
   } catch (error) {
-    // A synchronous throw while preparing the response (e.g. `JSON.stringify` on a
-    // circular value) must not escape as a raw exception/rejection: route it through
-    // the same error pipeline as a thrown/rejected handler value (onError, logging).
     return toResponse(toError(error), event, config);
   }
   if (typeof (response as PromiseLike<Response>)?.then === "function") {

--- a/src/response.ts
+++ b/src/response.ts
@@ -21,7 +21,15 @@ export function toResponse(
     ) as Promise<Response>;
   }
 
-  const response = prepareResponse(val, event, config);
+  let response: Response | Promise<Response>;
+  try {
+    response = prepareResponse(val, event, config);
+  } catch (error) {
+    // A synchronous throw while preparing the response (e.g. `JSON.stringify` on a
+    // circular value) must not escape as a raw exception/rejection: route it through
+    // the same error pipeline as a thrown/rejected handler value (onError, logging).
+    return toResponse(toError(error), event, config);
+  }
   if (typeof (response as PromiseLike<Response>)?.then === "function") {
     return toResponse(response, event, config);
   }

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -18,7 +18,7 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log(`Bundle size (H3): ${bundle.bytes} (gzip: ${bundle.gzipSize})`);
     }
-    expect(bundle.bytes).toBeLessThanOrEqual(18_400); // <18.4kb
+    expect(bundle.bytes).toBeLessThanOrEqual(18_420); // <18.42kb
     expect(bundle.gzipSize).toBeLessThanOrEqual(6_950); // <6.95kb
   });
 

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -34,8 +34,8 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log(`Bundle size (H3Core): ${bundle.bytes} (gzip: ${bundle.gzipSize})`);
     }
-    expect(bundle.bytes).toBeLessThanOrEqual(7600); // <7.6kb
-    expect(bundle.gzipSize).toBeLessThanOrEqual(3000); // <3kb
+    expect(bundle.bytes).toBeLessThanOrEqual(7630); // <7.63kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(3020); // <3.02kb
   });
 
   it("bundle size (defineHandler)", async () => {
@@ -50,7 +50,7 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log(`Bundle size (defineHandler): ${bundle.bytes} (gzip: ${bundle.gzipSize})`);
     }
-    expect(bundle.bytes).toBeLessThanOrEqual(6700); // <6.7kb
+    expect(bundle.bytes).toBeLessThanOrEqual(6750); // <6.75kb
     expect(bundle.gzipSize).toBeLessThanOrEqual(2700); // <2.7kb
   });
 });

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -324,4 +324,23 @@ describeMatrix("errors", (t, { it, expect, describe }) => {
       expect(res.status).toBe(500);
     });
   });
+
+  // Regression for #1503 (CodeRabbit): a synchronously-throwing `onError` hook must not
+  // recurse infinitely. `Promise.resolve(onError(error, event))` evaluates the call before
+  // wrapping it in a promise, so a sync throw there escaped `prepareResponse()` synchronously.
+  // That was caught by `toResponse()`'s try/catch (added for #1477) and re-entered
+  // `toResponse` with `nested` reset to `false` — calling the same throwing `onError` again,
+  // forever (stack overflow instead of a normalized 500).
+  it("a synchronously-throwing onError does not recurse infinitely", async () => {
+    t.app.config.onError = () => {
+      throw new Error("onError boom");
+    };
+    t.app.use(() => {
+      throw new Error("handler boom");
+    });
+
+    const res = await t.fetch("/");
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({ status: 500, unhandled: true });
+  });
 });

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -291,4 +291,37 @@ describeMatrix("errors", (t, { it, expect, describe }) => {
       expect(error.cause).toMatchObject({ secret: "db-password" });
     });
   });
+
+  // Regression for #1477: a synchronous throw while preparing the response (circular
+  // `JSON.stringify`) must be routed through the same 500 pipeline as any other error,
+  // not escape `fetch()` as a raw exception/rejection.
+  describe("response preparation throws", () => {
+    it("circular return value is rendered as a 500 instead of escaping fetch()", async () => {
+      t.app.use(() => {
+        const circular: any = {};
+        circular.self = circular;
+        return circular;
+      });
+
+      const res = await t.fetch("/");
+      expect(res.status).toBe(500);
+      expect(await res.json()).toMatchObject({ status: 500, unhandled: true });
+      t.errors = [];
+    });
+
+    it("thrown HTTPError with circular data is rendered as a 500 instead of escaping fetch() (no onError)", async () => {
+      // With no `onError` configured, `errorResponse()`'s `JSON.stringify` runs
+      // synchronously in the same pass as the throw (the async/onError branch is not
+      // taken), so this exercises the raw synchronous-escape path directly.
+      t.app.config.onError = undefined;
+      t.app.use(() => {
+        const data: any = {};
+        data.self = data;
+        throw new HTTPError({ status: 400, data });
+      });
+
+      const res = await t.fetch("/");
+      expect(res.status).toBe(500);
+    });
+  });
 });

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -98,4 +98,31 @@ describeMatrix("hooks", (t, { it, expect }) => {
 
     expect(t.hooks.onResponse).toHaveBeenCalledTimes(1);
   });
+
+  it("calls onRequest, onError and onResponse when a circular value is returned", async () => {
+    t.app.use(() => {
+      const circular: any = {};
+      circular.self = circular;
+      return circular;
+    });
+
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await t.fetch("/foo");
+
+    const errors = t.errors;
+    t.errors = [];
+
+    // The synchronous `JSON.stringify` throw is routed through the error pipeline
+    // instead of escaping `fetch()` as a raw exception/rejection.
+    expect(res.status).toBe(500);
+
+    expect(errors.length).toBe(1);
+    expect(errors[0].status).toBe(500);
+    expect(errors[0].cause).toBeInstanceOf(TypeError);
+
+    expect(t.hooks.onRequest).toHaveBeenCalledTimes(1);
+    expect(t.hooks.onError).toHaveBeenCalledTimes(1);
+    expect(t.hooks.onError.mock.calls[0]![0]!.cause).toBeInstanceOf(TypeError);
+    expect(t.hooks.onResponse).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
Part of #1477 (1 of 2 — split per @pi0's request; companion Uint8Array fix in https://github.com/h3js/h3/pull/1504).

Wraps the `prepareResponse` call in `toResponse` so a **synchronous throw during response preparation** — e.g. `JSON.stringify` on a circular return value, or circular `error.data` inside `errorResponse` — is routed through the normal error pipeline (`toError` → `errorResponse`) instead of escaping as a raw exception/rejection. `onError` / `onResponse` and logging now run, and a `500` is returned. A non-`Error` throw is handled the same way.

```ts
app.get("/circular", () => { const a: any = {}; a.self = a; return a; });
// before: app.fetch() rejects with a raw TypeError, hooks never run
// after:  toError() → errorResponse → 500, onError/onResponse fire
```

Tests (inside `describeMatrix`, via `t.app` / `t.fetch` per the coding guidelines): a circular return value and a thrown `HTTPError` with circular `data` both render as `500` without escaping, and the hook pipeline still fires. `pnpm test` (lint + format + typecheck + full vitest) is green.

Drafted with AI assistance; reviewed and verified against the test suite by me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when response preparation fails, including circular data and HTTP errors.
  * Synchronously throwing error hooks are now handled safely without escaping or causing recursion.
  * Requests now consistently return a normalized 500 error response when unrecoverable errors occur.
  * Ensured request, error, and response hooks are invoked correctly during failure scenarios.

* **Tests**
  * Added regression coverage for response preparation and hook error handling.
  * Updated bundle-size benchmark thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->