### PR TITLE
fix(response): allow status and headers staged during the first stream chunk

### DIFF
--- a/docs/2.utils/2.response.md
+++ b/docs/2.utils/2.response.md
@@ -60,6 +60,8 @@ Each chunk must be a string or a buffer.
 
 For generator (yielding) functions, the returned value is treated the same as yielded values.
 
+The first chunk is awaited before the response is created, so status and headers staged while producing it (`event.res.status`, `event.res.headers`) are still applied. Everything set after the first chunk is ignored — headers are already on the wire by then. (Returning a raw `ReadableStream` gives no such window: its response is created before the stream is read.)
+
 **Example:**
 
 ```ts

--- a/src/_deprecated.ts
+++ b/src/_deprecated.ts
@@ -159,7 +159,7 @@ export const sendIterable: <Value = unknown, Return = unknown>(
   options?: {
     serializer: IteratorSerializer<Value | Return>;
   },
-) => HTTPResponse = (_event, val, options) => {
+) => Promise<HTTPResponse> = (_event, val, options) => {
   return iterable(val, options);
 };
 

--- a/src/response.ts
+++ b/src/response.ts
@@ -92,11 +92,19 @@ export class HTTPResponse {
     this.body = body;
     this.#init = init;
   }
-  get status(): number {
-    return this.#init?.status || 200;
+  /**
+   * Status of the response, or `undefined` when unset.
+   *
+   * Unset means "inherit": the status staged on `event.res.status` is used, falling back to `200`.
+   * Defaulting to `200` here instead would make an untouched `HTTPResponse` indistinguishable from
+   * one explicitly built with `{ status: 200 }`, and always win over `event.res`.
+   */
+  get status(): number | undefined {
+    return this.#init?.status;
   }
-  get statusText(): string {
-    return this.#init?.statusText || "OK";
+  /** Status text of the response, or `undefined` when unset. See {@link HTTPResponse.status}. */
+  get statusText(): string | undefined {
+    return this.#init?.statusText;
   }
   get headers(): Headers {
     return (this.#headers ||= new Headers(this.#init?.headers));

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -186,6 +186,11 @@ export function writeEarlyHints(
  *
  * For generator (yielding) functions, the returned value is treated the same as yielded values.
  *
+ * The first chunk is awaited before the response is created, so status and headers staged while
+ * producing it (`event.res.status`, `event.res.headers`) are still applied. Everything set after
+ * the first chunk is ignored — headers are already on the wire by then. (Returning a raw
+ * `ReadableStream` gives no such window: its response is created before the stream is read.)
+ *
  * @param iterable - Iterator that produces chunks of the response.
  * @param serializer - Function that converts values from the iterable into stream-compatible values.
  * @template Value - Test
@@ -209,18 +214,22 @@ export function writeEarlyHints(
  *   return new Promise((resolve) => setTimeout(resolve, ms));
  * }
  */
-export function iterable<Value = unknown, Return = unknown>(
+export async function iterable<Value = unknown, Return = unknown>(
   iterable: IterationSource<Value, Return>,
   options?: {
     serializer: IteratorSerializer<Value | Return>;
   },
-): HTTPResponse {
+): Promise<HTTPResponse> {
   const serializer = options?.serializer ?? serializeIterableValue;
   const iterator = coerceIterable(iterable);
+  // Pull the first chunk up-front: the response is built as soon as the handler returns, so this
+  // is the only point where the producer can still influence status and headers.
+  let first: IteratorResult<Value | Return> | undefined = await iterator.next();
   return new HTTPResponse(
     new ReadableStream({
       async pull(controller) {
-        const { value, done } = await iterator.next();
+        const { value, done } = first ?? (await iterator.next());
+        first = undefined;
         if (value !== undefined) {
           const chunk = serializer(value);
           if (chunk !== undefined) {

--- a/test/iterable.test.ts
+++ b/test/iterable.test.ts
@@ -1,6 +1,6 @@
 import { ReadableStream } from "node:stream/web";
 import { vi } from "vitest";
-import { iterable } from "../src/index.ts";
+import { HTTPError, iterable } from "../src/index.ts";
 import { describeMatrix } from "./_setup.ts";
 
 describeMatrix("iterable", (t, { it, expect, describe }) => {
@@ -90,6 +90,60 @@ describeMatrix("iterable", (t, { it, expect, describe }) => {
           expect(await response.text()).toBe("the-value");
         });
       }
+    });
+
+    describe("response status and headers", () => {
+      it("keeps the status staged before the iterable is returned", async () => {
+        t.app.use((event) => {
+          event.res.status = 201;
+          return iterable(["a"]);
+        });
+        const result = await t.fetch("/");
+        expect(result.status).toBe(201);
+        expect(await result.text()).toBe("a");
+      });
+
+      it("applies status and headers set while producing the first chunk", async () => {
+        t.app.use((event) =>
+          iterable(async function* () {
+            await Promise.resolve();
+            event.res.status = 201;
+            event.res.headers.set("hello", "world");
+            yield "a";
+            yield "b";
+          }),
+        );
+        const result = await t.fetch("/");
+        expect(result.status).toBe(201);
+        expect(result.headers.get("hello")).toBe("world");
+        expect(await result.text()).toBe("ab");
+      });
+
+      it("ignores changes made after the first chunk", async () => {
+        t.app.use((event) =>
+          iterable(async function* () {
+            yield "a";
+            event.res.status = 201;
+            yield "b";
+          }),
+        );
+        const result = await t.fetch("/");
+        expect(result.status).toBe(200);
+        expect(await result.text()).toBe("ab");
+      });
+
+      it("renders an error response when the first chunk throws", async () => {
+        t.app.use(() =>
+          iterable(async function* () {
+            throw new HTTPError({ status: 418, message: "nope" });
+            // eslint-disable-next-line no-unreachable
+            yield "a";
+          }),
+        );
+        const result = await t.fetch("/");
+        expect(result.status).toBe(418);
+        expect((await result.json()).message).toBe("nope");
+      });
     });
 
     describe("serializer argument", () => {

--- a/test/status.test.ts
+++ b/test/status.test.ts
@@ -1,4 +1,4 @@
-import { noContent } from "../src/index.ts";
+import { html, HTTPResponse, noContent } from "../src/index.ts";
 import { describeMatrix } from "./_setup.ts";
 
 describeMatrix("event response", (t, { it, describe, expect }) => {
@@ -60,6 +60,39 @@ describeMatrix("event response", (t, { it, describe, expect }) => {
                 date: expect.any(String),
                 "keep-alive": "timeout=5",
               },
+      });
+    });
+  });
+
+  describe("HTTPResponse", () => {
+    it("keeps the status staged on event.res when the response has none", async () => {
+      t.app.get("/test", (event) => {
+        event.res.status = 201;
+        event.res.statusText = "Created";
+        return html`<p>hi</p>`;
+      });
+
+      const res = await t.fetch("/test");
+
+      expect(await webResponseToPlain(res)).toMatchObject({
+        status: 201,
+        statusText: "Created",
+        body: "<p>hi</p>",
+      });
+    });
+
+    it("own status wins over the one staged on event.res", async () => {
+      t.app.get("/test", (event) => {
+        event.res.status = 201;
+        return new HTTPResponse("hi", { status: 418, statusText: "teapot" });
+      });
+
+      const res = await t.fetch("/test");
+
+      expect(await webResponseToPlain(res)).toMatchObject({
+        status: 418,
+        statusText: "teapot",
+        body: "hi",
       });
     });
   });


### PR DESCRIPTION
Closes #1510 (partially — see caveat).

## What I found

Reproduced the report on `main`. `iterable()` (suggested in the issue thread) did **not** help either — two independent problems:

### 1. `HTTPResponse` silently discards `event.res.status`

Pre-existing and unrelated to streaming:

```ts
app.get("/", (event) => {
  event.res.status = 201;
  return html`<p>hi</p>`;   // -> 200 ❌   (returning "hi" instead -> 201 ✅)
});
```

`prepareResponse` does `res.status || preparedRes?.status`, but `res` is the `HTTPResponse` and its getter was `this.#init?.status || 200` — never `undefined`, so the staged status was dead code for every util returning an `HTTPResponse` (`html()`, `iterable()`, user-built ones). Same for `statusText`.

