### PR TITLE
feat: add requestId middleware for request id generation/propagation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -227,6 +227,10 @@ export { type BasicAuthOptions, requireBasicAuth, basicAuth } from "./utils/auth
 
 export { type RequestFingerprintOptions, getRequestFingerprint } from "./utils/fingerprint.ts";
 
+// Request ID
+
+export { type RequestIdOptions, requestId } from "./utils/request-id.ts";
+
 // WebSocket
 
 export {

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -35,4 +35,7 @@ export interface H3EventContext extends ServerRequestContext {
 
   /* Server-Timing entries collected via setServerTiming / withServerTiming */
   timing?: Array<{ name: string } & Record<string, unknown>>;
+
+  /* Request id assigned by the requestId middleware */
+  requestId?: string;
 }

--- a/src/utils/request-id.ts
+++ b/src/utils/request-id.ts
@@ -1,0 +1,49 @@
+import { getEventContext } from "./event.ts";
+
+import type { HTTPEvent } from "../event.ts";
+import type { H3EventContext } from "../types/context.ts";
+import type { Middleware } from "../types/handler.ts";
+
+export interface RequestIdOptions {
+  /**
+   * Request header to read an incoming id from, and to set on the response.
+   * @default "x-request-id"
+   */
+  header?: string;
+
+  /**
+   * Reuse an id already present on the incoming request's header instead of
+   * always generating a fresh one.
+   * @default true
+   */
+  trustIncoming?: boolean;
+
+  /**
+   * Generate a new id.
+   * @default () => crypto.randomUUID()
+   */
+  generate?: (event: HTTPEvent) => string;
+}
+
+/**
+ * Create a middleware that assigns a request id to `event.context.requestId`
+ * and echoes it on the response, for correlating logs/traces across a request.
+ *
+ * @example
+ * import { H3, requestId } from "h3";
+ * const app = new H3().use(requestId());
+ * app.get("/", (event) => `Request id: ${event.context.requestId}`);
+ */
+export function requestId(opts: RequestIdOptions = {}): Middleware {
+  const header = opts.header || "x-request-id";
+  const generate = opts.generate || (() => crypto.randomUUID());
+  return (event, next) => {
+    const incoming = opts.trustIncoming === false ? null : event.req.headers.get(header);
+    const id = incoming || generate(event);
+    getEventContext<H3EventContext>(event).requestId = id;
+    if (!event.res.headers.has(header)) {
+      event.res.headers.set(header, id);
+    }
+    return next();
+  };
+}

--- a/test/request-id.test.ts
+++ b/test/request-id.test.ts
@@ -1,0 +1,79 @@
+import { requestId } from "../src/index.ts";
+import { describeMatrix } from "./_setup.ts";
+
+describeMatrix("requestId", (t, { it, expect }) => {
+  it("generates an id and exposes it via event.context and the response header", async () => {
+    let contextId: string | undefined;
+    t.app.use(requestId());
+    t.app.get("/test", (event) => {
+      contextId = event.context.requestId;
+      return "ok";
+    });
+
+    const res = await t.fetch("/test");
+    expect(res.status).toBe(200);
+    const headerId = res.headers.get("x-request-id");
+    expect(headerId).toBeTruthy();
+    expect(contextId).toBe(headerId);
+  });
+
+  it("generates a different id per request", async () => {
+    t.app.use(requestId());
+    t.app.get("/test", () => "ok");
+
+    const res1 = await t.fetch("/test");
+    const res2 = await t.fetch("/test");
+    expect(res1.headers.get("x-request-id")).not.toBe(res2.headers.get("x-request-id"));
+  });
+
+  it("reuses an incoming request id header by default", async () => {
+    t.app.use(requestId());
+    t.app.get("/test", (event) => event.context.requestId || "");
+
+    const res = await t.fetch("/test", { headers: { "x-request-id": "incoming-id" } });
+    expect(res.headers.get("x-request-id")).toBe("incoming-id");
+    expect(await res.text()).toBe("incoming-id");
+  });
+
+  it("ignores an incoming header when trustIncoming is false", async () => {
+    t.app.use(requestId({ trustIncoming: false }));
+    t.app.get("/test", () => "ok");
+
+    const res = await t.fetch("/test", { headers: { "x-request-id": "incoming-id" } });
+    expect(res.headers.get("x-request-id")).not.toBe("incoming-id");
+    expect(res.headers.get("x-request-id")).toBeTruthy();
+  });
+
+  it("supports a custom header name", async () => {
+    t.app.use(requestId({ header: "x-trace-id" }));
+    t.app.get("/test", (event) => event.context.requestId || "");
+
+    const res = await t.fetch("/test", { headers: { "x-trace-id": "trace-123" } });
+    expect(res.headers.get("x-trace-id")).toBe("trace-123");
+    expect(res.headers.get("x-request-id")).toBeNull();
+    expect(await res.text()).toBe("trace-123");
+  });
+
+  it("supports a custom generate function", async () => {
+    let counter = 0;
+    t.app.use(requestId({ generate: () => `custom-${++counter}` }));
+    t.app.get("/test", () => "ok");
+
+    const res = await t.fetch("/test");
+    expect(res.headers.get("x-request-id")).toBe("custom-1");
+  });
+
+  it("does not overwrite a response header already set upstream", async () => {
+    t.app.use((event, next) => {
+      event.res.headers.set("x-request-id", "manual-id");
+      return next();
+    });
+    t.app.use(requestId());
+    t.app.get("/test", (event) => event.context.requestId || "");
+
+    const res = await t.fetch("/test");
+    expect(res.headers.get("x-request-id")).toBe("manual-id");
+    // event.context.requestId is still assigned, even though the response header wasn't overwritten
+    expect(await res.text()).not.toBe("manual-id");
+  });
+});

--- a/test/unit/package.test.ts
+++ b/test/unit/package.test.ts
@@ -113,6 +113,7 @@ describe("h3 package", () => {
         "redirectBack",
         "removeResponseHeader",
         "removeRoute",
+        "requestId",
         "requestWithBaseURL",
         "requestWithURL",
         "requireBasicAuth",


### PR DESCRIPTION
Closes #1389.

Adds a `requestId` middleware that assigns a request id to `event.context.requestId` and echoes it on the response, for correlating logs/traces across a request — the same shape as `getRequestFingerprint`/`basicAuth` (a small, opt-in utility, not core complexity).

```ts
import { H3, requestId } from "h3";
const app = new H3().use(requestId());
app.get("/", (event) => `Request id: ${event.context.requestId}`);
```

- Reuses an id already present on the request's header by default (`trustIncoming`, default `true`) — useful behind a proxy/gateway that already assigns one — or generates one via `crypto.randomUUID()`
- `header` (default `x-request-id`) and `generate` are both overridable
- A response header already set downstream of the middleware is left untouched (consistent with how `content-type`/`content-length` etc. are only set when absent elsewhere in the codebase)
- `event.context.requestId` is typed via a new optional field on `H3EventContext` (`src/types/context.ts`), following the existing `basicAuth`/`clientAddress` pattern

Tests (`describeMatrix`, via `t.app`/`t.fetch`, new `test/request-id.test.ts`): default generation, uniqueness per request, reusing/ignoring an incoming header (`trustIncoming`), custom `header`/`generate` options, and not clobbering a response header already set upstream. `pnpm test` (lint + format + typecheck + full vitest + coverage) is green.

Drafted with AI assistance; reviewed and verified against the test suite by me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request ID middleware for generating or preserving correlation IDs.
  * Request IDs are available in request context and response headers.
  * Added options for custom header names, ID generation, and incoming ID trust.
  * Exposed request ID functionality through the public API.

* **Tests**
  * Added coverage for default, custom, trusted, and generated request IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->