### PR TITLE
fix(cli): use fileURLToPath for docs directory resolution

### DIFF
--- a/bin/h3.mjs
+++ b/bin/h3.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { main } from "srvx/cli";
 import meta from "../package.json" with { type: "json" };
 
@@ -16,9 +17,9 @@ if (process.argv[2] === "docs") {
     } catch {}
   }) || ["npm", "x"];
   const runnerCmd = [runner[0], runner[1]].filter(Boolean).join(" ");
-  const docsDir = new URL("../dist/docs", import.meta.url).pathname;
+  const docsDir = fileURLToPath(new URL("../dist/docs", import.meta.url));
   const args = process.argv.slice(3).join(" ");
-  execSync(`${runnerCmd} mdzilla ${docsDir}${args ? ` ${args}` : ""}`, { stdio: "inherit" });
+  execSync(`${runnerCmd} mdzilla "${docsDir}"${args ? ` ${args}` : ""}`, { stdio: "inherit" });
   process.exit(0);
 }
 if (process.argv.includes("--help") || process.argv.includes("-h")) {

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+describe("CLI docs path resolution", () => {
+  it("resolves docs directory using fileURLToPath instead of URL.pathname", () => {
+    const cliSource = readFileSync(new URL("../../bin/h3.mjs", import.meta.url), "utf8");
+    expect(cliSource).toContain("fileURLToPath(new URL(\"../dist/docs\", import.meta.url))");
+  });
+
+  it("handles paths with spaces when using fileURLToPath", () => {
+    const importMetaUrl = "file:///path%20with%20spaces/bin/h3.mjs";
+    const docsDir = fileURLToPath(new URL("../dist/docs", importMetaUrl));
+    expect(docsDir).toBe("/path with spaces/dist/docs");
+  });
+});


### PR DESCRIPTION
## Problem

Running `h3 docs` fails on Windows and on install paths containing spaces or percent-encoded characters, reporting `ENOENT: no such file or directory`.

## Root Cause

`bin/h3.mjs` constructed the docs path via `new URL("../dist/docs", import.meta.url).pathname`. On Windows, this keeps a leading slash before the drive letter (`/C:/...`), and on paths with spaces it leaves percent-encoded `%20` sequences unescaped and unquoted in the `execSync` command string.

## Fix

- Use `fileURLToPath` to resolve `import.meta.url` to a native filesystem path.
- Quote the `docsDir` argument in `execSync` to safely handle paths containing spaces.

## Testing

- Added unit test in `test/unit/cli.test.ts` verifying `fileURLToPath` resolution for paths containing spaces.
- Verified all unit tests and lint checks pass cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation command handling for paths containing spaces and special characters.
  * Ensured documentation files are located correctly across environments.

* **Tests**
  * Added coverage for documentation path resolution, including paths with spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->