### PR TITLE
fix(encoding): avoid RangeError on large base64Encode without Buffer

### DIFF
--- a/src/utils/internal/encoding.ts
+++ b/src/utils/internal/encoding.ts
@@ -44,7 +44,15 @@ export function base64Encode(data: ArrayBuffer | Uint8Array | string): string {
     );
   }
 
-  return String.fromCharCode(...bytes);
+  // Avoid String.fromCharCode(...bytes): spread hits the engine argument
+  // limit (~65k–128k args) for larger payloads (session cookies, iron seals).
+  // See https://github.com/h3js/h3/issues/1514
+  let out = "";
+  const chunk = 0x8000;
+  for (let j = 0; j < bytes.length; j += chunk) {
+    out += String.fromCharCode(...bytes.slice(j, j + chunk));
+  }
+  return out;
 }
 export function base64Decode(b64Url: string): Uint8Array {
   if (globalThis.Buffer) {

--- a/test/unit/encoding.test.ts
+++ b/test/unit/encoding.test.ts
@@ -24,6 +24,26 @@ describe("encoding utilities", () => {
       const expected = "aGVsbG8";
       expect(base64Encode(input)).toBe(expected);
     });
+
+    it("should encode large payloads without RangeError when Buffer is absent", () => {
+      // Runtimes without global Buffer (Deno / service-workers / browser)
+      // take the hand-rolled path that used to spread ~1.33n args into
+      // String.fromCharCode and hit the engine argument limit.
+      const originalBuffer = globalThis.Buffer;
+      // @ts-expect-error — intentionally wipe Buffer for the fallback path
+      globalThis.Buffer = undefined;
+      try {
+        const input = new Uint8Array(128 * 1024);
+        for (let i = 0; i < input.length; i++) input[i] = i % 256;
+        const encoded = base64Encode(input);
+        expect(encoded.length).toBeGreaterThan(0);
+        // base64url: no padding, and alphabet excludes + /
+        expect(encoded).not.toMatch(/[+/=]/);
+        expect(base64Decode(encoded)).toEqual(input);
+      } finally {
+        globalThis.Buffer = originalBuffer;
+      }
+    });
   });
 
   describe("base64Decode", () => {

--- a/test/unit/encoding.test.ts
+++ b/test/unit/encoding.test.ts
@@ -29,9 +29,10 @@ describe("encoding utilities", () => {
       // Runtimes without global Buffer (Deno / service-workers / browser)
       // take the hand-rolled path that used to spread ~1.33n args into
       // String.fromCharCode and hit the engine argument limit.
-      const originalBuffer = globalThis.Buffer;
+      const hadBuffer = Object.prototype.hasOwnProperty.call(globalThis, "Buffer");
+      const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, "Buffer");
       // @ts-expect-error — intentionally wipe Buffer for the fallback path
-      globalThis.Buffer = undefined;
+      delete (globalThis as { Buffer?: unknown }).Buffer;
       try {
         const input = new Uint8Array(128 * 1024);
         for (let i = 0; i < input.length; i++) input[i] = i % 256;
@@ -41,7 +42,13 @@ describe("encoding utilities", () => {
         expect(encoded).not.toMatch(/[+/=]/);
         expect(base64Decode(encoded)).toEqual(input);
       } finally {
-        globalThis.Buffer = originalBuffer;
+        if (hadBuffer && originalDescriptor) {
+          Object.defineProperty(globalThis, "Buffer", originalDescriptor);
+        } else {
+          // leave absent if it was absent
+          // @ts-expect-error
+          delete (globalThis as { Buffer?: unknown }).Buffer;
+        }
       }
     });
   });


### PR DESCRIPTION
## Summary
- On runtimes without global `Buffer` (Deno / service-worker / browser entries), `base64Encode` built a number array then called `String.fromCharCode(...bytes)`.
- Spreading ~1.33×input-bytes into `fromCharCode` hits engine argument limits on larger payloads (~128KB+), throwing `RangeError: Maximum call stack size exceeded` / max arguments.
- Chunk the encode so large iron/session payloads work offline Buffer. Fixes #1514.

## Test plan
- [x] `pnpm exec vitest run test/unit/encoding.test.ts` (includes large payload with Buffer wiped)
- [ ] CI on PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Base64 encoding for large payloads, preventing failures with oversized inputs.
  * Preserved Base64URL output compatibility, including padding and character handling.

* **Tests**
  * Added coverage for encoding and decoding large payloads in environments without `Buffer`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->