### PR TITLE
types(handler): expose validated query/headers on validated hander type

### DIFF
--- a/src/h3.ts
+++ b/src/h3.ts
@@ -247,7 +247,7 @@ export const H3 = /* @__PURE__ */ (() => {
       return this;
     }
 
-    all(route: string, handler: EventHandler, opts?: RouteOptions) {
+    all(route: string, handler: HTTPHandler, opts?: RouteOptions) {
       return this.on("", route, handler, opts);
     }
 
@@ -292,7 +292,7 @@ export const H3 = /* @__PURE__ */ (() => {
     (H3Core as any).prototype[method.toLowerCase()] = function (
       this: H3Type,
       route: string,
-      handler: EventHandler,
+      handler: HTTPHandler,
       opts?: RouteOptions,
     ) {
       return this.on(method, route, handler, opts);

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -14,7 +14,6 @@ import type {
   HTTPHandler,
 } from "./types/handler.ts";
 import type { StandardSchemaV1, InferOutput } from "./utils/internal/standard-schema.ts";
-import type { TypedRequest } from "fetchdts";
 import { NoHandler, type H3Core } from "./h3.ts";
 import { validatedRequest, validatedURL, type OnValidateError } from "./utils/internal/validate.ts";
 
@@ -54,6 +53,16 @@ type StringHeaders<T> = {
   [K in keyof T]: Extract<T[K], string>;
 };
 
+type ValidatedRequest<
+  RequestBody extends StandardSchemaV1,
+  RequestHeaders extends StandardSchemaV1,
+  RequestQuery extends StandardSchemaV1,
+> = {
+  body: InferOutput<RequestBody>;
+  headers: StringHeaders<InferOutput<RequestHeaders>>;
+  query: StringHeaders<InferOutput<RequestQuery>>;
+};
+
 /**
  * @experimental defineValidatedHandler is an experimental feature and API may change.
  */
@@ -70,15 +79,9 @@ export function defineValidatedHandler<
       query?: RequestQuery;
       onError?: OnValidateError;
     };
-    handler: EventHandler<
-      {
-        body: InferOutput<RequestBody>;
-        query: StringHeaders<InferOutput<RequestQuery>>;
-      },
-      Res
-    >;
+    handler: EventHandler<ValidatedRequest<RequestBody, RequestHeaders, RequestQuery>, Res>;
   },
-): EventHandlerWithFetch<TypedRequest<InferOutput<RequestBody>, InferOutput<RequestHeaders>>, Res> {
+): EventHandlerWithFetch<ValidatedRequest<RequestBody, RequestHeaders, RequestQuery>, Res> {
   if (!def.validate) {
     return defineHandler(def) as any;
   }

--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -5,7 +5,7 @@ import type { MaybePromise } from "./_utils.ts";
 import type { H3RouteMeta } from "./h3.ts";
 import type { H3Core } from "../h3.ts";
 
-export type HTTPHandler = EventHandler | FetchableObject | H3Core;
+export type HTTPHandler = EventHandler<any, any> | FetchableObject | H3Core;
 
 //  --- event handler ---
 

--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -29,6 +29,7 @@ export interface EventHandlerObject<
 
 export interface EventHandlerRequest {
   body?: unknown;
+  headers?: unknown;
   query?: Partial<Record<string, string>>;
   routerParams?: Record<string, string>;
 }

--- a/test/unit/types.test-d.ts
+++ b/test/unit/types.test-d.ts
@@ -1,4 +1,5 @@
 import type { H3Event, RouteRules, WebSocketResponse } from "../../src/index.ts";
+import { H3 } from "../../src/index.ts";
 import { describe, it, expectTypeOf } from "vitest";
 import {
   defineHandler,
@@ -112,6 +113,19 @@ describe("types", () => {
       expectTypeOf<Req["body"]>().toEqualTypeOf<{ title: string; count: number }>();
       expectTypeOf<Req["query"]>().toEqualTypeOf<{ page?: string | undefined }>();
       expectTypeOf<Req["headers"]>().toEqualTypeOf<{ "x-thing": string }>();
+    });
+
+    it("handlers with a concrete request type can be registered on an app", () => {
+      const validated = defineValidatedHandler({
+        validate: { body: z.object({ title: z.string() }) },
+        handler: () => "ok",
+      });
+      const typed = defineHandler<{ body: { id: string } }, string>(() => "ok");
+
+      new H3().get("/validated", validated).post("/typed", typed).all("/all", validated);
+
+      // @ts-expect-error not an event handler
+      new H3().get("/bad", (n: number) => n);
     });
   });
 

--- a/test/unit/types.test-d.ts
+++ b/test/unit/types.test-d.ts
@@ -98,6 +98,8 @@ describe("types", () => {
   });
 
   describe("defineValidatedHandler", () => {
+    type ReqOf<H> = H extends (event: H3Event<infer R>) => any ? R : never;
+
     it("returned handler exposes validated body, query and headers", () => {
       const handler = defineValidatedHandler({
         validate: {
@@ -108,11 +110,32 @@ describe("types", () => {
         handler: () => "ok",
       });
 
-      type Req = typeof handler extends (event: H3Event<infer R>) => any ? R : never;
+      type Req = ReqOf<typeof handler>;
 
       expectTypeOf<Req["body"]>().toEqualTypeOf<{ title: string; count: number }>();
       expectTypeOf<Req["query"]>().toEqualTypeOf<{ page?: string | undefined }>();
       expectTypeOf<Req["headers"]>().toEqualTypeOf<{ "x-thing": string }>();
+    });
+
+    it("leaves unvalidated parts of the request empty", () => {
+      const bodyOnly = defineValidatedHandler({
+        validate: { body: z.object({ title: z.string() }) },
+        handler: () => "ok",
+      });
+      type BodyOnlyReq = ReqOf<typeof bodyOnly>;
+
+      expectTypeOf<BodyOnlyReq["body"]>().toEqualTypeOf<{ title: string }>();
+      expectTypeOf<BodyOnlyReq["query"]>().toEqualTypeOf<{}>();
+      expectTypeOf<BodyOnlyReq["headers"]>().toEqualTypeOf<{}>();
+    });
+
+    it("types the request as unvalidated when no schema is given", () => {
+      const unvalidated = defineValidatedHandler({ handler: () => "ok" });
+      type UnvalidatedReq = ReqOf<typeof unvalidated>;
+
+      expectTypeOf<UnvalidatedReq["body"]>().toBeUnknown();
+      expectTypeOf<UnvalidatedReq["query"]>().toEqualTypeOf<{}>();
+      expectTypeOf<UnvalidatedReq["headers"]>().toEqualTypeOf<{}>();
     });
 
     it("handlers with a concrete request type can be registered on an app", () => {

--- a/test/unit/types.test-d.ts
+++ b/test/unit/types.test-d.ts
@@ -96,6 +96,25 @@ describe("types", () => {
     });
   });
 
+  describe("defineValidatedHandler", () => {
+    it("returned handler exposes validated body, query and headers", () => {
+      const handler = defineValidatedHandler({
+        validate: {
+          body: z.object({ title: z.string(), count: z.number() }),
+          headers: z.object({ "x-thing": z.string() }),
+          query: z.object({ page: z.string().optional() }),
+        },
+        handler: () => "ok",
+      });
+
+      type Req = typeof handler extends (event: H3Event<infer R>) => any ? R : never;
+
+      expectTypeOf<Req["body"]>().toEqualTypeOf<{ title: string; count: number }>();
+      expectTypeOf<Req["query"]>().toEqualTypeOf<{ page?: string | undefined }>();
+      expectTypeOf<Req["headers"]>().toEqualTypeOf<{ "x-thing": string }>();
+    });
+  });
+
   describe("getQuery", () => {
     it("untyped", () => {
       defineHandler((event) => {


### PR DESCRIPTION
`defineValidatedHandler` types the handler's input with the validated body and query, but the value it returns is typed with a `Request`-shaped `TypedRequest`, so the query has nowhere to live and `R['body']` resolves to `ReadableStream | null` rather than the validated body.

this returns the same `{ body, headers, query }` request type on both sides (adding a `headers` slot to `EventHandlerRequest`), which makes all three recoverable from the handler's own type for inference purposes (see https://github.com/nitrojs/nitro/issues/2758)

this also widens the route registration slots so handlers with a concrete request type are still accepted (a preexisting bug for `defineHandler<T>()` already)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validated request handlers now expose validated body, headers, and query data with accurate type information.
  * Request headers are now available through event request data.
  * Improved type inference for handlers using validation schemas.
  * Typed handlers can now be registered consistently across HTTP route methods.

* **Tests**
  * Added coverage for inferred body, headers, and query types.
  * Added checks for registering typed handlers across common route methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->