### PR TITLE
perf(rules): evict memoized matches with SIEVE instead of FIFO

### DIFF
--- a/docs/1.guide/2.rules.md
+++ b/docs/1.guide/2.rules.md
@@ -373,7 +373,8 @@ app.use(
 
 A given `method + pathname` always produces the same merged result, so `routeRules()` memoizes results **by default**. Repeated requests can skip pattern lookup, path canonicalization, merging, and middleware construction, reducing the hot path to a map lookup.
 
-- The memoization map holds up to `1024` entries by default and uses FIFO eviction. Dynamic paths therefore cannot grow it without limit. Change the cap with `memoize: { max }`.
+- The memoization map holds up to `1024` entries by default. Dynamic paths therefore cannot grow it without limit. Change the cap with `memoize: { max }`.
+- Eviction uses [SIEVE](https://cachemon.github.io/SIEVE-website/): entries are evicted in insertion order, except that an entry requested since the eviction hand last passed it survives that pass. A small set of hot paths is therefore not displaced by a flood of one-shot dynamic paths, which plain FIFO would evict it alongside. A cache hit stays a single map lookup — unlike LRU, nothing is reordered on read.
 - Use `memoize: false` to resolve every request again and create fresh result objects.
 
 Lower-level matchers do not enable memoization automatically. Wrap a matcher with `memoizeRouteRulesMatcher(matcher, opts?)` to opt in. If you do not use it, bundlers can tree-shake the memoization code.

--- a/src/rules/match.ts
+++ b/src/rules/match.ts
@@ -45,7 +45,8 @@ export interface RouteRulesMatcherOptions {
 export interface MatcherMemoizeOptions {
   /**
    * Maximum number of memoized `method + pathname` entries. On overflow the
-   * oldest entry is evicted (FIFO). `0` (or negative) disables memoization.
+   * oldest entry not hit since the eviction hand last passed it is evicted
+   * (SIEVE). `0` (or negative) disables memoization.
    * @default 1024
    */
   max?: number;
@@ -380,9 +381,24 @@ export function buildRouteRuleMiddleware(
   return routeRuleMiddleware;
 }
 
+interface MemoEntry {
+  key: string;
+  result: MatchResult;
+  /** Set on every hit, cleared by the hand — one hit buys one sweep's reprieve. */
+  visited: boolean;
+}
+
 /**
- * Memoize matches by method and pathname with a 1024-entry FIFO cap by default.
+ * Memoize matches by method and pathname with a 1024-entry cap by default.
  * Returned objects are shared and must be treated as immutable.
+ *
+ * Eviction is SIEVE: insertion-ordered like a FIFO, but an entry hit since the
+ * hand last passed it survives that pass. Plain FIFO evicts a hot static path
+ * on the same schedule as the one-shot dynamic paths that displaced it, so a
+ * mixed workload (a small hot set plus high-cardinality `/:id` traffic) loses
+ * cached entries it is about to ask for again. Unlike LRU this costs no map
+ * mutation on a hit — only a boolean store — which keeps the hot path the
+ * single lookup the memo exists to provide.
  */
 export function memoizeRouteRulesMatcher(
   matcher: RouteRulesMatcher,
@@ -392,17 +408,47 @@ export function memoizeRouteRulesMatcher(
   if (max <= 0) {
     return matcher;
   }
-  const memo = new Map<string, MatchResult>();
+  const memo = new Map<string, MemoEntry>();
+  // The hand: a live Map iterator walking oldest → newest. Map iterators skip
+  // entries deleted behind them and see entries appended ahead of them, so it
+  // holds its place across evictions without a linked list or a second
+  // structure. Exhausted means it reached the newest entry — wrap to the oldest.
+  let hand: MapIterator<MemoEntry> | undefined;
+  // Amortized O(1): each `visited` set costs at most one clearing step here.
+  const evict = (): void => {
+    for (;;) {
+      let next = hand?.next();
+      if (!next || next.done) {
+        hand = memo.values();
+        next = hand.next();
+        if (next.done) {
+          // Unreachable from the call site (only called at `size >= max >= 1`),
+          // but the loop must not spin on an empty map.
+          return;
+        }
+      }
+      const entry = next.value;
+      if (entry.visited) {
+        entry.visited = false; // Reprieve spent; the next pass evicts it.
+      } else {
+        memo.delete(entry.key);
+        return;
+      }
+    }
+  };
   return (method, pathname) => {
     const key = method + " " + pathname;
-    let result = memo.get(key);
-    if (!result) {
-      result = matcher(method, pathname);
-      if (memo.size >= max) {
-        memo.delete(memo.keys().next().value!);
-      }
-      memo.set(key, result);
+    const entry = memo.get(key);
+    if (entry) {
+      entry.visited = true;
+      return entry.result;
     }
+    // Resolve before evicting so a throwing matcher costs no cached entry.
+    const result = matcher(method, pathname);
+    if (memo.size >= max) {
+      evict();
+    }
+    memo.set(key, { key, result, visited: false });
     return result;
   };
 }

--- a/src/rules/middleware.ts
+++ b/src/rules/middleware.ts
@@ -20,7 +20,7 @@ import type { MatchResult, RouteRuleConfig } from "./types.ts";
 export interface RouteRulesOptions extends RouteRulesMatcherOptions {
   /**
    * Memoize matches by method and pathname. Enabled by default with a 1024-entry
-   * FIFO cap; shared results must be treated as read-only.
+   * cap; shared results must be treated as read-only.
    * @default true
    */
   memoize?: boolean | MatcherMemoizeOptions;

--- a/test/rules/memoize.test.ts
+++ b/test/rules/memoize.test.ts
@@ -158,12 +158,36 @@ describe("memoizeRouteRulesMatcher", () => {
       () => (calls++, { routeRules: {}, matchedRules: {}, routeRuleMiddleware: [] }),
       { max: 8 },
     );
-    // 200 distinct keys cycled through an 8-entry cache. If the cap leaked, the
-    // second lap onward would be all hits and `calls` would settle at 200.
+    // 200 distinct keys cycled through an 8-entry cache. No key is ever hit
+    // twice while resident, so nothing is ever spared and every request misses.
+    // If the cap leaked, the second lap onward would be all hits and `calls`
+    // would settle at 200.
     for (let lap = 0; lap < 10; lap++) {
       for (let i = 0; i < 200; i++) memoized("GET", `/p/${i}`);
     }
-    expect(calls).toBeGreaterThan(200);
+    expect(calls).toBe(2000);
+  });
+
+  it("evicts a just-cleared entry when the whole cache is visited", () => {
+    // The sweep's termination case: with every entry spared, the hand clears
+    // all of them, runs off the end, wraps to the oldest and evicts the entry
+    // whose reprieve it just spent. A hand that stopped at the end instead of
+    // wrapping would return without evicting and let the map outgrow the cap.
+    let calls = 0;
+    const memoized = memoizeRouteRulesMatcher(
+      () => (calls++, { routeRules: {}, matchedRules: {}, routeRuleMiddleware: [] }),
+      { max: 3 },
+    );
+    for (const p of ["/a", "/b", "/c"]) memoized("GET", p);
+    for (const p of ["/a", "/b", "/c"]) memoized("GET", p); // all now visited
+    expect(calls).toBe(3);
+    memoized("GET", "/d"); // full sweep, wrap, evict /a
+    expect(calls).toBe(4);
+    memoized("GET", "/b"); // spared by the sweep, still resident
+    memoized("GET", "/c");
+    expect(calls).toBe(4);
+    memoized("GET", "/a"); // the one the wrap took
+    expect(calls).toBe(5);
   });
 
   it("a non-positive cap disables memoization (not a cap of 1)", () => {

--- a/test/rules/memoize.test.ts
+++ b/test/rules/memoize.test.ts
@@ -79,7 +79,7 @@ describe("memoizeRouteRulesMatcher", () => {
     expect(matcher("GET", "/api/x")).toBe(matcher("GET", "/api/x"));
   });
 
-  it("evicts FIFO past the entry cap and re-resolves evicted paths", () => {
+  it("evicts past the entry cap and re-resolves evicted paths", () => {
     let calls = 0;
     const memoized = memoizeRouteRulesMatcher(
       () => (calls++, { routeRules: {}, matchedRules: {}, routeRuleMiddleware: [] }),
@@ -104,9 +104,66 @@ describe("memoizeRouteRulesMatcher", () => {
     expect(calls).toBe(1024);
     memoized("GET", "/p/0"); // still memoized at exactly the cap
     expect(calls).toBe(1024);
-    memoized("GET", "/p/1024"); // 1025th entry evicts the oldest (/p/0)
-    memoized("GET", "/p/0"); // → re-resolved
+    // The 1025th entry forces an eviction. `/p/0` was just requested, so the
+    // hand spares it and takes the oldest untouched entry (`/p/1`) instead.
+    memoized("GET", "/p/1024");
+    memoized("GET", "/p/0"); // survived → still a hit
+    expect(calls).toBe(1025);
+    memoized("GET", "/p/1"); // evicted in its place → re-resolved
     expect(calls).toBe(1026);
+  });
+
+  it("spares an entry hit since the hand last passed it (SIEVE, not FIFO)", () => {
+    let calls = 0;
+    const memoized = memoizeRouteRulesMatcher(
+      () => (calls++, { routeRules: {}, matchedRules: {}, routeRuleMiddleware: [] }),
+      { max: 4 },
+    );
+    for (const p of ["/a", "/b", "/c", "/d"]) memoized("GET", p);
+    expect(calls).toBe(4);
+    memoized("GET", "/a"); // hit — marks /a as visited
+    // Each miss evicts one entry. /a is spared on the pass that reaches it, so
+    // the three untouched entries go first.
+    memoized("GET", "/x");
+    memoized("GET", "/y");
+    memoized("GET", "/z");
+    expect(calls).toBe(7);
+    memoized("GET", "/a"); // still resident; plain FIFO would have evicted it
+    expect(calls).toBe(7);
+    for (const p of ["/b", "/c", "/d"]) memoized("GET", p); // all evicted
+    expect(calls).toBe(10);
+  });
+
+  it("keeps a hot path cached under a flood of one-shot paths", () => {
+    let calls = 0;
+    const memoized = memoizeRouteRulesMatcher(
+      () => (calls++, { routeRules: {}, matchedRules: {}, routeRuleMiddleware: [] }),
+      { max: 16 },
+    );
+    let hotMisses = 0;
+    for (let i = 0; i < 500; i++) {
+      const before = calls;
+      memoized("GET", "/hot");
+      if (calls !== before) hotMisses++;
+      // One-shot dynamic paths, interleaved 1:1 with the hot path.
+      memoized("GET", `/scan/${i}`);
+    }
+    // Resolved once, then never evicted again.
+    expect(hotMisses).toBe(1);
+  });
+
+  it("holds the cap when the key space exceeds it", () => {
+    let calls = 0;
+    const memoized = memoizeRouteRulesMatcher(
+      () => (calls++, { routeRules: {}, matchedRules: {}, routeRuleMiddleware: [] }),
+      { max: 8 },
+    );
+    // 200 distinct keys cycled through an 8-entry cache. If the cap leaked, the
+    // second lap onward would be all hits and `calls` would settle at 200.
+    for (let lap = 0; lap < 10; lap++) {
+      for (let i = 0; i < 200; i++) memoized("GET", `/p/${i}`);
+    }
+    expect(calls).toBeGreaterThan(200);
   });
 
   it("a non-positive cap disables memoization (not a cap of 1)", () => {

--- a/test/rules/middleware.test.ts
+++ b/test/rules/middleware.test.ts
@@ -102,7 +102,7 @@ describe("routeRules() middleware", () => {
     expect(seen[3]).not.toBe(seen[2]);
   });
 
-  it("memoize accepts MatcherMemoizeOptions (FIFO entry cap)", async () => {
+  it("memoize accepts MatcherMemoizeOptions (entry cap)", async () => {
     const { app, seen } = appWithContextProbe(
       { "/api/**": { headers: { "x-api": "1" } } },
       { memoize: { max: 1 } },

--- a/test/rules/treeshake.test.ts
+++ b/test/rules/treeshake.test.ts
@@ -177,8 +177,9 @@ describe("tree-shaking (esbuild)", () => {
   it("un-memoized createMatcherFromFind shakes out the memoize wrapper", async () => {
     // Memoization is wired in createRouteRulesMatcher, not createMatcherFromFind,
     // so an un-memoized compiled matcher must not bundle memoizeRouteRulesMatcher
-    // (~240 B). `.keys().next()` is its FIFO eviction — a marker no other matcher
-    // code emits — so its absence pins the wrapper out of the compiled path.
+    // (~430 B). Its SIEVE eviction hand walks a live Map iterator, so `.next(`
+    // is a marker no other matcher code emits — its absence pins the wrapper
+    // out of the compiled path.
     const out = await bundle(
       `import * as rules from "h3/rules";\nexport const m = rules.createMatcherFromFind(() => []);`,
     );


### PR DESCRIPTION
## Problem

The route rules memo (`memoizeRouteRulesMatcher`) is keyed per `method + pathname`, not per matched pattern — `/users/1` and `/users/2` are separate entries even though both matched `/users/:id`. That is the right trade (a hit skips the rou3 lookup, the alternate-reading passes, merging *and* middleware construction), but it means the key space is unbounded, which is why there's a cap.

The cap evicted FIFO. So a hot static path and the one-shot dynamic paths that displaced it were evicted on the same schedule: any app mixing a small hot set with high-cardinality `/:id` traffic kept dropping entries it was about to ask for again.

## Change

SIEVE ([NSDI '24](https://cachemon.github.io/SIEVE-website/)) keeps the insertion-ordered queue and adds one bit per entry: an entry hit since the eviction hand last passed it survives that pass.

The hand is a live `Map` iterator. Map iterators skip entries deleted behind them and see entries appended ahead of them, so it holds its place across evictions with no linked list and no second data structure.

## Numbers

Hit ratio at the default 1024-entry cap, 500k requests:

| workload | FIFO | LRU | SIEVE |
|---|---|---|---|
| 300 static paths, zipf | 99.9% | 99.9% | 99.9% |
| 100k dynamic ids, uniform | 1.0% | 1.0% | 1.0% |
| 100k dynamic ids, zipf(1.1) | 62.9% | 66.8% | **73.1%** |
| 300 static (50%) + uniform dynamic (50%) | 41.1% | 45.2% | **50.1%** |
| 300 static (20%) + uniform dynamic (80%) | 13.9% | 15.6% | **20.1%** |
| 2k paths, zipf, 2x over cap | 85.1% | 88.2% | **90.2%** |

Rows 4 and 5 are the failure case; their theoretical ceilings are 50% and 20%. SIEVE reaches both — it fully protects the hot set from the dynamic scan — while LRU closes under half the gap. Rows 1 and 2 confirm neither policy invents hits where the workload has none.

## Why not LRU

Cost. LRU via `Map` re-insertion (`delete` + `set` on hit) puts two map mutations on the path whose entire purpose is to be one lookup:

```
FIFO    21.50 ns/hit   46.5M hits/s
LRU     78.66 ns/hit   12.7M hits/s     ← 3.7x
SIEVE   24.88 ns/hit   40.2M hits/s     ← +16%
```

SIEVE only stores a boolean on hit, and wins on hit ratio anyway.

## Notes

- **No API change.** `MatcherMemoizeOptions.max`, the default of 1024, `memoize: false`, and the shared/read-only result contract are all unchanged. This is a policy swap behind the existing surface.
- Eviction is amortized O(1) — each `visited` set costs at most one clearing step. Measured at 0.99 hand steps/op over 1M random ops.
- The `max <= 0` short-circuit and the resolve-before-evict order (a throwing matcher costs no cached entry) are preserved.

## Tests

`test/rules/memoize.test.ts`:

- The cap-2 eviction test passes unchanged.
- The default-cap test needed updating, and the old assertion is exactly the deficiency being fixed: it requested `/p/0`, forced one eviction, then asserted `/p/0` was gone. It now survives, and the oldest untouched entry is taken instead.
- Added: the hand spares a visited entry; a hot path survives a 500-path flood at `max: 16` (resolved once, never re-resolved); the cap holds when the key space exceeds it.

Full suite green — 2775 passed, no type errors, lint/fmt clean.

🤖 Generated with AI assistant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated route-rule memoization to use SIEVE eviction, allowing recently accessed entries to remain cached while removing older, unused entries.
  * Preserved the configured cache capacity and efficient lookups under high volumes of one-time routes.
* **Documentation**
  * Updated memoization guidance to explain the new eviction behavior and its benefits for frequently used routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->