### PR TITLE
fix(response): defer stream metadata until first chunk

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -108,6 +108,7 @@ function prepareResponse(
   event: H3Event,
   config: H3Config,
   nested?: boolean,
+  primed?: boolean,
 ): Response | Promise<Response> {
   if (val === kHandled) {
     return new FastResponse(null);
@@ -141,6 +142,12 @@ function prepareResponse(
           .catch((error) => error)
           .then((newVal) => prepareResponse(newVal ?? val, event, config, true))
       : errorResponse(error, config.debug, errHeaders);
+  }
+
+  // Delay preparing the response until the stream produces its first chunk. This
+  // lets async renderers set status and headers before the runtime commits them.
+  if (!primed && val instanceof ReadableStream) {
+    return primeStream(val).then((stream) => prepareResponse(stream, event, config, nested, true));
   }
 
   // Only set if event.res.headers is accessed
@@ -200,6 +207,15 @@ function prepareResponse(
         headers: val.headers,
       }) as Response)
     : val;
+}
+
+async function primeStream(stream: ReadableStream): Promise<BodyInit> {
+  const [probe, body] = stream.tee();
+  const reader = probe.getReader();
+  await reader.read();
+  // Do not await: tee cancellation settles only once the response branch ends.
+  void reader.cancel();
+  return body;
 }
 
 function mergeHeaders(base: HeadersInit, overrides: Headers, target = new Headers(base)): Headers {

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -76,6 +76,26 @@ describeMatrix(
 
     // --- Response stream: Web ReadableStream ---
 
+    it("waits for the first stream chunk before committing response metadata", async () => {
+      ctx.app.get("/stream", (event) => {
+        return new ReadableStream({
+          async start(controller) {
+            await Promise.resolve();
+            event.res.status = 201;
+            event.res.headers.set("x-stream-header", "ready");
+            controller.enqueue(new TextEncoder().encode("Hello World"));
+            controller.close();
+          },
+        });
+      });
+
+      const res = await ctx.fetch("/stream");
+
+      expect(res.status).toBe(201);
+      expect(res.headers.get("x-stream-header")).toBe("ready");
+      expect(await res.text()).toBe("Hello World");
+    });
+
     it("web response stream: client abort propagates to cancel", async () => {
       const { promise: cancelled, resolve: onCancelled } = Promise.withResolvers<boolean>();
 


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #1510

### 📚 Description

Wait for a returned `ReadableStream` to produce its first chunk before preparing the HTTP response. This restores the v1 behavior needed by async streaming renderers: status and headers set while producing the first chunk are included before the runtime commits the response.

The stream is teed so the probed chunk remains available to the response consumer, while cancellation continues to propagate to the source. A matrix regression test covers both web and Node adapters.

### 🧪 Validation

- `pnpm vitest run test/stream.test.ts test/dispose.test.ts --typecheck.enabled=false` (31 passed, 3 skipped)
- `pnpm exec oxlint src/response.ts test/stream.test.ts`
- `pnpm exec oxfmt --check src/response.ts test/stream.test.ts`
- `pnpm typecheck`
- Full `pnpm test`: 1,610 passed, 44 skipped; one environment-specific IP assertion failed (`::ffff:127.0.0.1` vs expected loopback forms), plus the three bundle-size budgets increased by ~306–320 raw bytes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming responses so status codes and headers are finalized after the first content chunk is ready.
  * Ensures clients receive accurate response metadata alongside streamed content.

* **Tests**
  * Added coverage verifying delayed stream initialization, response metadata, and streamed body content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->