### PR TITLE
docs(websocket): fix broken route-rules guide link

### DIFF
--- a/docs/1.guide/901.advanced/2.websocket.md
+++ b/docs/1.guide/901.advanced/2.websocket.md
@@ -33,7 +33,7 @@ serve(app, {
 
 `defineWebSocketHandler()` attaches the hooks to the **request** (CrossWS reads them back with `getWebSocketHooks(request)`, keyed by `Symbol.for("crossws.hooks")`), and answers the upgrade request with `426 Upgrade Required` for anything that is not a WebSocket client.
 
-They are attached to the request rather than to that response because a `Response` gets rebuilt on its way out of an app — merging a header staged by a [route rule](/guide/api/utils/route-rules) or CORS middleware, or any middleware doing `new Response(res.body, res)` — and a rebuilt response carries none of the original's own properties. The response also exposes the hooks as `res.crossws` for convenience, but only when nothing rebuilt it; if you write a custom `resolve`, read the request instead:
+They are attached to the request rather than to that response because a `Response` gets rebuilt on its way out of an app — merging a header staged by a [route rule](/guide/rules) or CORS middleware, or any middleware doing `new Response(res.body, res)` — and a rebuilt response carries none of the original's own properties. The response also exposes the hooks as `res.crossws` for convenience, but only when nothing rebuilt it; if you write a custom `resolve`, read the request instead:
 
 ```js
 import { getWebSocketHooks } from "crossws";


### PR DESCRIPTION
### Summary

Updates the route rules guide link in `docs/1.guide/901.advanced/2.websocket.md` from `/guide/api/utils/route-rules` to `/guide/rules`.