### PR TITLE
feat(sse): allow returning EventStream directly from handlers

### DIFF
--- a/docs/1.guide/901.advanced/2.websocket.md
+++ b/docs/1.guide/901.advanced/2.websocket.md
@@ -167,7 +167,7 @@ app.get("/", (event) => {
     clearInterval(interval);
   });
 
-  return eventStream.send();
+  return eventStream;
 });
 
 serve(app);

--- a/docs/2.utils/2.response.md
+++ b/docs/2.utils/2.response.md
@@ -34,7 +34,7 @@ app.get("/sse", (event) => {
     await eventStream.close();
   });
 
-  return eventStream.send();
+  return eventStream;
 });
 ```
 

--- a/examples/server-sent-events.mjs
+++ b/examples/server-sent-events.mjs
@@ -16,7 +16,7 @@ app.get("/", (event) => {
     clearInterval(interval);
   });
 
-  return eventStream.send();
+  return eventStream;
 });
 
 serve(app);

--- a/src/utils/event-stream.ts
+++ b/src/utils/event-stream.ts
@@ -43,7 +43,7 @@ export interface EventStreamMessage {
  *     await eventStream.close();
  *   });
  *
- *   return eventStream.send();
+ *   return eventStream;
  * });
  * ```
  */

--- a/src/utils/internal/event-stream.ts
+++ b/src/utils/internal/event-stream.ts
@@ -1,15 +1,20 @@
 import type { H3Event } from "../../event.ts";
 import type { EventStreamMessage, EventStreamOptions } from "../event-stream.ts";
+import { HTTPResponse } from "../../response.ts";
 import { onDispose } from "./dispose.ts";
 
 const _noop = () => {};
 
 /**
  * A helper class for [server sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format)
+ *
+ * Extends {@link HTTPResponse} so it can be returned directly from a handler
+ * (`return eventStream`) — `toResponse` already renders any `HTTPResponse` as
+ * the response, streaming the readable side with the SSE headers below.
  */
