### PR TITLE
fix(cli): resolve docs directory to file system path with fileURLToPath

### DIFF
--- a/bin/h3.mjs
+++ b/bin/h3.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { main } from "srvx/cli";
 import meta from "../package.json" with { type: "json" };
 
@@ -16,9 +17,9 @@ if (process.argv[2] === "docs") {
     } catch {}
   }) || ["npm", "x"];
   const runnerCmd = [runner[0], runner[1]].filter(Boolean).join(" ");
-  const docsDir = new URL("../dist/docs", import.meta.url).pathname;
+  const docsDir = fileURLToPath(new URL("../dist/docs", import.meta.url));
   const args = process.argv.slice(3).join(" ");
-  execSync(`${runnerCmd} mdzilla ${docsDir}${args ? ` ${args}` : ""}`, { stdio: "inherit" });
+  execSync(`${runnerCmd} mdzilla "${docsDir}"${args ? ` ${args}` : ""}`, { stdio: "inherit" });
   process.exit(0);
 }
 if (process.argv.includes("--help") || process.argv.includes("-h")) {

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
+
+describe("h3 CLI docs", () => {
+  it("resolves docs directory to valid filesystem path instead of URL pathname", () => {
+    const binContent = readFileSync(new URL("../../bin/h3.mjs", import.meta.url), "utf8");
+    expect(binContent).toMatch(
+      /fileURLToPath\(new URL\(['"]\.\.\/dist\/docs['"], import\.meta\.url\)\)/,
+    );
+    expect(binContent).toMatch(/`\${runnerCmd} mdzilla "\${docsDir}"/);
+  });
+
+  it("fileURLToPath correctly handles spaces and special characters compared to URL.pathname", () => {
+    const sampleUrl = new URL("file:///path%20with%20spaces/docs");
+    expect(sampleUrl.pathname).toBe("/path%20with%20spaces/docs");
+    expect(fileURLToPath(sampleUrl)).toBe("/path with spaces/docs");
+  });
+});


### PR DESCRIPTION
## Problem

When running `h3 docs`, the docs directory path was constructed using `new URL('../dist/docs', import.meta.url).pathname`. On Windows, `URL.pathname` retains a leading slash before the drive letter (e.g. `/C:/...`), and on paths containing spaces or special characters, URL percent-encoding (e.g. `%20`) is preserved without proper shell quoting. This causes `mdzilla` or underlying file scanning to fail with `ENOENT`.

## Root Cause

`URL.pathname` is a URL component rather than a platform-native filesystem path. Furthermore, the path was interpolated unquoted into `execSync`.

## Fix

- Use `fileURLToPath` from `node:url` to properly convert the `file://` URL into a platform filesystem path.
- Wrap `${docsDir}` in double quotes in the `execSync` command to handle paths containing spaces.

## Testing

- Added unit tests in `test/unit/cli.test.ts` verifying `fileURLToPath` usage and path normalization.
- Verified with `pnpm vitest run test/unit/cli.test.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the CLI documentation command’s path handling across platforms, including Windows paths and directories containing spaces.
  - Documentation generation now reliably locates the correct source directory.

- **Tests**
  - Added coverage to verify platform-specific path resolution and URL-encoded directory names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->