### PR TITLE
feat: re-export TypedHeaders, RequestHeaders, and ResponseHeaders from fetchdts (#1308)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,13 @@ export type {
   FetchableObject,
   HTTPHandler,
   TypedServerRequest,
+  TypedHeaders,
+  RequestHeaders,
+  ResponseHeaders,
+  RequestHeaderMap,
+  ResponseHeaderMap,
+  RequestHeaderName,
+  ResponseHeaderName,
 } from "./types/handler.ts";
 
 export {

--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -1,5 +1,15 @@
 import type { ServerRequest } from "srvx";
-import type { TypedRequest, TypedResponse, ResponseHeaderMap } from "fetchdts";
+import type {
+  TypedRequest,
+  TypedResponse,
+  TypedHeaders as _TypedHeaders,
+  RequestHeaders,
+  ResponseHeaders,
+  RequestHeaderMap,
+  ResponseHeaderMap,
+  RequestHeaderName,
+  ResponseHeaderName,
+} from "fetchdts";
 import type { H3Event, HTTPEvent } from "../event.ts";
 import type { MaybePromise } from "./_utils.ts";
 import type { H3RouteMeta } from "./h3.ts";
@@ -44,6 +54,18 @@ export type TypedServerRequest<_RequestT extends EventHandlerRequest = EventHand
     TypedRequest<NonNullable<_RequestT["body"]>, Record<keyof ResponseHeaderMap, string>>,
     "json" | "headers" | "clone"
   >;
+
+export type TypedHeaders<T extends Record<string, string> | unknown = RequestHeaderMap> =
+  _TypedHeaders<T>;
+
+export type {
+  RequestHeaders,
+  ResponseHeaders,
+  RequestHeaderMap,
+  ResponseHeaderMap,
+  RequestHeaderName,
+  ResponseHeaderName,
+};
 
 // --- fetchable ---
 

--- a/test/unit/types.test-d.ts
+++ b/test/unit/types.test-d.ts
@@ -312,3 +312,14 @@ describe("deprecated v1 signatures", () => {
     expectTypeOf(sendRedirect).toBeCallableWith({} as H3Event, "/target");
   });
 });
+
+describe("header types", () => {
+  it("re-exports TypedHeaders, RequestHeaders, ResponseHeaders from fetchdts", () => {
+    expectTypeOf<import("../../src/index.ts").TypedHeaders>().not.toBeAny();
+    expectTypeOf<import("../../src/index.ts").RequestHeaders>().not.toBeAny();
+    expectTypeOf<import("../../src/index.ts").ResponseHeaders>().not.toBeAny();
+    expectTypeOf<import("../../src/index.ts").TypedHeaders>().toEqualTypeOf<
+      import("../../src/index.ts").RequestHeaders
+    >();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1308.

In v2, `TypedServerRequest` is exported but `TypedHeaders`, `RequestHeaders`, and `ResponseHeaders` were not re-exported from `fetchdts`. This made it cumbersome to write functions or middleware accepting typed h3 request/response headers.

### Changes
- Re-exports `TypedHeaders`, `RequestHeaders`, `ResponseHeaders`, `RequestHeaderMap`, `ResponseHeaderMap`, `RequestHeaderName`, and `ResponseHeaderName` from `fetchdts` in `src/types/handler.ts` and `src/index.ts`.
- Defaults `TypedHeaders`'s generic parameter to `RequestHeaderMap` (`TypedHeaders<T = RequestHeaderMap>`) so it can be used ergonomically without explicitly passing a generic.
- Adds type testing assertions in `test/unit/types.test-d.ts`.

## Verification
- `pnpm typecheck`: 0 errors
- `pnpm lint`: 0 warnings, 0 errors
- `pnpm vitest run test/unit/types.test-d.ts`: 26/26 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the public type API with header-related types for typed requests and responses.
  * Added support for defining typed header names and maps.
  * Added a `TypedHeaders` type that defaults to request headers.

* **Tests**
  * Added compile-time checks confirming the new header types are publicly available and correctly related.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->