### PR TITLE
fix(session): do not persist a session that is only read

### DIFF
--- a/docs/2.utils/4.security.md
+++ b/docs/2.utils/4.security.md
@@ -51,6 +51,8 @@ Clear the session data for the current request.
 
 Get the session for the current request.
 
+A request without a session gets a new one initialized in memory only — no `Set-Cookie` is issued until something is stored with {@link updateSession}, so reading the session (an auth check, for example) does not start one for anonymous visitors. Its `id` is therefore only stable across requests once the session has been written; use {@link useSession} to start one eagerly.
+
 ### `sealSession(event, config)`
 
 Encrypt and sign the session data for the current request.
@@ -66,6 +68,8 @@ Update the session data for the current request.
 ### `useSession(event, config)`
 
 Create a session manager for the current request.
+
+Starts a session if the request does not carry one, persisting it so its id is stable across requests. Use {@link getSession} to read a session without starting one.
 
 <!-- /automd -->
 

--- a/docs/4.examples/handle-session.md
+++ b/docs/4.examples/handle-session.md
@@ -11,7 +11,7 @@ A session is a way to remember users using cookies. It is a very common method f
 H3 provides many utilities to handle sessions:
 
 - `useSession` initializes a session and returns a wrapper to control it.
-- `getSession` initializes or retrieves the current user session.
+- `getSession` retrieves the current user session, without starting one.
 - `updateSession` updates the data of the current session.
 - `clearSession` clears the current session.
 

--- a/src/utils/internal/session.ts
+++ b/src/utils/internal/session.ts
@@ -2,6 +2,8 @@ import type { SessionConfig } from "../session.ts";
 
 export const kGetSession: unique symbol = /* @__PURE__ */ Symbol.for("h3.internal.session.promise");
 
+export const kSessionNew: unique symbol = /* @__PURE__ */ Symbol.for("h3.internal.session.new");
+
 export const kLegacySeal: unique symbol = /* @__PURE__ */ Symbol.for(
   "h3.internal.session.legacy-seal",
 );

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -2,7 +2,7 @@ import { seal, unseal, defaults as sealDefaults } from "./internal/iron-crypto.t
 import { getChunkedCookie, setChunkedCookie, deleteChunkedCookie } from "./cookie.ts";
 import { DEFAULT_SESSION_NAME, DEFAULT_SESSION_COOKIE } from "./internal/session.ts";
 import { EmptyObject } from "./internal/obj.ts";
-import { kGetSession, kLegacySeal } from "./internal/session.ts";
+import { kGetSession, kLegacySeal, kSessionNew } from "./internal/session.ts";
 
 import type { H3Event, HTTPEvent } from "../event.ts";
 import type { CookieSerializeOptions } from "cookie-es";
