### PR TITLE
Add RFC 9457 (Problem Details) support for error responses

### DIFF
--- a/docs/1.guide/1.basics/6.error.md
+++ b/docs/1.guide/1.basics/6.error.md
@@ -58,6 +58,8 @@ This will end the request with `400 - Bad Request` status code and the following
 - `headers`: Additional HTTP headers to be sent in the error response.
 - `cause`: The original error object that caused this error, useful for tracing and debugging.
 - `unhandled`: Indicates whether the error was thrown for unknown reasons. See [Unhandled Errors](#unhandled-errors).
+- `type`: A URI reference identifying the problem type. Used as the `type` member when the error is sent as [RFC 9457 Problem Details](#rfc-9457-problem-details).
+- `instance`: A URI reference identifying this specific occurrence of the problem. Used as the `instance` member when the error is sent as [RFC 9457 Problem Details](#rfc-9457-problem-details).
 
 > [!TIP]
 > The recommended way to include headers in error responses is to use `new HTTPError({ headers })`:
@@ -74,6 +76,38 @@ This will end the request with `400 - Bad Request` status code and the following
 
 > [!IMPORTANT]
 > Error `statusText` should be short (max 512 to 1024 characters) and only include tab, spaces or visible ASCII characters and extended characters (byte value 128–255). Prefer `message` in JSON body for extended message.
+
+## RFC 9457 Problem Details
+
+H3 can send errors as [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457.html) "Problem Details for HTTP APIs", a standardized machine-readable error format. This is negotiated automatically: send `Accept: application/problem+json` and H3 responds with the `application/problem+json` shape instead of its default JSON error body. No configuration is needed, and clients that don't ask for it keep getting the default shape.
+
+```js
+app.get("/error", () => {
+  throw new HTTPError({
+    status: 422,
+    statusText: "Unprocessable Entity",
+    message: "The email field is invalid",
+    type: "https://example.com/probs/invalid-input",
+    instance: "/errors/1",
+    data: { field: "email" },
+  });
+});
+```
+
+Requesting this route with `Accept: application/problem+json` returns:
+
+```json
+{
+  "type": "https://example.com/probs/invalid-input",
+  "title": "Unprocessable Entity",
+  "status": 422,
+  "detail": "The email field is invalid",
+  "instance": "/errors/1",
+  "data": { "field": "email" }
+}
+```
+
+`title` comes from `statusText`, `detail` comes from `message`, and `type` defaults to `"about:blank"` when not set. Just like the default JSON shape, `detail` and `data`/`body` are hidden for [unhandled errors](#unhandled-errors).
 
 ## Unhandled Errors
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -51,6 +51,20 @@ export interface ErrorBody<DataT = unknown> {
   message: string;
 
   /**
+   * A URI reference identifying the problem type, per [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457.html).
+   *
+   * Used as the `type` member when the error is negotiated as `application/problem+json`. Defaults to `"about:blank"`.
+   */
+  type?: string;
+
+  /**
+   * A URI reference identifying this specific occurrence of the problem, per [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457.html).
+   *
+   * Used as the `instance` member when the error is negotiated as `application/problem+json`.
+   */
+  instance?: string;
+
+  /**
    * Flag to indicate that the error was not handled by the application.
    *
    * Unhandled error stack trace, `data`, `body` and `message` are hidden for security reasons.
@@ -66,6 +80,22 @@ export interface ErrorBody<DataT = unknown> {
    * Additional top level JSON body properties to attach in the error JSON body.
    */
   body?: Record<string, unknown>;
+}
+
+/**
+ * RFC 9457 ("Problem Details for HTTP APIs") representation of an {@link HTTPError}.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9457.html
+ */
+export interface ProblemDetails<DataT = unknown> {
+  type: string;
+  title: string | undefined;
+  status: number;
+  detail: string | undefined;
+  instance: string | undefined;
+  unhandled: boolean | undefined;
+  data: DataT | undefined;
+  [key: string]: unknown;
 }
 
 /**
@@ -110,6 +140,16 @@ export class HTTPError<DataT = unknown> extends Error implements ErrorBody<DataT
    * Additional top level JSON body properties to attach in the error JSON body.
    */
   readonly body: Record<string, unknown> | undefined;
+
+  /**
+   * A URI reference identifying the problem type, per [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457.html).
+   */
+  readonly type: string | undefined;
+
+  /**
+   * A URI reference identifying this specific occurrence of the problem, per [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457.html).
+   */
+  readonly instance: string | undefined;
 
   /**
    * Flag to indicate that the error was not handled by the application.
@@ -202,6 +242,9 @@ export class HTTPError<DataT = unknown> extends Error implements ErrorBody<DataT
 
     this.data = (details as ErrorBody)?.data as DataT | undefined;
     this.body = (details as ErrorBody)?.body;
+
+    this.type = (details as ErrorBody)?.type;
+    this.instance = (details as ErrorBody)?.instance;
   }
 
   /**
@@ -227,6 +270,25 @@ export class HTTPError<DataT = unknown> extends Error implements ErrorBody<DataT
       message: unhandled ? "HTTPError" : this.message,
       data: unhandled ? undefined : this.data,
       ...(unhandled ? undefined : this.body),
+    };
+  }
+
+  /**
+   * Render this error as [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457.html) "Problem Details".
+   *
+   * Used by h3 when the request negotiates `application/problem+json` via its `Accept` header.
+   */
+  toProblem(): ProblemDetails<DataT> {
+    const unhandled = this.unhandled;
+    return {
+      ...(unhandled ? undefined : this.body),
+      type: this.type ?? "about:blank",
+      title: unhandled ? "HTTPError" : this.statusText,
+      status: this.status,
+      detail: unhandled ? undefined : this.message,
+      instance: this.instance,
+      unhandled,
+      data: unhandled ? undefined : this.data,
     };
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,13 @@ export { toResponse, HTTPResponse } from "./response.ts";
 
 // Error
 
-export { type ErrorDetails, type ErrorBody, type ErrorInput, HTTPError } from "./error.ts";
+export {
+  type ErrorDetails,
+  type ErrorBody,
+  type ErrorInput,
+  type ProblemDetails,
+  HTTPError,
+} from "./error.ts";
 
 // Adapters
 

--- a/src/response.ts
+++ b/src/response.ts
@@ -148,7 +148,7 @@ function prepareResponse(
           .then(() => onError(error, event))
           .catch((error) => error)
           .then((newVal) => prepareResponse(newVal ?? val, event, config, true))
-      : errorResponse(error, config.debug, errHeaders);
+      : errorResponse(error, event, config.debug, errHeaders);
   }
 
   // Only set if event.res.headers is accessed
@@ -241,6 +241,10 @@ const jsonHeaders = /* @__PURE__ */ new FrozenHeaders({
   "content-type": "application/json;charset=UTF-8",
 });
 
+const problemJsonHeaders = /* @__PURE__ */ new FrozenHeaders({
+  "content-type": "application/problem+json;charset=UTF-8",
+});
+
 function prepareResponseBody(
   val: unknown,
   event: H3Event,
@@ -325,17 +329,41 @@ function nullBody(method: string, status: number | undefined): boolean | 0 | und
   )
 }
 
-function errorResponse(error: HTTPError, debug?: boolean, errHeaders?: Headers): Response {
+// Only an exact `application/problem+json` media range with a nonzero `q` counts, so mixed
+// `Accept` headers (other types, wildcards, `q=0`) are negotiated correctly rather than matched
+// by substring.
+function wantsProblemJSON(event: H3Event): boolean {
+  const accept = event.req.headers.get("accept") || "";
+  for (const range of accept.split(",")) {
+    const [type, ...params] = range.split(";").map((s) => s.trim().toLowerCase());
+    if (type === "application/problem+json") {
+      const q = params.find((p) => p.startsWith("q="));
+      if (!q || Number.parseFloat(q.slice(2)) > 0) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function errorResponse(
+  error: HTTPError,
+  event: H3Event,
+  debug?: boolean,
+  errHeaders?: Headers,
+): Response {
+  const asProblem = wantsProblemJSON(event);
+  const baseHeaders = asProblem ? problemJsonHeaders : jsonHeaders;
   let headers: Headers = error.headers
-    ? mergeHeaders(jsonHeaders, error.headers)
-    : new Headers(jsonHeaders);
+    ? mergeHeaders(baseHeaders, error.headers)
+    : new Headers(baseHeaders);
   if (errHeaders) {
     headers = mergeHeaders(headers, errHeaders);
   }
   return new FastResponse(
     JSON.stringify(
       {
-        ...error.toJSON(),
+        ...(asProblem ? error.toProblem() : error.toJSON()),
         stack: debug && error.stack ? error.stack.split("\n").map((l) => l.trim()) : undefined,
       },
       undefined,

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -18,8 +18,10 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log(`Bundle size (H3): ${bundle.bytes} (gzip: ${bundle.gzipSize})`);
     }
-    expect(bundle.bytes).toBeLessThanOrEqual(18_420); // <18.42kb
-    expect(bundle.gzipSize).toBeLessThanOrEqual(6_950); // <6.95kb
+    // Budget bumped for RFC 9457 problem-details support (content-negotiated `application/problem+json` errors),
+    // and again for correct q-value based Accept negotiation (was a naive substring check).
+    expect(bundle.bytes).toBeLessThanOrEqual(19_200); // <19.2kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(7_200); // <7.2kb
   });
 
   it("bundle size (H3Core)", async () => {
@@ -34,8 +36,10 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log(`Bundle size (H3Core): ${bundle.bytes} (gzip: ${bundle.gzipSize})`);
     }
-    expect(bundle.bytes).toBeLessThanOrEqual(7630); // <7.63kb
-    expect(bundle.gzipSize).toBeLessThanOrEqual(3020); // <3.02kb
+    // Budget bumped for RFC 9457 problem-details support (content-negotiated `application/problem+json` errors),
+    // and again for correct q-value based Accept negotiation (was a naive substring check).
+    expect(bundle.bytes).toBeLessThanOrEqual(8_400); // <8.4kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(3_250); // <3.25kb
   });
 
   it("bundle size (defineHandler)", async () => {
@@ -50,8 +54,10 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log(`Bundle size (defineHandler): ${bundle.bytes} (gzip: ${bundle.gzipSize})`);
     }
-    expect(bundle.bytes).toBeLessThanOrEqual(6750); // <6.75kb
-    expect(bundle.gzipSize).toBeLessThanOrEqual(2700); // <2.7kb
+    // Budget bumped for RFC 9457 problem-details support (content-negotiated `application/problem+json` errors),
+    // and again for correct q-value based Accept negotiation (was a naive substring check).
+    expect(bundle.bytes).toBeLessThanOrEqual(7_500); // <7.5kb
+    expect(bundle.gzipSize).toBeLessThanOrEqual(2_950); // <2.95kb
   });
 });
 

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -343,4 +343,160 @@ describeMatrix("errors", (t, { it, expect, describe }) => {
     expect(res.status).toBe(500);
     expect(await res.json()).toMatchObject({ status: 500, unhandled: true });
   });
+
+  describe("RFC 9457 problem details", () => {
+    it("default Accept header keeps the plain JSON error shape", async () => {
+      t.app.use(() => {
+        throw new HTTPError({
+          status: 422,
+          statusText: "Unprocessable",
+          message: "Invalid input",
+          type: "https://example.com/probs/invalid-input",
+          instance: "/errors/1",
+        });
+      });
+      const result = await t.fetch("/");
+      expect(result.status).toBe(422);
+      expect(result.headers.get("content-type")).toMatch("application/json");
+      expect(result.headers.get("content-type")).not.toMatch("problem+json");
+      const body = await result.json();
+      expect(body).toMatchObject({
+        status: 422,
+        statusText: "Unprocessable",
+        message: "Invalid input",
+      });
+      expect(body.type).toBeUndefined();
+      expect(body.detail).toBeUndefined();
+      expect(body.instance).toBeUndefined();
+    });
+
+    it("Accept: application/problem+json negotiates RFC 9457 shape", async () => {
+      t.app.use(() => {
+        throw new HTTPError({
+          status: 422,
+          statusText: "Unprocessable",
+          message: "Invalid input",
+          type: "https://example.com/probs/invalid-input",
+          instance: "/errors/1",
+          data: { field: "email" },
+          body: { topLevel: "works" },
+        });
+      });
+      const result = await t.fetch("/", { headers: { accept: "application/problem+json" } });
+      expect(result.status).toBe(422);
+      expect(result.statusText).toBe("Unprocessable");
+      expect(result.headers.get("content-type")).toMatch("application/problem+json");
+      expect(await result.json()).toMatchObject({
+        type: "https://example.com/probs/invalid-input",
+        title: "Unprocessable",
+        status: 422,
+        detail: "Invalid input",
+        instance: "/errors/1",
+        data: { field: "email" },
+        topLevel: "works",
+      });
+    });
+
+    it("body cannot overwrite reserved Problem Details members", async () => {
+      t.app.use(() => {
+        throw new HTTPError({
+          status: 422,
+          statusText: "Unprocessable",
+          message: "Invalid input",
+          type: "https://example.com/probs/invalid-input",
+          instance: "/errors/1",
+          data: { field: "email" },
+          body: {
+            type: "hijacked-type",
+            title: "hijacked-title",
+            status: 999,
+            detail: "hijacked-detail",
+            instance: "hijacked-instance",
+            unhandled: true,
+            data: "hijacked-data",
+            topLevel: "works",
+          },
+        });
+      });
+      const result = await t.fetch("/", { headers: { accept: "application/problem+json" } });
+      expect(result.status).toBe(422);
+      const body = await result.json();
+      expect(body).toMatchObject({
+        type: "https://example.com/probs/invalid-input",
+        title: "Unprocessable",
+        status: 422,
+        detail: "Invalid input",
+        instance: "/errors/1",
+        data: { field: "email" },
+        topLevel: "works",
+      });
+      expect(body.unhandled).not.toBe(true);
+    });
+
+    it("Accept header with q=0 for problem+json falls back to plain JSON", async () => {
+      t.app.use(() => {
+        throw new HTTPError({ status: 422, statusText: "Unprocessable" });
+      });
+      const result = await t.fetch("/", {
+        headers: { accept: "application/problem+json;q=0, application/json" },
+      });
+      expect(result.status).toBe(422);
+      expect(result.headers.get("content-type")).toMatch("application/json");
+      expect(result.headers.get("content-type")).not.toMatch("problem+json");
+    });
+
+    it("Accept header with mixed media ranges still negotiates problem+json", async () => {
+      t.app.use(() => {
+        throw new HTTPError({ status: 422, statusText: "Unprocessable" });
+      });
+      const result = await t.fetch("/", {
+        headers: { accept: "text/html, application/xhtml+xml;q=0.9, application/problem+json" },
+      });
+      expect(result.status).toBe(422);
+      expect(result.headers.get("content-type")).toMatch("application/problem+json");
+    });
+
+    it("Accept header casing is ignored when negotiating problem+json", async () => {
+      t.app.use(() => {
+        throw new HTTPError({ status: 422, statusText: "Unprocessable" });
+      });
+      const result = await t.fetch("/", { headers: { accept: "Application/Problem+JSON" } });
+      expect(result.status).toBe(422);
+      expect(result.headers.get("content-type")).toMatch("application/problem+json");
+    });
+
+    it("does not match non-exact problem+json media types by substring", async () => {
+      t.app.use(() => {
+        throw new HTTPError({ status: 422, statusText: "Unprocessable" });
+      });
+      const result = await t.fetch("/", {
+        headers: { accept: "application/problem+json+extra, application/vnd.problem+json" },
+      });
+      expect(result.status).toBe(422);
+      expect(result.headers.get("content-type")).toMatch("application/json");
+      expect(result.headers.get("content-type")).not.toMatch("problem+json");
+    });
+
+    it("unhandled errors negotiated as problem+json still hide detail/data", async () => {
+      t.app.use("/api/test", () => {
+        // @ts-expect-error
+        foo.bar = 123;
+      });
+      const result = await t.fetch("/api/test", {
+        headers: { accept: "application/problem+json" },
+      });
+      expect(result.status).toBe(500);
+      expect(result.headers.get("content-type")).toMatch("application/problem+json");
+      const body = await result.json();
+      expect(body).toMatchObject({
+        type: "about:blank",
+        title: "HTTPError",
+        status: 500,
+        unhandled: true,
+      });
+      expect(body.detail).toBeUndefined();
+      expect(body.data).toBeUndefined();
+      t.errors = [];
+    });
+  });
 });


### PR DESCRIPTION
Resolves #1384
Adds support for `RFC 9457` "Problem Details for HTTP APIs". When a request sends Accept: `application/problem+json`, `HTTPError` responses are now rendered in the standard `type/title/status/detail/instance` shape with an `application/problem+json` content type. Requests that don't ask for it get the exact same JSON error shape as before.
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added RFC 9457 Problem Details responses when clients request `application/problem+json`.
  - Problem responses include standardized fields such as type, title, status, detail, instance, and additional error data.
  - Added support for defining error `type` and `instance` values.
  - Exposed the `ProblemDetails` type and conversion support for HTTP errors.

- **Bug Fixes**
  - Sensitive details and data remain hidden for unhandled errors.
  - Improved content negotiation for media types, case sensitivity, and quality factors.
  - Existing JSON error responses remain available when Problem Details are not requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->