-export class EventStream {
+export class EventStream extends HTTPResponse {
   private readonly _event: H3Event;
-  private readonly _transformStream = new TransformStream();
+  private readonly _transformStream: TransformStream;
   private readonly _writer: WritableStreamDefaultWriter;
   private readonly _encoder: TextEncoder = new TextEncoder();
 
@@ -19,15 +24,20 @@ export class EventStream {
   private _paused = false;
   private _unsentData: undefined | string;
   private _disposed = false;
-  private _handled = false;
 
   private get _isClosed(): boolean {
     return this._writerIsClosed || this._disposed;
   }
 
   constructor(event: H3Event, _opts: EventStreamOptions = {}) {
+    // The transform stream must exist before `super()` so the readable side can
+    // be handed to HTTPResponse as the body; a field initializer would run after
+    // super() and replace it with a different stream, orphaning that body.
+    const transformStream = new TransformStream();
+    super(transformStream.readable, { status: 200, headers: eventStreamHeaders(event) });
     this._event = event;
-    this._writer = this._transformStream.writable.getWriter();
+    this._transformStream = transformStream;
+    this._writer = transformStream.writable.getWriter();
     // `closed` rejects when the readable side is cancelled (client disconnect)
     // and resolves on a graceful `close()`. Both mean the stream is over.
     this._writer.closed.catch(_noop).finally(() => {
@@ -184,10 +194,16 @@ export class EventStream {
     this._closeCallbacks.push(cb);
   }
 
+  /**
+   * Return the readable side of the stream, staging the SSE headers on the event.
+   *
+   * Prefer returning the stream itself (`return eventStream`) — it carries the
+   * same headers via {@link HTTPResponse}. This method is kept for compatibility
+   * with the `return eventStream.send()` pattern.
+   */
   async send(): Promise<BodyInit> {
     setEventStreamHeaders(this._event);
     this._event.res.status = 200;
-    this._handled = true;
     return this._transformStream.readable;
   }
 }
@@ -252,16 +268,21 @@ export function formatEventStreamMessages(messages: EventStreamMessage[]): strin
   return result;
 }
 
-export function setEventStreamHeaders(event: H3Event): void {
-  event.res.headers.set("content-type", "text/event-stream");
-  event.res.headers.set(
-    "cache-control",
-    "private, no-cache, no-store, no-transform, must-revalidate, max-age=0",
-  );
-  // prevent nginx from buffering the response
-  event.res.headers.set("x-accel-buffering", "no");
-
+export function eventStreamHeaders(event: H3Event): Record<string, string> {
+  const headers: Record<string, string> = {
+    "content-type": "text/event-stream",
+    "cache-control": "private, no-cache, no-store, no-transform, must-revalidate, max-age=0",
+    // prevent nginx from buffering the response
+    "x-accel-buffering": "no",
+  };
   if (event.req.headers.get("connection") === "keep-alive") {
-    event.res.headers.set("connection", "keep-alive");
+    headers["connection"] = "keep-alive";
+  }
+  return headers;
+}
+
+export function setEventStreamHeaders(event: H3Event): void {
+  for (const [name, value] of Object.entries(eventStreamHeaders(event))) {
+    event.res.headers.set(name, value);
   }
 }

--- a/src/utils/internal/event-stream.ts
+++ b/src/utils/internal/event-stream.ts
@@ -197,8 +197,8 @@ export class EventStream extends HTTPResponse {
   /**
    * Return the readable side of the stream, staging the SSE headers on the event.
    *
-   * Prefer returning the stream itself (`return eventStream`) — it carries the
-   * same headers via {@link HTTPResponse}. This method is kept for compatibility
+   * @deprecated Return the stream itself instead (`return eventStream`) — it
+   * carries the same headers via {@link HTTPResponse}. Kept for compatibility
    * with the `return eventStream.send()` pattern.
    */
   async send(): Promise<BodyInit> {

--- a/test/sse.test.ts
+++ b/test/sse.test.ts
@@ -40,6 +40,28 @@ describeMatrix("sse", (t, { it, expect }) => {
     expect(messages.length).toBe(3);
   });
 
+  it("streams events when returning the stream directly", async () => {
+    t.app.get("/sse-direct", (event) => {
+      const eventStream = createEventStream(event);
+      let counter = 0;
+      const clear = setInterval(() => {
+        if (counter++ === 3) {
+          clearInterval(clear);
+          eventStream.close();
+          return;
+        }
+        eventStream.push("hello world");
+      });
+      return eventStream;
+    });
+
+    const res = await t.fetch("/sse-direct");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/event-stream");
+    const messages = (await res.text()).split("\n\n").filter(Boolean);
+    expect(messages.length).toBe(3);
+  });
+
   it("streams events", async () => {
     const res = await t.fetch("/sse?includeMeta=true");
     expect(res.status).toBe(200);


### PR DESCRIPTION
## Summary

Handlers can now `return eventStream` instead of `return eventStream.send()`.

`EventStream` extends `HTTPResponse`, so the existing `toResponse` →
`prepareResponseBody` branch (`val instanceof HTTPResponse`) renders it as the
response directly — streaming the readable side with the SSE headers. **No
core / `response.ts` changes were needed.**

```js
app.get("/sse", (event) => {
  const eventStream = createEventStream(event);
  const interval = setInterval(() => eventStream.push("Hello world"), 1000);
  eventStream.onClosed(() => clearInterval(interval));
  return eventStream; // previously: return eventStream.send()
});
```

## Details

- `EventStream extends HTTPResponse`: the transform stream is created before
  `super()` so its readable side becomes the response body, with `status: 200`
  and the SSE headers passed to `super()`.
- Extracted an `eventStreamHeaders(event)` helper shared by the direct-return
  path and `setEventStreamHeaders()`.
- `send()` is **kept and fully backward-compatible** (still stages headers on
  `event.res` and returns the readable), so `return eventStream.send()` keeps
  working.
- Prepared `event.res.headers` still merge in as before; `HEAD` / null-body
  handling comes for free via the `HTTPResponse` path.

## Tests

- Added a regression test asserting the direct-return path streams events with
  `text/event-stream` and status 200 (runs in both web + node matrix).
- Updated docs/examples (`return eventStream`).
- Full suite green: 1610 passed, no type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSE handlers can now return event streams directly for simpler streaming responses.
  * Added centralized SSE header handling to standardize response headers.

* **Bug Fixes**
  * Improved event stream response initialization and streaming behavior while keeping existing push/cleanup behavior.

* **Documentation**
  * Updated SSE guides and examples to show handlers returning the event stream directly.

* **Tests**
  * Added an SSE test covering direct event stream returns and verification of multiple streamed messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->