### PR TITLE
fix: preserve repeated validated query values

### DIFF
--- a/src/utils/internal/validate.ts
+++ b/src/utils/internal/validate.ts
@@ -2,6 +2,7 @@ import { type ErrorDetails, HTTPError } from "../../error.ts";
 
 import type { ServerRequest } from "srvx";
 import type { StandardSchemaV1, FailureResult, InferOutput, Issue } from "./standard-schema.ts";
+import { parseQuery } from "./query.ts";
 
 export type ValidateResult<T> = T | true | false | void;
 
@@ -162,13 +163,20 @@ export async function validatedURL(
 
   const validatedQuery = await validateSource(
     "query",
-    Object.fromEntries(url.searchParams.entries()),
-    validate.query as StandardSchemaV1<Record<string, string>>,
+    parseQuery(url.search.slice(1)),
+    validate.query as StandardSchemaV1<Record<string, string | string[]>>,
     validate.onError,
   );
 
   for (const [key, value] of Object.entries(validatedQuery)) {
-    url.searchParams.set(key, value);
+    if (Array.isArray(value)) {
+      url.searchParams.delete(key);
+      for (const item of value) {
+        url.searchParams.append(key, item);
+      }
+    } else {
+      url.searchParams.set(key, value);
+    }
   }
 
   return url;

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -125,6 +125,27 @@ describe("handler.ts", () => {
   });
 
   describe("defineValidatedHandler", () => {
+    it("preserves repeated query values for validation", async () => {
+      let validatorInput: unknown;
+      const handler = defineValidatedHandler({
+        validate: {
+          query: z.preprocess(
+            (input) => {
+              validatorInput = input;
+              return input;
+            },
+            z.object({ tag: z.array(z.string()) }),
+          ),
+        },
+        handler: (event) => event.url.searchParams.getAll("tag"),
+      });
+
+      const response = await handler.fetch(toRequest("/?tag=a&tag=b"));
+
+      expect(validatorInput).toEqual({ tag: ["a", "b"] });
+      expect(await response.json()).toEqual(["a", "b"]);
+    });
+
     const handler = defineValidatedHandler({
       validate: {
         body: z.object({


### PR DESCRIPTION
## Summary

- feed `defineValidatedHandler` query schemas through h3's existing `parseQuery`, preserving repeated keys as arrays
- write validated array values back with repeated `URLSearchParams` entries
- add a regression test covering both the validator input and the handler-visible URL

## Reproduction

On current `main` (`1892ee9`), `?tag=a&tag=b` reaches `getQuery` as `{ tag: ['a', 'b'] }`, but `defineValidatedHandler` constructs its validation input with `Object.fromEntries(url.searchParams.entries())`. The validator therefore receives `{ tag: 'b' }`; the first value cannot be recovered by any schema.

This matters for schemas that intentionally accept repeated query keys, for example `z.object({ tag: z.array(z.string()) })`.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `vitest --run --coverage` (73 files, 2734 tests passed, 1 file/65 tests skipped)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved repeated query parameters during URL validation instead of reducing them to a single value.
  * Maintained array-valued query parameters when validated URLs are rewritten.

* **Tests**
  * Added coverage confirming repeated parameters remain available as arrays and can be retrieved in full.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->