### PR TITLE
fix(request): compare methods case-insensitively in isMethod

### DIFF
--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -382,15 +382,21 @@ export function isMethod(
   expected: HTTPMethod | HTTPMethod[],
   allowHead?: boolean,
 ): boolean {
-  if (allowHead && event.req.method === "HEAD") {
+  // `expected` is typed uppercase, but a request method arrives as sent:
+  // `new Request()` only normalizes the fetch spec's fixed token list
+  // (DELETE/GET/HEAD/OPTIONS/POST/PUT), so `patch` stays `patch`. Comparing raw
+  // would report a mismatch for a method the request actually used.
+  const method = event.req.method.toUpperCase();
+
+  if (allowHead && method === "HEAD") {
     return true;
   }
 
   if (typeof expected === "string") {
-    if (event.req.method === expected) {
+    if (method === expected) {
       return true;
     }
-  } else if (expected.includes(event.req.method as HTTPMethod)) {
+  } else if (expected.includes(method as HTTPMethod)) {
     return true;
   }
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -4,6 +4,7 @@ import {
   redirectBack,
   withBase,
   assertMethod,
+  isMethod,
   getQuery,
   getRequestURL,
   getRequestHost,
@@ -550,6 +551,74 @@ describeMatrix("utils", (t, { it, describe, expect }) => {
       expect(new Set(res405.headers.get("Allow")?.split(/\s*,\s*/))).toEqual(
         new Set(["GET", "POST"]),
       );
+    });
+
+    // Regression: `assertMethod` compared a raw `event.req.method` against the
+    // expected method, so a request that spelled the method in any other case
+    // was rejected with a spurious 405. `new Request()` only normalizes the
+    // fetch spec's fixed token list (DELETE/GET/HEAD/OPTIONS/POST/PUT), so
+    // `patch` reaches handlers verbatim through `app.fetch()` on every runtime.
+    //
+    // `t.app.request()` instead of `t.fetch()`: in node mode the latter goes
+    // over a real socket, and llhttp rejects an unknown-cased method token with
+    // a 400 before h3 sees it. The in-process path is the one actually reachable.
+    for (const method of ["PATCH", "patch", "PaTcH"]) {
+      it(`allows a PATCH assertion for a request spelled ${method}`, async () => {
+        t.app.all("/patch", (event) => {
+          assertMethod(event, "PATCH");
+          return "ok";
+        });
+        const res = await t.app.request("http://localhost/patch", { method });
+        expect(res.status).toBe(200);
+        expect(await res.text()).toBe("ok");
+      });
+    }
+
+    it("still rejects a genuinely different method", async () => {
+      t.app.all("/patch", (event) => {
+        assertMethod(event, "PATCH");
+        return "ok";
+      });
+      for (const method of ["POST", "post"]) {
+        const res = await t.app.request("http://localhost/patch", { method });
+        expect(res.status, method).toBe(405);
+      }
+    });
+  });
+
+  describe("isMethod", () => {
+    for (const method of ["QUERY", "query", "QuErY"]) {
+      it(`matches a QUERY expectation for a request spelled ${method}`, async () => {
+        t.app.all("/query", (event) => String(isMethod(event, "QUERY")));
+        const res = await t.app.request("http://localhost/query", { method });
+        expect(await res.text()).toBe("true");
+      });
+    }
+
+    it("matches a lowercase method within a list of expected methods", async () => {
+      t.app.all("/list", (event) => String(isMethod(event, ["PATCH", "QUERY"])));
+      const res = await t.app.request("http://localhost/list", { method: "patch" });
+      expect(await res.text()).toBe("true");
+    });
+
+    it("allows an unnormalized `head` token when allowHead is set", async () => {
+      let matched: boolean | undefined;
+      t.app.all("/head", (event) => {
+        matched = isMethod(event, "GET", true);
+        return "ok";
+      });
+      // `new Request()` normalizes `head` to `HEAD`; force the token back to
+      // model a runtime that hands h3 the method as it arrived on the wire.
+      const req = new Request("http://localhost/head", { method: "HEAD" });
+      Object.defineProperty(req, "method", { value: "head", configurable: true });
+      await t.app.request(req);
+      expect(matched).toBe(true);
+    });
+
+    it("does not match a different method", async () => {
+      t.app.all("/other", (event) => String(isMethod(event, "PATCH")));
+      const res = await t.app.request("http://localhost/other", { method: "post" });
+      expect(await res.text()).toBe("false");
     });
   });
 


### PR DESCRIPTION
### Problem

`isMethod()` — and `assertMethod()`, which delegates to it — compared
`event.req.method` raw against the expected method.

`new Request()` only normalizes the fetch spec's fixed token list
(DELETE/GET/HEAD/OPTIONS/POST/PUT). `PATCH` and `QUERY` are both in h3's
`HTTPMethod` union and neither is on that list, so `patch` stays `patch` and
reaches handlers verbatim through `app.fetch()` on every runtime.

The result is a wrong answer for the method the request actually used:

```ts
app.all("/x", (event) => {
  assertMethod(event, "PATCH"); // throws 405 on a legitimate PATCH
  return "ok";
});

await app.request(new Request("http://localhost/x", { method: "patch" }));
// -> 405, and isMethod(event, "PATCH") silently returns false
```

### Fix

Uppercase `event.req.method` once at the top of `isMethod`, exactly as
850f25c ("fix(middleware): compare method scopes case-insensitively") did for
method-scoped middleware. `assertMethod` needs no change — it goes through
`isMethod`.

This makes `request.ts` consistent with the rest of the codebase, which already
treats a lowercase method as valid input: `removeRoute()` types its parameter
`HTTPMethod | Lowercase<HTTPMethod> | ""` and uppercases, and `proxy()`
uppercases too. `request.ts` was the last holdout.

### Tests

Added regression coverage in `test/utils.test.ts` alongside the existing
`assertMethod` tests, covering `PATCH`/`patch`/`PaTcH` and
`QUERY`/`query`/`QuErY`, the array form, the `allowHead` path with an
unnormalized `head` token, and negative controls so a genuinely different
method still 405s / returns `false`.

They use in-process `t.app.request()` rather than `t.fetch()` for the same
reason the middleware regression test does: in node mode `t.fetch()` goes over
a real socket and llhttp rejects the odd-cased token with a 400 before h3 sees
it.

- Before the fix: 12 failures (6 assertions × the web/node matrix), with the
  uppercase variants and the negative controls passing.
- After the fix: `pnpm vitest run test/utils.test.ts` → 170 passed, 2 skipped,
  no type errors.

`oxlint` and `tsc --noEmit` are clean. Two unrelated failures in
`test/unit/event.test.ts` and `test/unit/route-normalize.test.ts` (percent-escape
normalization) reproduce identically on a clean `main` on my machine and are not
caused by this change.

### Note

Assisted by Claude Opus 5; every change was reviewed and verified locally by me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP method matching is now case-insensitive, improving compatibility with differently cased request methods.
  * Existing `HEAD` handling and method-list matching continue to work as expected.

* **Tests**
  * Added coverage for mixed-case standard and custom methods, method lists, mismatches, and `HEAD` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->