@@ -25,6 +25,8 @@ export interface Session<T extends SessionDataT = SessionDataT> {
   lastSeenAt?: number;
   data: SessionData<T>;
   [kGetSession]?: Promise<Session<T>>;
+  /** Set on a session created in-memory for this request and not yet persisted */
+  [kSessionNew]?: true;
 }
 
 export interface SessionManager<T extends SessionDataT = SessionDataT> {
@@ -98,6 +100,9 @@ export interface SessionConfig {
 /**
  * Create a session manager for the current request.
  *
+ * Starts a session if the request does not carry one, persisting it so its id
+ * is stable across requests. Use {@link getSession} to read a session without
+ * starting one.
  */
 export async function useSession<T extends SessionData = SessionData>(
   event: HTTPEvent,
@@ -105,7 +110,11 @@ export async function useSession<T extends SessionData = SessionData>(
 ): Promise<SessionManager<T>> {
   // Create a synced wrapper around the session
   const sessionName = config.name || DEFAULT_SESSION_NAME;
-  await getSession(event, config); // Force init
+  // Force init: persist a session created during this request so its id is stable
+  const session = await getSession(event, config);
+  if (session[kSessionNew]) {
+    await updateSession(event, config);
+  }
   const sessionManager = {
     get id() {
       const context = getEventContext<H3EventContext>(event);
@@ -129,6 +138,12 @@ export async function useSession<T extends SessionData = SessionData>(
 
 /**
  * Get the session for the current request.
+ *
+ * A request without a session gets a new one initialized in memory only — no
+ * `Set-Cookie` is issued until something is stored with {@link updateSession},
+ * so reading the session (an auth check, for example) does not start one for
+ * anonymous visitors. Its `id` is therefore only stable across requests once
+ * the session has been written; use {@link useSession} to start one eagerly.
  */
 export async function getSession<T extends SessionData = SessionData>(
   event: HTTPEvent,
@@ -199,11 +214,12 @@ export async function getSession<T extends SessionData = SessionData>(
     await promise;
   }
 
-  // New session store in response cookies
+  // New session: initialize in memory only. It is persisted by the first
+  // `updateSession` (or by `useSession`, which force-inits).
   if (!session.id) {
     session.id = config.generateId?.() ?? (config.crypto || crypto).randomUUID();
     session.createdAt = Date.now();
-    await updateSession(event, config);
+    session[kSessionNew] = true;
   }
 
   return session;
@@ -235,6 +251,10 @@ export async function updateSession<T extends SessionData = SessionData>(
   if (update) {
     Object.assign(session.data, update);
   }
+
+  // Persisted (or persistence is disabled by config): no longer a fresh session
+  // awaiting its first write.
+  delete session[kSessionNew];
 
   // Seal and store in cookie
   if (config.cookie !== false && (event as H3Event).res) {

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -1,6 +1,14 @@
 import type { SessionConfig } from "../src/utils/session.ts";
-import { beforeEach, vi } from "vitest";
-import { useSession, clearSession, readBody, H3, HTTPError } from "../src/index.ts";
+import { beforeEach, describe, vi } from "vitest";
+import {
+  useSession,
+  getSession,
+  updateSession,
+  clearSession,
+  readBody,
+  H3,
+  HTTPError,
+} from "../src/index.ts";
 import { seal, unseal, defaults as sealDefaults } from "../src/utils/internal/iron-crypto.ts";
 import { describeMatrix } from "./_setup.ts";
 
@@ -660,5 +668,91 @@ describeMatrix("session", (t, { it, expect }) => {
 
     const body = await res.json();
     expect(body.session.data.token).toBe(token);
+  });
+
+  describe("lazy creation", () => {
+    const lazyConfig: SessionConfig = {
+      name: "h3-lazy",
+      password: "1234567123456712345671234567123456712345671234567",
+    };
+
+    it("does not persist a session that is only read", async () => {
+      t.app.get("/peek", async (event) => {
+        const session = await getSession(event, lazyConfig);
+        return { id: session.id, data: session.data };
+      });
+
+      const res = await t.fetch("/peek");
+      expect(res.headers.getSetCookie()).toHaveLength(0);
+      expect(await res.json()).toMatchObject({ data: {} });
+    });
+
+    it("persists on the first write after a read", async () => {
+      t.app.get("/login", async (event) => {
+        await getSession(event, lazyConfig);
+        const session = await updateSession(event, lazyConfig, { user: "alice" });
+        return { id: session.id, data: session.data };
+      });
+
+      const res = await t.fetch("/login");
+      expect(res.headers.getSetCookie()).toHaveLength(1);
+      expect(res.headers.getSetCookie()[0]).toContain("h3-lazy=");
+      expect(await res.json()).toMatchObject({ data: { user: "alice" } });
+    });
+
+    it("seals once when updateSession creates the session", async () => {
+      const deriveBits = vi.spyOn(crypto.subtle, "deriveBits");
+      t.app.get("/seal-count", async (event) => {
+        await updateSession(event, lazyConfig, { user: "alice" });
+        return "ok";
+      });
+
+      deriveBits.mockClear();
+      const res = await t.fetch("/seal-count");
+      expect(res.headers.getSetCookie()).toHaveLength(1);
+      // Two derivations (encryption + integrity) for a single seal
+      expect(deriveBits).toHaveBeenCalledTimes(2);
+      deriveBits.mockRestore();
+    });
+
+    it("useSession still force-inits after a bare getSession", async () => {
+      t.app.get("/peek-then-use", async (event) => {
+        await getSession(event, lazyConfig); // e.g. auth middleware peeking
+        const session = await useSession(event, lazyConfig);
+        return { id: session.id };
+      });
+
+      const res = await t.fetch("/peek-then-use");
+      expect(res.headers.getSetCookie()).toHaveLength(1);
+    });
+
+    it("useSession still force-inits when read concurrently", async () => {
+      t.app.get("/concurrent", async (event) => {
+        const [, session] = await Promise.all([
+          getSession(event, lazyConfig),
+          useSession(event, lazyConfig),
+        ]);
+        return { id: session.id };
+      });
+
+      const res = await t.fetch("/concurrent");
+      expect(res.headers.getSetCookie()).toHaveLength(1);
+    });
+
+    it("keeps the session id stable across requests once persisted", async () => {
+      t.app.get("/stable", async (event) => {
+        const session = await useSession(event, lazyConfig);
+        return { id: session.id };
+      });
+
+      const res1 = await t.fetch("/stable");
+      const setCookie = res1.headers.getSetCookie()[0];
+      const { id } = await res1.json();
+
+      const res2 = await t.fetch("/stable", {
+        headers: { Cookie: setCookie.split(";")[0] },
+      });
+      expect(await res2.json()).toMatchObject({ id });
+    });
   });
 });


### PR DESCRIPTION
Resolves #1523. Alternative to #1535 and #1536.

## What changed

`getSession()` no longer saves a new empty session when code only reads it. This avoids sending a `Set-Cookie` header to anonymous visitors.

A new session stays in memory until the first `updateSession()` call. `useSession()` still creates and saves a session immediately, including when `getSession()` ran earlier in the same request.

This also removes an extra session seal when `updateSession()` creates a session.

There are no public API or config changes.

## Results

For a request without a session cookie:

| Case | Before | After |
| --- | --- | --- |
| `getSession()` only | 2 crypto calls / 1 cookie | 0 crypto calls / 0 cookies |
| `updateSession()` | 4 crypto calls / 1 cookie | 2 crypto calls / 1 cookie |
| `useSession()` | unchanged | unchanged |

## Tests

Added tests for:

- reading without setting a cookie
- saving on the first update
- keeping `useSession()` eager after earlier or concurrent reads
- keeping the session ID after it is saved

All session tests, lint, and type checks pass.

## Behavior change

A session that is only read is no longer saved, so its ID will not stay the same across requests. Code that needs a stable anonymous session ID should use `useSession()` or write session data.

`sealSession()` also no longer sets a cookie when no session exists.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions retrieved with `getSession` are now created lazily and remain in memory until updated.
  * Session cookies are persisted when session data is first written.
  * `useSession` continues to immediately persist sessions, providing a stable session ID across requests.

* **Documentation**
  * Updated security and session guides to clarify session initialization, persistence, and ID stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->