### PR TITLE
feat(session): support autoCreate option in SessionConfig

### DIFF
--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -93,6 +93,12 @@ export interface SessionConfig {
   crypto?: Crypto;
   /** Default is Crypto.randomUUID */
   generateId?: () => string;
+  /**
+   * Automatically persist an initial empty session when `getSession` is called on a request without one.
+   *
+   * @default true
+   */
+  autoCreate?: boolean;
 }
 
 /**
@@ -203,7 +209,9 @@ export async function getSession<T extends SessionData = SessionData>(
   if (!session.id) {
     session.id = config.generateId?.() ?? (config.crypto || crypto).randomUUID();
     session.createdAt = Date.now();
-    await updateSession(event, config);
+    if (config.autoCreate !== false) {
+      await updateSession(event, config);
+    }
   }
 
   return session;

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -1,6 +1,6 @@
 import type { SessionConfig } from "../src/utils/session.ts";
 import { beforeEach, vi } from "vitest";
-import { useSession, clearSession, readBody, H3, HTTPError } from "../src/index.ts";
+import { useSession, getSession, clearSession, readBody, H3, HTTPError } from "../src/index.ts";
 import { seal, unseal, defaults as sealDefaults } from "../src/utils/internal/iron-crypto.ts";
 import { describeMatrix } from "./_setup.ts";
 
@@ -35,6 +35,32 @@ describeMatrix("session", (t, { it, expect }) => {
     expect(await result.json()).toMatchObject({
       session: { id: "1", data: {} },
     });
+  });
+
+  it("does not write session cookie when autoCreate is false until updated", async () => {
+    t.app.get("/read-only-session", async (event) => {
+      const session = await getSession(event, {
+        ...sessionConfig,
+        autoCreate: false,
+      });
+      return { id: session.id, data: session.data };
+    });
+
+    const res1 = await t.fetch("/read-only-session");
+    expect(res1.headers.getSetCookie()).toHaveLength(0);
+    expect(await res1.json()).toMatchObject({ data: {} });
+
+    t.app.post("/write-session", async (event) => {
+      const session = await useSession(event, {
+        ...sessionConfig,
+        autoCreate: false,
+      });
+      await session.update({ user: "alice" });
+      return { ok: true };
+    });
+
+    const res2 = await t.fetch("/write-session", { method: "POST" });
+    expect(res2.headers.getSetCookie()).toHaveLength(1);
   });
 
   it("sets SameSite=Lax by default", async () => {


### PR DESCRIPTION
## Problem

`getSession()` previously unconditionally persisted a newly initialized empty session (writing a `Set-Cookie` header) whenever no session existed on the incoming request. For read-only callers (such as authentication or authorization middleware checking for an active session on anonymous requests), this caused unwanted empty session cookies to be issued to all visitors.

## Solution

- Added `autoCreate?: boolean` to `SessionConfig` (defaulting to `true` to preserve backwards compatibility).
- When `autoCreate: false`, `getSession()` initializes an in-memory session object for the current request without eagerly calling `updateSession()` or writing `Set-Cookie`.
- When session data is subsequently updated (via `updateSession` or `sessionManager.update`), the session cookie is sealed and written as expected.

## Testing

- Added unit tests in `test/session.test.ts` verifying that `autoCreate: false` suppresses empty session cookie emission on read-only requests and writes cookies upon update.
- Verified all 46 session tests and type checks pass cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to prevent automatic creation of empty sessions when retrieving session data.
  * Sessions are now created only when explicitly updated, helping read-only requests avoid unnecessary session cookies.

* **Bug Fixes**
  * Prevented empty session cookies from being written during read-only session access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->