### PR TITLE
feat(static): support HTTP Range requests in serveStatic

### DIFF
--- a/src/utils/static.ts
+++ b/src/utils/static.ts
@@ -194,19 +194,118 @@ export async function serveStatic(
     event.res.headers.set("content-encoding", meta.encoding);
   }
 
-  if (meta.size !== undefined && meta.size > 0 && !event.res.headers.get("content-length")) {
-    event.res.headers.set("content-length", meta.size + "");
+  // Range requests need a known, whole-asset size to validate/compute against.
+  let range: { start: number; end: number } | undefined;
+  const size = meta.size !== undefined && meta.size > 0 ? meta.size : undefined;
+  if (size !== undefined) {
+    event.res.headers.set("accept-ranges", "bytes");
+    const rangeHeader = event.req.headers.get("range");
+    if (rangeHeader) {
+      const parsed = parseRange(rangeHeader, size);
+      if (parsed === "unsatisfiable") {
+        return new HTTPResponse(null, {
+          status: 416,
+          headers: { "content-range": `bytes */${size}`, "content-length": "0" },
+        });
+      }
+      range = parsed;
+    }
+  }
+
+  if (range) {
+    event.res.headers.set("content-range", `bytes ${range.start}-${range.end}/${size}`);
+    event.res.headers.set("content-length", range.end - range.start + 1 + "");
+  } else if (size !== undefined && !event.res.headers.get("content-length")) {
+    event.res.headers.set("content-length", size + "");
   }
 
   if (event.req.method === "HEAD") {
-    return new HTTPResponse(null, { status: 200 });
+    return new HTTPResponse(null, { status: range ? 206 : 200 });
   }
 
   const contents = await options.getContents(id);
+  if (range) {
+    const sliced = sliceBody(contents, range.start, range.end);
+    if (sliced !== undefined) {
+      return new HTTPResponse(sliced, { status: 206 });
+    }
+    // Content isn't sliceable (e.g. a stream): fall back to a full response.
+    event.res.headers.delete("content-range");
+    event.res.headers.set("content-length", size + "");
+  }
   return new HTTPResponse(contents || null, { status: 200 });
 }
 
 // --- Internal Utils ---
+
+/**
+ * Parse a `range` request header against a known resource size.
+ *
+ * Only a single `bytes=<start>-<end>` range is supported (per the spec, a
+ * multi-range request is one that a server may satisfy by ignoring the header
+ * and returning the full entity instead) — malformed or multi-range headers
+ * return `undefined` so the caller serves the full response. A range that is
+ * out of bounds (start beyond the resource size, or an empty suffix range)
+ * returns `"unsatisfiable"` so the caller can respond with `416`.
+ */
+function parseRange(
+  header: string,
+  size: number,
+): { start: number; end: number } | "unsatisfiable" | undefined {
+  const match = /^bytes=(\d+)?-(\d+)?$/.exec(header.trim());
+  if (!match) {
+    return undefined; // Malformed or multi-range: ignore, serve full response
+  }
+  const [, startStr, endStr] = match;
+  if (startStr === undefined && endStr === undefined) {
+    return undefined;
+  }
+
+  let start: number;
+  let end: number;
+  if (startStr === undefined) {
+    // Suffix range: last `endStr` bytes
+    const suffixLength = Number(endStr);
+    if (suffixLength === 0) {
+      return "unsatisfiable";
+    }
+    start = Math.max(0, size - suffixLength);
+    end = size - 1;
+  } else {
+    start = Number(startStr);
+    end = endStr === undefined ? size - 1 : Number(endStr);
+  }
+
+  if (start > end || start >= size) {
+    return "unsatisfiable";
+  }
+  return { start, end: Math.min(end, size - 1) };
+}
+
+/**
+ * Slice a `BodyInit` to the given inclusive byte range. Returns `undefined`
+ * when the content type can't be sliced without fully buffering it (e.g. a
+ * `ReadableStream`), letting the caller fall back to a full response.
+ */
+function sliceBody(
+  contents: BodyInit | null | undefined,
+  start: number,
+  end: number,
+): BodyInit | undefined {
+  if (typeof contents === "string") {
+    return new TextEncoder().encode(contents).slice(start, end + 1);
+  }
+  if (contents instanceof Blob) {
+    return contents.slice(start, end + 1);
+  }
+  if (contents instanceof ArrayBuffer) {
+    return contents.slice(start, end + 1);
+  }
+  if (contents instanceof Uint8Array) {
+    return contents.slice(start, end + 1);
+  }
+  return undefined;
+}
 
 function parseAcceptEncoding(header?: string, encodingMap?: Record<string, string>): string[] {
   if (!encodingMap || !header) {

--- a/test/static.test.ts
+++ b/test/static.test.ts
@@ -401,6 +401,179 @@ describeMatrix("serve static MIME types", (t, { it, expect }) => {
   });
 });
 
