### PR TITLE
ci: harden workflows

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -5,11 +5,11 @@ jobs:
   autofix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - run: npm i -fg corepack && corepack enable
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with: { node-version: lts/*, cache: pnpm }
       - run: pnpm install
       - run: pnpm fmt
-      - uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27
+      - uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27 # v1.3.2
         with: { commit-message: "chore: apply automated updates" }

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -9,7 +9,7 @@ on:
 
 permissions: {}
 
-concurrency: { group: autofix-$, { { github.ref } }, cancel-in-progress: true }
+concurrency: { group: "autofix-${{ github.ref }}", cancel-in-progress: true }
 
 jobs:
   autofix:

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,14 +1,30 @@
 name: autofix.ci
-on: { push: {}, pull_request: {} }
-permissions: { contents: read }
+
+# `pull_request` already covers PR branches. Without the `push` branch filter,
+# every push to a PR branch ran this workflow twice for the same commit, the two
+# runs racing to push a fixup commit to the same branch.
+on:
+  push: { branches: [main] }
+  pull_request: {}
+
+permissions: {}
+
+concurrency: { group: autofix-$, { { github.ref } }, cancel-in-progress: true }
+
 jobs:
   autofix:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # `autofix-ci/action` commits through its own GitHub App, not `GITHUB_TOKEN`.
+    permissions: { contents: read }
     steps:
+      # No `persist-credentials: false` here, unlike the other workflows:
+      # `autofix-ci/action` runs `git fetch origin <pull_request.head.sha>` when
+      # it has fixes to apply, which needs the checkout credentials.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - run: npm i -fg corepack && corepack enable
+      - run: npm i -fg corepack@0.35.0 && corepack enable
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with: { node-version: lts/*, cache: pnpm }
+        with: { node-version-file: .nvmrc, cache: pnpm }
       - run: pnpm install
       - run: pnpm fmt
       - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -5,11 +5,11 @@ jobs:
   autofix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: npm i -fg corepack && corepack enable
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with: { node-version: lts/*, cache: pnpm }
       - run: pnpm install
       - run: pnpm fmt
-      - uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27 # v1.3.2
+      - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4
         with: { commit-message: "chore: apply automated updates" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions: { contents: read }
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: npm i -g --force corepack && corepack enable
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with: { node-version: lts/*, cache: pnpm }
       - run: pnpm install
       - run: pnpm lint
@@ -27,11 +27,14 @@ jobs:
     permissions: { contents: read }
     timeout-minutes: 10
     needs: tests
+    # Preview publishing must never gate the nightly npm release in `publish.yml`,
+    # which is triggered by the `ci` workflow concluding successfully.
+    continue-on-error: true
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { fetch-depth: 0 }
       - run: npm i -fg corepack && corepack enable
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with: { node-version: lts/*, cache: "pnpm" }
       - run: pnpm install
       - run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
         with: { node-version: lts/*, cache: "pnpm" }
       - run: pnpm install
       - run: pnpm build
-      - run: pnpm exec pkg-pr-new publish || true
+      - run: pnpm exec pkg-pr-new publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,16 +8,18 @@ on:
 
 permissions: {}
 
-# Superseded PR runs are wasted work. Pushes to `main` are never cancelled:
-# `publish.yml` triggers off this workflow's conclusion, and a cancelled run
-# concludes `cancelled`, which would silently skip that commit's nightly.
+# Superseded PR runs are wasted work. Pushes to `main` each get their own group
+# instead of sharing `ci-refs/heads/main`: a group holds at most one *pending*
+# run, so a third push would cancel the second, and `publish.yml` skips any ci
+# run that concludes `cancelled` — losing that commit's nightly and its verdict.
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions: { contents: read }
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -30,8 +32,14 @@ jobs:
       - run: pnpm typecheck
       - run: pnpm build
       - run: pnpm vitest --coverage
+      # `version` is what actually gets pinned here: the action downloads the
+      # Codecov CLI at runtime and defaults to `latest`, so pinning the action
+      # SHA alone pins none of the code that runs.
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        with: { token: "${{ secrets.CODECOV_TOKEN }}", files: ./coverage/clover.xml }
+        with:
+          token: "${{ secrets.CODECOV_TOKEN }}"
+          files: ./coverage/clover.xml
+          version: v11.3.1
   publish-pkg-pr-new:
     runs-on: ubuntu-latest
     permissions: { contents: read }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,45 +4,35 @@ on:
   push: { branches: [main] }
   pull_request: { branches: [main] }
 
+permissions: {}
+
 jobs:
   tests:
     runs-on: ubuntu-latest
+    permissions: { contents: read }
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - run: npm i -g --force corepack && corepack enable
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with: { node-version: lts/*, cache: pnpm }
       - run: pnpm install
       - run: pnpm lint
       - run: pnpm typecheck
       - run: pnpm build
       - run: pnpm vitest --coverage
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with: { token: "${{ secrets.CODECOV_TOKEN }}" }
-  publish:
-    runs-on: ubuntu-latest
-    permissions: { id-token: write, contents: read }
-    needs: tests
-    if: contains('refs/heads/main', github.ref) && github.event_name == 'push'
-    steps:
-      - uses: actions/checkout@v5
-        with: { fetch-depth: 0 }
-      - run: npm i -fg corepack && corepack enable
-      - uses: actions/setup-node@v5
-        with: { node-version: lts/*, cache: "pnpm" }
-      - run: pnpm install
-      - run: pnpm changelogen --bump -r 2.0.0 --canary nightly
-      - run: npm i -g npm@latest && npm publish --tag latest
   publish-pkg-pr-new:
     runs-on: ubuntu-latest
+    permissions: { contents: read }
     timeout-minutes: 10
     needs: tests
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with: { fetch-depth: 0 }
       - run: npm i -fg corepack && corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with: { node-version: lts/*, cache: "pnpm" }
       - run: pnpm install
       - run: pnpm build
-      - run: pnpm dlx pkg-pr-new publish || true
+      - run: pnpm exec pkg-pr-new publish || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+# `publish.yml` triggers off this workflow by NAME (`workflows: [ci]`), not by
+# filename — renaming it stops nightly publishing.
 name: ci
 
 on:
@@ -6,36 +8,46 @@ on:
 
 permissions: {}
 
+# Superseded PR runs are wasted work. Pushes to `main` are never cancelled:
+# `publish.yml` triggers off this workflow's conclusion, and a cancelled run
+# concludes `cancelled`, which would silently skip that commit's nightly.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   tests:
     runs-on: ubuntu-latest
     permissions: { contents: read }
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - run: npm i -g --force corepack && corepack enable
+        with: { persist-credentials: false }
+      - run: npm i -fg corepack@0.35.0 && corepack enable
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with: { node-version: lts/*, cache: pnpm }
+        with: { node-version-file: .nvmrc, cache: pnpm }
       - run: pnpm install
       - run: pnpm lint
       - run: pnpm typecheck
       - run: pnpm build
       - run: pnpm vitest --coverage
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        with: { token: "${{ secrets.CODECOV_TOKEN }}" }
+        with: { token: "${{ secrets.CODECOV_TOKEN }}", files: ./coverage/clover.xml }
   publish-pkg-pr-new:
     runs-on: ubuntu-latest
     permissions: { contents: read }
     timeout-minutes: 10
     needs: tests
-    # Preview publishing must never gate the nightly npm release in `publish.yml`,
-    # which is triggered by the `ci` workflow concluding successfully.
-    continue-on-error: true
+    # PRs only. `publish.yml` fires when this whole workflow concludes, so any
+    # job running here on a `main` push delays the nightly npm release by its
+    # own runtime — up to `timeout-minutes` if pkg.pr.new hangs.
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with: { fetch-depth: 0 }
-      - run: npm i -fg corepack && corepack enable
+        with: { persist-credentials: false }
+      - run: npm i -fg corepack@0.35.0 && corepack enable
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with: { node-version: lts/*, cache: "pnpm" }
+        with: { node-version-file: .nvmrc, cache: pnpm }
       - run: pnpm install
-      - run: pnpm build
+      # No build step: `pkg-pr-new` packs with `npm pack`, which runs `prepack`
+      # (`pnpm build`) itself.
       - run: pnpm exec pkg-pr-new publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,9 @@ permissions: {}
 jobs:
   publish:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Generous: this job has no dependency cache (see below), so every nightly
+    # pays a cold `pnpm install` plus a full `prepack` build inside `npm publish`.
+    timeout-minutes: 20
     # Nightly releases must not race: two quick pushes to `main` would otherwise
     # both bump and publish. Declared on the job, not the workflow: job-level
     # concurrency is evaluated after `if:`, so runs that skip (failed `ci`, fork
@@ -56,9 +58,11 @@ jobs:
           ref: "${{ github.event.workflow_run.head_sha }}"
       - run: npm i -fg corepack@0.35.0 && corepack enable
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        # setup-node's docs advise disabling the package-manager cache in
-        # privileged jobs: a poisoned store would execute with the OIDC token
-        # live. This job installs once per nightly, so the cache buys seconds.
+        # No `cache: pnpm` here, unlike `ci.yml`: the store is written by
+        # unprivileged jobs, and a poisoned one would execute with the OIDC
+        # token live. `package-manager-cache: false` opts out of setup-node's
+        # implicit cache too (npm-only today, but `packageManager` may change).
+        # Costs one cold install per nightly, which the timeout above allows for.
         with: { node-version-file: .nvmrc, package-manager-cache: false }
       - run: pnpm install
       - run: pnpm changelogen --bump -r 2.0.0 --canary nightly
@@ -68,3 +72,25 @@ jobs:
       # if the Node line ever moves to one bundling an older npm.
       - run: printf '11.5.1\n%s\n' "$(npm --version)" | sort -VC
       - run: npm publish --tag latest
+
+  # `publish` skipping is normally correct (failed ci, fork PR, re-run of an old
+  # run) and needs no noise. The one case worth surfacing is a commit that passed
+  # ci but was overtaken on `main` before its publish run started: that commit
+  # gets no nightly, and nothing else reports it.
+  report-skipped:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    if: >-
+      github.repository == 'h3js/h3' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.head_sha != github.sha
+    steps:
+      - run: |
+          echo "::warning title=Nightly skipped::${SKIPPED_SHA} passed ci but is no longer the tip of main (${TIP_SHA}); no nightly was published for it."
+        env:
+          SKIPPED_SHA: "${{ github.event.workflow_run.head_sha }}"
+          TIP_SHA: "${{ github.sha }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: publish
+
+# Split from `ci.yml` so npm trusted publishing (OIDC) trusts a workflow file
+# that contains nothing but the publish job. `workflow_run` is used instead of
+# `workflow_call` on purpose: npm validates the entry-point workflow filename,
+# so a reusable workflow would keep the trust bound to `ci.yml`.
+#
+# The npm trusted publisher must be configured with `publish.yml`.
+on:
+  workflow_run:
+    workflows: [ci]
+    types: [completed]
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions: { id-token: write, contents: read }
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push'
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with: { fetch-depth: 0, ref: "${{ github.event.workflow_run.head_sha }}" }
+      - run: npm i -fg corepack && corepack enable
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with: { node-version: lts/*, cache: "pnpm" }
+      - run: pnpm install
+      - run: pnpm changelogen --bump -r 2.0.0 --canary nightly
+      - run: npm i -g npm@latest && npm publish --tag latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,29 +8,63 @@ name: publish
 # The npm trusted publisher must be configured with `publish.yml`.
 on:
   workflow_run:
+    # Matches by workflow *name* (`name: ci`), not filename — renaming it
+    # silently stops all nightly publishing.
     workflows: [ci]
     types: [completed]
+    # Not a security control: this filters the *triggering* run's `head_branch`,
+    # which a fork PR chooses, so a fork branch named `main` matches. The job
+    # `if:` below is the gate.
     branches: [main]
 
 permissions: {}
 
-# Nightly releases must not race: two quick pushes to `main` would otherwise
-# both bump and `npm publish --tag latest`.
-concurrency: { group: publish, cancel-in-progress: false }
-
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Nightly releases must not race: two quick pushes to `main` would otherwise
+    # both bump and publish. Declared on the job, not the workflow: job-level
+    # concurrency is evaluated after `if:`, so runs that skip (failed `ci`, fork
+    # PRs, superseded commits) never occupy the group and cannot evict a pending
+    # real release.
+    concurrency: { group: publish, cancel-in-progress: false }
     permissions: { id-token: write, contents: read }
+    # Every clause is load-bearing:
+    # - `event == 'push'` + `head_repository` + `head_branch` keep fork PRs out.
+    #   This job holds `id-token: write`, and `pnpm install`/`prepack` would run
+    #   the checked-out commit's code.
+    # - `head_sha == github.sha` requires the tested commit to still be the tip
+    #   of `main`. npm builds its provenance statement from the runner's
+    #   `GITHUB_SHA` (main's tip under `workflow_run`), not from the `ref:`
+    #   checked out below, so publishing a non-tip commit would attest the wrong
+    #   source. It also stops a re-run of an old `ci` run from republishing
+    #   stale code as the newest nightly.
     if: >-
+      github.repository == 'h3js/h3' &&
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push'
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.head_sha == github.sha
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with: { fetch-depth: 0, ref: "${{ github.event.workflow_run.head_sha }}" }
-      - run: npm i -fg corepack && corepack enable
+        with:
+          # Required: `changelogen --bump` walks tags and history.
+          fetch-depth: 0
+          persist-credentials: false
+          ref: "${{ github.event.workflow_run.head_sha }}"
+      - run: npm i -fg corepack@0.35.0 && corepack enable
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with: { node-version: lts/*, cache: "pnpm" }
+        # setup-node's docs advise disabling the package-manager cache in
+        # privileged jobs: a poisoned store would execute with the OIDC token
+        # live. This job installs once per nightly, so the cache buys seconds.
+        with: { node-version-file: .nvmrc, package-manager-cache: false }
       - run: pnpm install
       - run: pnpm changelogen --bump -r 2.0.0 --canary nightly
-      - run: npm i -g npm@latest && npm publish --tag latest
+      # Trusted publishing (OIDC) needs npm >= 11.5.1, which the runner's bundled
+      # npm satisfies today (Node 24.6+ ships 11.17.0) — so no global npm install
+      # is needed. Assert it rather than failing later with an opaque auth error
+      # if the Node line ever moves to one bundling an older npm.
+      - run: printf '11.5.1\n%s\n' "$(npm --version)" | sort -VC
+      - run: npm publish --tag latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,10 @@ on:
 
 permissions: {}
 
+# Nightly releases must not race: two quick pushes to `main` would otherwise
+# both bump and `npm publish --tag latest`.
+concurrency: { group: publish, cancel-in-progress: false }
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -22,10 +26,10 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push'
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { fetch-depth: 0, ref: "${{ github.event.workflow_run.head_sha }}" }
       - run: npm i -fg corepack && corepack enable
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with: { node-version: lts/*, cache: "pnpm" }
       - run: pnpm install
       - run: pnpm changelogen --bump -r 2.0.0 --canary nightly

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "oxc-parser": "^0.144.0",
     "oxfmt": "^0.63.0",
     "oxlint": "^1.78.0",
+    "pkg-pr-new": "^0.0.88",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "typescript": "^7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       oxlint:
         specifier: ^1.78.0
         version: 1.78.0
+      pkg-pr-new:
+        specifier: ^0.0.88
+        version: 0.0.88
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -2030,6 +2033,10 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
+  pkg-pr-new@0.0.88:
+    resolution: {integrity: sha512-Xc6PMJ2gher0WZP+rtjefFk26hIb7V1PTLL30bmy1Z2vsRmSvqiss7Ag1XUdyplTGYzIlFNJp4L3vMNmK44N6g==}
+    hasBin: true
+
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
@@ -3841,6 +3848,8 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.5: {}
+
+  pkg-pr-new@0.0.88: {}
 
   pkg-types@1.3.1:
     dependencies:


### PR DESCRIPTION
## ⚠️ Action required before merging

The npm **trusted publisher** must be repointed from `ci.yml` to `publish.yml` — on the **`h3-nightly`** package, not `h3` (`changelogen --canary nightly` renames the package before publishing).

This is confirmed by the live provenance attestation on the newest nightly, which records `path: .github/workflows/ci.yml`. If this merges first, every nightly fails OIDC — and because publishing now lives in its own workflow, that failure appears on no PR and no commit check.

---

The core issue: third-party actions on mutable major tags were running in the same workflow file that npm trusts for OIDC publishing, and no job declared `permissions:`, so every job inherited the repo default `GITHUB_TOKEN` scope.

### Pin every action, and everything else that is fetched and executed

A major tag like `@v3` is mutable — whoever controls it executes arbitrary code in our runner, and `codecov/codecov-action@v3` was also being handed `secrets.CODECOV_TOKEN`.

| Action | Was | Now |
| --- | --- | --- |
| `actions/checkout` | `@v5` / `@v6` | `3d3c42e` (v7.0.1) |
| `actions/setup-node` | `@v5` / `@v6` | `8207627` (v7.0.0) |
| `codecov/codecov-action` | `@v3` | `fb8b358` (v7.0.0) |
| `autofix-ci/action` | `635ffb0` (v1.3.2) | `c5b2d67` (v1.3.4) |

The `# vX.Y.Z` comments are the format renovate reads, so `unjs/renovate-config` (which extends `helpers:pinGitHubActionDigests`) keeps both the SHA and the comment current. The codecov bump from v3 is not cosmetic — v3 rides the retired Codecov uploader.

Pinning `uses:` is only half of it. Also closed:

- `npm i -g npm@latest` in the publish job — an unpinned install running as the next command in the one job holding `id-token: write`. It bought nothing: the runner's bundled npm is already past the 11.5.1 that trusted publishing requires, so the job now asserts that floor instead of reinstalling npm.
- `npm i -fg corepack` → `corepack@0.35.0`, in all four call sites.
- `pnpm dlx pkg-pr-new` → a lockfile-pinned devDependency invoked with `pnpm exec`, which is what [pkg.pr.new's own docs recommend](https://github.com/stackblitz-labs/pkg.pr.new#publish-packages). It also caches — `dlx` re-downloaded it every run.
- `persist-credentials: false` on every checkout, so the token is not left in `.git/config` where the next step's `pnpm install` lifecycle scripts can read it. Not in `autofix.yml`, where the action fetches the PR head from origin and needs it.

### Least-privilege permissions

`permissions: {}` at workflow level in all three files, with explicit grants per job (`contents: read`, plus `id-token: write` only on `publish`). Notably `tests` — the job that runs the codecov action — now provably cannot mint an OIDC token.

The publish job also sets `package-manager-cache: false`, per setup-node's own guidance for privileged jobs: a poisoned store would execute with the OIDC token live. It installs once per nightly, so the cache buys seconds.

### Split `publish` into its own entry-point workflow

npm trusted publishing trusts a **workflow file**, not a job. With `publish` living in `ci.yml`, everything else in that file sat inside the trust boundary.

This uses `workflow_run`, not `workflow_call`: [npm validates the entry-point workflow filename](https://docs.npmjs.com/trusted-publishers/), so a reusable workflow would have kept the trust bound to `ci.yml` and gained nothing.

That trigger needs care, and the gating is deliberate:

- **`on.workflow_run.branches: [main]` is not a security control.** It filters the *triggering* run's `head_branch`, which a fork PR chooses — a fork branch named `main` matches it.
- The job `if:` is the gate: `event == 'push'` **and** `head_repository.full_name == github.repository` **and** `head_branch == 'main'`, plus a `github.repository` guard so a fork with actions enabled does not attempt to publish.
- **`head_sha == github.sha`** requires the tested commit to still be the tip of `main`. npm builds its provenance statement from the runner's `GITHUB_SHA` — main's tip under `workflow_run` — not from the `ref:` being checked out, so publishing a superseded commit would sign an attestation naming a commit that was never built. The same clause stops a re-run of an old `ci` run from republishing stale code as the newest nightly.
- `concurrency` is declared on the **job**, not the workflow, because job-level groups are evaluated after `if:` — skipped runs never occupy the group and cannot evict a pending real release.
- `timeout-minutes: 10`, so a hung publish cannot hold that non-cancelling group for the 360-minute default.

Checkout pins to `github.event.workflow_run.head_sha` so the publish builds exactly the commit that was tested, and `fetch-depth: 0` stays because `changelogen --bump` walks tags and history.

### Keep `ci`'s conclusion meaningful

`publish.yml` fires when the **whole** `ci` run concludes, which makes every job in `ci.yml` a release gate. So the preview publish now runs on pull requests only:

- On a `main` push it was serialising ahead of the nightly — up to its full 10-minute timeout if pkg.pr.new hung — even though its result no longer mattered.
- `continue-on-error` would have re-masked at run level what 635812c unmasked at step level. Dropped: a failed preview is now visibly red on the PR.

`ci.yml` also gets a concurrency group that cancels only for pull requests — a cancelled run on `main` concludes `cancelled`, which would silently skip that commit's nightly.

Two consequences worth stating: a commit superseded before its `ci` finishes gets no nightly (the tip does), and a cancelled `ci` run on `main` means no nightly for that commit.

### Smaller cleanups

- `autofix.yml` ran twice for every PR-branch push — `push: {}` and `pull_request: {}` both matched the same commit, and the two runs raced to push a fixup commit to the same branch. Narrowed to `push: { branches: [main] }`, plus a concurrency group and a timeout.
- Node version now comes from `.nvmrc`, which already existed and nothing read.
- Dropped `fetch-depth: 0` from the preview job (pkg-pr-new only runs `git rev-parse HEAD`) and its `pnpm build` step (`npm pack` runs `prepack`, which builds).
- Pinned the coverage file for codecov: `vitest.config.mjs` sets no reporters, so the defaults emit `clover.xml` and no lcov, and a discovery miss after the v3 → v7 jump would be silent.
- `publish.yml` matches `ci` by workflow **name**, not filename; both files now say so.

### Deliberately not changed

- **Tokenless Codecov OIDC.** It needs `id-token: write` on `tests`. Arguably the split makes this safe — an OIDC token minted in `ci.yml` cannot satisfy a publisher bound to `publish.yml` — but it needs verification on the Codecov side, so it is left for a follow-up.
- **A `.github/actions/setup` composite action.** The four-copy bootstrap is normalised here, but no unjs/h3js repo uses that pattern yet; worth its own PR.
- **Binding the trusted publisher to a GitHub Environment.** npm supports it and it survives someone later adding a job to `publish.yml`, but it is an npm-side config change on top of an already-required one.
- **`packageManager` integrity hash.** `corepack use pnpm@11.15.1` would add it; separate change.
- **`--frozen-lockfile` / `--ignore-scripts`.** Already covered: pnpm enables frozen-lockfile under `CI=true`, and `pnpm-workspace.yaml` gates dependency build scripts via `allowBuilds`, with nothing allowed to build.
- **`h3` itself is still published by hand** through the `release` script, with a long-lived token and no provenance. Only the nightly channel is hardened here.

### Verification

All four SHA pins dereference to the tags named in the comments. `publish.yml` cannot be exercised before merge — `workflow_run` workflows only run from the default branch — so its first execution is a live publish; the gating clauses above are the reason that is bounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved automation security with restricted permissions and verified action versions.
  - Updated continuous integration for more reliable testing and package validation.
  - Added package previews for reviewing pull request changes before release.
  - Added automated nightly canary package releases after successful main-branch builds.
  - Improved release consistency with automatic canary versioning and secure publishing authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->