### PR TITLE
chore: add .gitattributes for line ending and binary normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,92 @@
+# Auto-detect text files and normalize line endings
+* text=auto
+
+# Images
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.tif binary
+*.tiff binary
+*.ico binary
+*.webp binary
+*.bmp binary
+*.psd binary
+# SVG is XML text, not binary
+*.svg text
+
+# Fonts
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary
+*.otf binary
+
+# Archives
+*.7z binary
+*.bz2 binary
+*.gz binary
+*.rar binary
+*.tar binary
+*.tar.gz binary
+*.tgz binary
+*.zip binary
+*.zst binary
+
+# Compiled objects and libraries
+*.a binary
+*.lib binary
+*.o binary
+*.obj binary
+
+# Executables and shared libraries
+*.dll binary
+*.dylib binary
+*.exe binary
+*.so binary
+
+# Documents and data
+*.pdf binary
+*.db binary
+*.sqlite binary
+*.sqlite3 binary
+
+# Preserve byte sequences in patches
+*.patch -text
+*.diff -text
+
+# Audio
+*.aac binary
+*.aif binary
+*.aiff binary
+*.flac binary
+*.m4a binary
+*.mid binary
+*.midi binary
+*.mp3 binary
+*.ogg binary
+*.wav binary
+*.wma binary
+
+# Video
+*.3gp binary
+*.avi binary
+*.flv binary
+*.m4v binary
+*.mkv binary
+*.mov binary
+*.mp4 binary
+*.mpeg binary
+*.mpg binary
+*.ogv binary
+*.webm binary
+*.wmv binary
+
+# Lockfiles
+package-lock.json binary
+yarn.lock binary
+pnpm-lock.yaml binary
+bun.lock binary
+
+# Source maps — suppress noisy diffs (Web.gitattributes)
+*.map text -diff


### PR DESCRIPTION
Add a `.gitattributes` file to normalize line endings and mark binary files across h3's contributor base.

## What

- `* text=auto` — git auto-detects and normalizes line endings on checkout/commit
- `pnpm-lock.yaml binary` (and `package-lock.json`, `yarn.lock`, `bun.lock`) — prevents merge conflicts in lockfile diffs and suppresses noisy hunks in PRs
- Binary markers for images, fonts, archives, compiled objects, executables, audio, video — keeps `git diff` clean
- `*.map text -diff` — source maps are text but suppress in diffs (common web project convention)
- `*.patch -text`, `*.diff -text` — preserve byte sequences in patches

## Why

h3 runs across Node.js, Bun, Deno, and Cloudflare Workers, and contributors develop on macOS, Linux, and Windows. Without `.gitattributes`, Windows checkouts can introduce CRLF line endings and Renovate bot's `pnpm-lock.yaml` updates show as line-ending noise rather than true dependency diffs. The `autofix.ci` formatter already runs `oxfmt` on PRs; this closes the orthogonal problem of VCS-level normalization.

This change is additive and does not touch any source files, CI configuration, or runtime behavior.

---

This change was generated by [Autar](https://autar.ai) and reviewed by a human before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved handling of text and binary files in version control.
  * Preserved patch and diff formatting.
  * Reduced noise from generated source-map files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->