`HTTPResponse.status` / `.statusText` now return `undefined` when unset, meaning "inherit": `event.res.status` is used, falling back to `200`. `prepareResponse` itself is unchanged — the `|| preparedRes?.status` fallback finally does what it was written to do.

### 2. `iterable()` built its response before the producer ran

The `ReadableStream` was constructed synchronously, so `toResponse` had already built the `Response` by the time `pull` first ran. `iterable()` now awaits the **first** chunk before constructing the `HTTPResponse` — the same window v1 had, where headers went out on first write:

```ts
app.get("/", (event) =>
  iterable(async function* () {
    const data = await load();
    event.res.status = 201;
    event.res.headers.set("hello", "world");
    yield render(data);
  }),
);
```

Side effect: a throw before the first chunk now renders a proper error response instead of tearing a stream mid-flight.

## Caveat

Returning a **raw `ReadableStream`** (the exact snippet in #1510) still cannot support this — the `Response` must be constructed before anything reads the stream, and eagerly priming every returned stream would stall headers for SSE/long-poll bodies. `iterable()` is the supported way to keep a v1-style window; documented on the util.

## Breaking

- `HTTPResponse.status` is `number | undefined` (was `number`, always ≥ `200`); `statusText` likewise.
- `iterable()` returns `Promise<HTTPResponse>` (as does the deprecated `sendIterable`). Returning it from a handler is unaffected — `toResponse` already awaits.

## Size

Bundle budgets unchanged and still green — this comes out ~11 bytes **smaller** than `main` (dropping the `|| 200` / `|| "OK"` defaults pays for the fix).

Tests added in `test/status.test.ts` (staged status vs. own status) and `test/iterable.test.ts` (status/headers before, during and after the first chunk; throw before the first chunk). Full suite + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved streaming responses so status codes and headers set while generating the first chunk are applied correctly.
  * Explicit response status and status text now take precedence over staged values.

* **Bug Fixes**
  * Corrected error handling when the first streamed chunk fails.
  * Unset response status and status text now remain unset instead of defaulting automatically.

* **Documentation**
  * Clarified when streaming response headers are finalized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->