+describeMatrix("serve static range requests", (t, { it, expect }) => {
+  const content = "0123456789"; // 10 bytes
+
+  beforeEach(() => {
+    const options: ServeStaticOptions = {
+      getContents: vi.fn(() => content),
+      getMeta: vi.fn(() => ({ type: "text/plain", size: content.length })),
+    };
+    t.app.all("/**", (event) => serveStatic(event, options));
+  });
+
+  it("advertises accept-ranges when size is known, even without a Range header", async () => {
+    const res = await t.fetch("/file.txt");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("accept-ranges")).toBe("bytes");
+    expect(await res.text()).toBe(content);
+  });
+
+  it("serves a partial response for a start-end range (GET)", async () => {
+    const res = await t.fetch("/file.txt", { headers: { range: "bytes=2-5" } });
+    expect(res.status).toBe(206);
+    expect(res.headers.get("content-range")).toBe("bytes 2-5/10");
+    expect(res.headers.get("content-length")).toBe("4");
+    expect(await res.text()).toBe("2345");
+  });
+
+  it("serves headers only (no body) for a valid range on HEAD", async () => {
+    const res = await t.fetch("/file.txt", {
+      method: "HEAD",
+      headers: { range: "bytes=2-5" },
+    });
+    expect(res.status).toBe(206);
+    expect(res.headers.get("content-range")).toBe("bytes 2-5/10");
+    expect(res.headers.get("content-length")).toBe("4");
+    expect(await res.text()).toBe("");
+  });
+
+  it("serves an open-ended range (bytes=N-)", async () => {
+    const res = await t.fetch("/file.txt", { headers: { range: "bytes=7-" } });
+    expect(res.status).toBe(206);
+    expect(res.headers.get("content-range")).toBe("bytes 7-9/10");
+    expect(await res.text()).toBe("789");
+  });
+
+  it("serves a suffix range (bytes=-N)", async () => {
+    const res = await t.fetch("/file.txt", { headers: { range: "bytes=-3" } });
+    expect(res.status).toBe(206);
+    expect(res.headers.get("content-range")).toBe("bytes 7-9/10");
+    expect(await res.text()).toBe("789");
+  });
+
+  it("clamps a suffix range larger than the resource to the full body", async () => {
+    const res = await t.fetch("/file.txt", { headers: { range: "bytes=-1000" } });
+    expect(res.status).toBe(206);
+    expect(res.headers.get("content-range")).toBe("bytes 0-9/10");
+    expect(await res.text()).toBe(content);
+  });
+
+  it("clamps an end beyond the resource size", async () => {
+    const res = await t.fetch("/file.txt", { headers: { range: "bytes=5-1000" } });
+    expect(res.status).toBe(206);
+    expect(res.headers.get("content-range")).toBe("bytes 5-9/10");
+    expect(await res.text()).toBe("56789");
+  });
+
+  it("returns 416 when the start is beyond the resource size", async () => {
+    const res = await t.fetch("/file.txt", { headers: { range: "bytes=100-200" } });
+    expect(res.status).toBe(416);
+    expect(res.headers.get("content-range")).toBe("bytes */10");
+    expect(res.headers.get("content-length")).toBe("0");
+  });
+
+  it("returns 416 for a zero-length suffix range (bytes=-0)", async () => {
+    const res = await t.fetch("/file.txt", { headers: { range: "bytes=-0" } });
+    expect(res.status).toBe(416);
+    expect(res.headers.get("content-range")).toBe("bytes */10");
+  });
+
+  it("returns 416 when start is after end", async () => {
+    const res = await t.fetch("/file.txt", { headers: { range: "bytes=5-2" } });
+    expect(res.status).toBe(416);
+  });
+
+  it("ignores a malformed range header and serves the full response", async () => {
+    const res = await t.fetch("/file.txt", { headers: { range: "not-a-range" } });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-range")).toBeNull();
+    expect(await res.text()).toBe(content);
+  });
+
+  it("ignores a multi-range header and serves the full response", async () => {
+    const res = await t.fetch("/file.txt", { headers: { range: "bytes=0-1,3-4" } });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-range")).toBeNull();
+    expect(await res.text()).toBe(content);
+  });
+
+  it("does not advertise accept-ranges or honor Range when size is unknown", async () => {
+    const options: ServeStaticOptions = {
+      getContents: vi.fn(() => content),
+      getMeta: vi.fn(() => ({ type: "text/plain" })),
+    };
+    t.app.all("/nosize/**", (event) => serveStatic(event, options));
+
+    const res = await t.fetch("/nosize/file.txt", { headers: { range: "bytes=2-5" } });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("accept-ranges")).toBeNull();
+    expect(res.headers.get("content-range")).toBeNull();
+    expect(await res.text()).toBe(content);
+  });
+
+  it("slices a Uint8Array response for a range", async () => {
+    const options: ServeStaticOptions = {
+      getContents: vi.fn(() => new TextEncoder().encode(content)),
+      getMeta: vi.fn(() => ({ type: "text/plain", size: content.length })),
+    };
+    t.app.all("/u8/**", (event) => serveStatic(event, options));
+
+    const res = await t.fetch("/u8/file.txt", { headers: { range: "bytes=2-5" } });
+    expect(res.status).toBe(206);
+    expect(res.headers.get("content-range")).toBe("bytes 2-5/10");
+    expect(await res.text()).toBe("2345");
+  });
+
+  it("slices an ArrayBuffer response for a range", async () => {
+    const options: ServeStaticOptions = {
+      getContents: vi.fn(() => new TextEncoder().encode(content).buffer),
+      getMeta: vi.fn(() => ({ type: "text/plain", size: content.length })),
+    };
+    t.app.all("/ab/**", (event) => serveStatic(event, options));
+
+    const res = await t.fetch("/ab/file.txt", { headers: { range: "bytes=2-5" } });
+    expect(res.status).toBe(206);
+    expect(res.headers.get("content-range")).toBe("bytes 2-5/10");
+    expect(await res.text()).toBe("2345");
+  });
+
+  it("slices a Blob response for a range", async () => {
+    const options: ServeStaticOptions = {
+      getContents: vi.fn(() => new Blob([content])),
+      getMeta: vi.fn(() => ({ type: "text/plain", size: content.length })),
+    };
+    t.app.all("/blob/**", (event) => serveStatic(event, options));
+
+    const res = await t.fetch("/blob/file.txt", { headers: { range: "bytes=2-5" } });
+    expect(res.status).toBe(206);
+    expect(res.headers.get("content-range")).toBe("bytes 2-5/10");
+    expect(await res.text()).toBe("2345");
+  });
+
+  it("falls back to a full response when content isn't sliceable (e.g. a stream)", async () => {
+    const options: ServeStaticOptions = {
+      getContents: vi.fn(
+        () =>
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode(content));
+              controller.close();
+            },
+          }),
+      ),
+      getMeta: vi.fn(() => ({ type: "text/plain", size: content.length })),
+    };
+    t.app.all("/stream/**", (event) => serveStatic(event, options));
+
+    const res = await t.fetch("/stream/file.txt", { headers: { range: "bytes=2-5" } });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-range")).toBeNull();
+    expect(res.headers.get("content-length")).toBe("10");
+    expect(await res.text()).toBe(content);
+  });
+});
+
 describe("serve static (malformed url)", () => {
   it("falls through on a malformed `%` instead of throwing", async () => {
     // With `allowMalformedURL`, a raw malformed `%` (e.g. `/foo%`) reaches


### PR DESCRIPTION
Closes #1267.

Adds single-range byte support to `serveStatic` for `GET`/`HEAD` requests when the asset size is known (`meta.size`), following the behavior proposed in the issue:

- Always advertises `accept-ranges: bytes` when size is known
- Supports only a single byte range (`bytes=start-end`, `bytes=start-`, `bytes=-suffix`); malformed or multi-range headers are ignored and the full response is served
- A satisfiable range returns `206 Partial Content` with `content-range`/`content-length`; `HEAD` returns headers only
- An out-of-bounds range returns `416 Range Not Satisfiable` with `content-range: bytes */<size>` and `content-length: 0`
- No interaction with existing caching (`if-none-match`/`if-modified-since`), encoding selection, `fallthrough`, or 404/405 handling — all untouched
- No new public exports; range parsing/slicing lives entirely inside `src/utils/static.ts`

```ts
app.get("/video.mp4", (event) => serveStatic(event, { getMeta, getContents }));
// Range: bytes=0-1023  -> 206, content-range: bytes 0-1023/<size>
// Range: bytes=999999- -> 416, content-range: bytes */<size>  (if out of bounds)
```

Content is sliced for `string`/`Uint8Array`/`ArrayBuffer`/`Blob` return values from `getContents`. Any other body type (e.g. a `ReadableStream`) can't be sliced without fully buffering it, so it falls back to a full `200` response rather than silently mis-serving a range.

Tests (`describeMatrix`, via `t.app`/`t.fetch`): start-end/open-ended/suffix ranges, clamping past the end and oversized suffix ranges, 416 for out-of-bounds/zero-length-suffix/inverted ranges, malformed and multi-range headers ignored, no Range support when size is unknown, and per-body-type slicing (string/Uint8Array/ArrayBuffer/Blob) plus the stream fallback. `pnpm test` (lint + format + typecheck + full vitest + coverage) is green; the only failure locally (`getRequestFingerprint` IP match) is a pre-existing, unrelated sandbox-networking flake reproducible on `main` without this change.

Drafted with AI assistance; reviewed and verified against the test suite by me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for single-byte range requests when serving static assets.
  * Valid range requests now return partial content with appropriate range and length headers.
  * Added support for open-ended and suffix ranges, including `HEAD` requests.
  * Static assets advertise byte-range support when their size is known.

* **Bug Fixes**
  * Unsatisfiable ranges now return `416` responses.
  * Unsupported or unsliceable content safely falls back to a complete response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->