### PR TITLE
fix(encoding): encode large payloads without a global Buffer

### DIFF
--- a/src/utils/internal/encoding.ts
+++ b/src/utils/internal/encoding.ts
@@ -44,7 +44,13 @@ export function base64Encode(data: ArrayBuffer | Uint8Array | string): string {
     );
   }
 
-  return String.fromCharCode(...bytes);
+  // Spreading the whole array exceeds the engine's argument limit for large
+  // payloads, so build the string in chunks.
+  let base64 = "";
+  for (let offset = 0; offset < bytes.length; offset += 8192) {
+    base64 += String.fromCharCode(...bytes.slice(offset, offset + 8192));
+  }
+  return base64;
 }
 export function base64Decode(b64Url: string): Uint8Array {
   if (globalThis.Buffer) {

--- a/test/unit/encoding.test.ts
+++ b/test/unit/encoding.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   base64Encode,
   base64Decode,
@@ -23,6 +23,18 @@ describe("encoding utilities", () => {
       const input = new Uint8Array([104, 101, 108, 108, 111]).buffer;
       const expected = "aGVsbG8";
       expect(base64Encode(input)).toBe(expected);
+    });
+
+    it("should encode large payloads without a global Buffer", () => {
+      const input = new Uint8Array(200_000).map((_, i) => i % 256);
+      const expected = Buffer.from(input).toString("base64url");
+
+      vi.stubGlobal("Buffer", undefined);
+      try {
+        expect(base64Encode(input)).toBe(expected);
+      } finally {
+        vi.unstubAllGlobals();
+      }
     });
   });
 


### PR DESCRIPTION
Fixes #1514.

The `base64Encode` fallback runs when `globalThis.Buffer` is absent: the `deno`, `service-worker` and browser entries, and workerd without `nodejs_compat`. It ends with `String.fromCharCode(...bytes)`, and `bytes` holds one entry per output character, so a large payload spreads past the engine's argument limit:

```
RangeError: Maximum call stack size exceeded
 ❯ base64Encode src/utils/internal/encoding.ts:47:17
```

The fix builds the string in 8192-character chunks instead, so the output is unchanged.

The test stubs `globalThis.Buffer` away, since the fast path otherwise hides the fallback in Node, and checks that a 200 KB payload encodes to the same string as `Buffer.from(...).toString("base64url")`. It fails on `main` with the error above and passes with the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Base64 encoding for large data payloads.
  * Encoding now remains reliable in environments without global `Buffer` support.

* **Tests**
  * Added coverage for large payload encoding scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->