### PR TITLE
types(handler): infer route handler request type instead of any

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -142,8 +142,8 @@ export function dynamicEventHandler(initial?: EventHandler | FetchableObject): D
 
 type MaybePromise<T> = T | Promise<T>;
 
-export function defineLazyEventHandler(
-  loader: () => MaybePromise<HTTPHandler>,
+export function defineLazyEventHandler<Req extends EventHandlerRequest = EventHandlerRequest>(
+  loader: () => MaybePromise<HTTPHandler<Req>>,
 ): EventHandlerWithFetch {
   let handler: EventHandler | undefined;
   let promise: Promise<EventHandler> | undefined;
@@ -162,9 +162,11 @@ export function defineLazyEventHandler(
 
 // --- normalization utils ---
 
-export function toEventHandler(handler: HTTPHandler | undefined): EventHandler | undefined {
+export function toEventHandler<Req extends EventHandlerRequest = EventHandlerRequest>(
+  handler: HTTPHandler<Req> | undefined,
+): EventHandler | undefined {
   if (typeof handler === "function") {
-    return handler;
+    return handler as EventHandler;
   }
   if (typeof (handler as H3Core)?.handler === "function" && (handler as any).constructor?.["~h3"]) {
     return (handler as H3Core).handler;

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -12,6 +12,7 @@ import type {
   EventHandlerWithFetch,
   FetchableObject,
   HTTPHandler,
+  ResolvedRequest,
 } from "./types/handler.ts";
 import type { StandardSchemaV1, InferOutput } from "./utils/internal/standard-schema.ts";
 import { NoHandler, type H3Core } from "./h3.ts";
@@ -144,7 +145,7 @@ type MaybePromise<T> = T | Promise<T>;
 
 export function defineLazyEventHandler<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
   loader: () => MaybePromise<HTTPHandler<_RequestT>>,
-): EventHandlerWithFetch<_RequestT> {
+): EventHandlerWithFetch<ResolvedRequest<_RequestT>> {
   let handler: EventHandler | undefined;
   let promise: Promise<EventHandler> | undefined;
   return defineHandler(function lazyHandler(event) {
@@ -164,12 +165,12 @@ export function defineLazyEventHandler<_RequestT extends EventHandlerRequest = E
 
 export function toEventHandler<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
   handler: HTTPHandler<_RequestT> | undefined,
-): EventHandler<_RequestT> | undefined {
+): EventHandler<ResolvedRequest<_RequestT>> | undefined {
   if (typeof handler === "function") {
-    return handler as EventHandler<_RequestT>;
+    return handler as EventHandler<ResolvedRequest<_RequestT>>;
   }
   if (typeof (handler as H3Core)?.handler === "function" && (handler as any).constructor?.["~h3"]) {
-    return (handler as H3Core).handler as EventHandler<_RequestT>;
+    return (handler as H3Core).handler as EventHandler<ResolvedRequest<_RequestT>>;
   }
   if (typeof (handler as FetchableObject)?.fetch === "function") {
     return function _fetchHandler(event: H3Event) {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -142,9 +142,9 @@ export function dynamicEventHandler(initial?: EventHandler | FetchableObject): D
 
 type MaybePromise<T> = T | Promise<T>;
 
-export function defineLazyEventHandler<Req extends EventHandlerRequest = EventHandlerRequest>(
-  loader: () => MaybePromise<HTTPHandler<Req>>,
-): EventHandlerWithFetch {
+export function defineLazyEventHandler<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
+  loader: () => MaybePromise<HTTPHandler<_RequestT>>,
+): EventHandlerWithFetch<_RequestT> {
   let handler: EventHandler | undefined;
   let promise: Promise<EventHandler> | undefined;
   return defineHandler(function lazyHandler(event) {
@@ -162,14 +162,14 @@ export function defineLazyEventHandler<Req extends EventHandlerRequest = EventHa
 
 // --- normalization utils ---
 
-export function toEventHandler<Req extends EventHandlerRequest = EventHandlerRequest>(
-  handler: HTTPHandler<Req> | undefined,
-): EventHandler | undefined {
+export function toEventHandler<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
+  handler: HTTPHandler<_RequestT> | undefined,
+): EventHandler<_RequestT> | undefined {
   if (typeof handler === "function") {
-    return handler as EventHandler;
+    return handler as EventHandler<_RequestT>;
   }
   if (typeof (handler as H3Core)?.handler === "function" && (handler as any).constructor?.["~h3"]) {
-    return (handler as H3Core).handler;
+    return (handler as H3Core).handler as EventHandler<_RequestT>;
   }
   if (typeof (handler as FetchableObject)?.fetch === "function") {
     return function _fetchHandler(event: H3Event) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export type {
   HTTPMethod,
   PreparedResponse,
   RouteOptions,
+  RouteRegistrar,
   MiddlewareOptions,
   RouterContext,
   MatchedRoute,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,7 +4,13 @@ import { createRouteMatcher } from "./utils/internal/route.ts";
 
 import type { H3Event } from "./event.ts";
 import type { MiddlewareOptions } from "./types/h3.ts";
-import type { EventHandler, FetchableObject, HTTPHandler, Middleware } from "./types/handler.ts";
+import type {
+  EventHandler,
+  EventHandlerRequest,
+  FetchableObject,
+  HTTPHandler,
+  Middleware,
+} from "./types/handler.ts";
 import type { H3Core } from "./h3.ts";
 
 export function defineMiddleware(input: Middleware): Middleware {
@@ -159,7 +165,9 @@ function isUnhandledResponse(val: unknown) {
  *
  * If FetchableObject or Handler returns a Response with 404 status, the next middleware will be called.
  */
-export function toMiddleware(input: HTTPHandler | Middleware | undefined): Middleware {
+export function toMiddleware<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
+  input: HTTPHandler<_RequestT> | Middleware | undefined,
+): Middleware {
   let h = (input as H3Core).handler || (input as EventHandler | Middleware);
   let isFunction: boolean = typeof h === "function";
   if (!isFunction && typeof (input as FetchableObject)?.fetch === "function") {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,13 +4,7 @@ import { createRouteMatcher } from "./utils/internal/route.ts";
 
 import type { H3Event } from "./event.ts";
 import type { MiddlewareOptions } from "./types/h3.ts";
-import type {
-  EventHandler,
-  EventHandlerRequest,
-  FetchableObject,
-  HTTPHandler,
-  Middleware,
-} from "./types/handler.ts";
+import type { EventHandler, FetchableObject, HTTPHandler, Middleware } from "./types/handler.ts";
 import type { H3Core } from "./h3.ts";
 
 export function defineMiddleware(input: Middleware): Middleware {
@@ -165,9 +159,7 @@ function isUnhandledResponse(val: unknown) {
  *
  * If FetchableObject or Handler returns a Response with 404 status, the next middleware will be called.
  */
-export function toMiddleware<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
-  input: HTTPHandler<_RequestT> | Middleware | undefined,
-): Middleware {
+export function toMiddleware(input: HTTPHandler | Middleware | undefined): Middleware {
   let h = (input as H3Core).handler || (input as EventHandler | Middleware);
   let isFunction: boolean = typeof h === "function";
   if (!isFunction && typeof (input as FetchableObject)?.fetch === "function") {

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -87,6 +87,7 @@ export function tracingPlugin(traceOpts?: TracingPluginOptions): H3Plugin {
     if ("on" in h3 && typeof h3.on === "function") {
       const originalOn = h3.on;
 
+      // `on` is generic, so the rest args need an explicit type to stay applicable.
       h3.on = (...args: Parameters<H3["on"]>) => {
         const instance = originalOn.apply(h3, args);
         // Since it uses route push, we can wrap the last route handler added

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -87,7 +87,7 @@ export function tracingPlugin(traceOpts?: TracingPluginOptions): H3Plugin {
     if ("on" in h3 && typeof h3.on === "function") {
       const originalOn = h3.on;
 
-      h3.on = (...args) => {
+      h3.on = (...args: Parameters<H3["on"]>) => {
         const instance = originalOn.apply(h3, args);
         // Since it uses route push, we can wrap the last route handler added
         // Wrapping the handler at the arg level is problematic because we need the `event` to be passed to the tracePromise.

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -87,7 +87,6 @@ export function tracingPlugin(traceOpts?: TracingPluginOptions): H3Plugin {
     if ("on" in h3 && typeof h3.on === "function") {
       const originalOn = h3.on;
 
-      // `on` is generic, so the rest args need an explicit type to stay applicable.
       h3.on = (...args: Parameters<H3["on"]>) => {
         const instance = originalOn.apply(h3, args);
         // Since it uses route push, we can wrap the last route handler added

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -1,5 +1,5 @@
 import type { H3EventContext } from "./context.ts";
-import type { HTTPHandler, EventHandler, Middleware } from "./handler.ts";
+import type { HTTPHandler, EventHandler, EventHandlerRequest, Middleware } from "./handler.ts";
 import type { HTTPError } from "../error.ts";
 import type { MaybePromise } from "./_utils.ts";
 import type { FetchHandler, ServerRequest } from "srvx";
@@ -180,10 +180,10 @@ export declare class H3 extends H3Core {
   /**
    * Register a route handler for the specified HTTP method and route.
    */
-  on(
+  on<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
     method: HTTPMethod | Lowercase<HTTPMethod> | "",
     route: string,
-    handler: HTTPHandler,
+    handler: HTTPHandler<_RequestT>,
     opts?: RouteOptions,
   ): this;
 
@@ -204,16 +204,60 @@ export declare class H3 extends H3Core {
   /**
    * Register a route handler for all HTTP methods.
    */
-  all(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
+  all<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
+    route: string,
+    handler: HTTPHandler<_RequestT>,
+    opts?: RouteOptions,
+  ): this;
 
-  get(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
-  post(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
-  put(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
-  delete(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
-  patch(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
-  head(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
-  options(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
-  connect(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
-  trace(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
-  query(route: string, handler: HTTPHandler, opts?: RouteOptions): this;
+  get<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
+    route: string,
+    handler: HTTPHandler<_RequestT>,
+    opts?: RouteOptions,
+  ): this;
+  post<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
+    route: string,
+    handler: HTTPHandler<_RequestT>,
+    opts?: RouteOptions,
+  ): this;
+  put<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
+    route: string,
+    handler: HTTPHandler<_RequestT>,
+    opts?: RouteOptions,
+  ): this;
+  delete<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
+    route: string,
+    handler: HTTPHandler<_RequestT>,
+    opts?: RouteOptions,
+  ): this;
+  patch<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
+    route: string,
+    handler: HTTPHandler<_RequestT>,
+    opts?: RouteOptions,
+  ): this;
+  head<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
+    route: string,
+    handler: HTTPHandler<_RequestT>,
+    opts?: RouteOptions,
+  ): this;
+  options<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
+    route: string,
+    handler: HTTPHandler<_RequestT>,
+    opts?: RouteOptions,
+  ): this;
+  connect<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
+    route: string,
+    handler: HTTPHandler<_RequestT>,
+    opts?: RouteOptions,
+  ): this;
+  trace<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
+    route: string,
+    handler: HTTPHandler<_RequestT>,
+    opts?: RouteOptions,
+  ): this;
+  query<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
+    route: string,
+    handler: HTTPHandler<_RequestT>,
+    opts?: RouteOptions,
+  ): this;
 }

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -154,6 +154,17 @@ export declare class H3Core {
   "~addRoute"(_route: H3Route): void;
 }
 
+/**
+ * Registers a route handler, inferring the handler request type when it has one.
+ */
+export interface RouteRegistrar<T> {
+  <_RequestT extends EventHandlerRequest = EventHandlerRequest>(
+    route: string,
+    handler: HTTPHandler<_RequestT>,
+    opts?: RouteOptions,
+  ): T;
+}
+
 export declare class H3 extends H3Core {
   /** @internal */
   "~rou3": RouterContext;
@@ -204,60 +215,15 @@ export declare class H3 extends H3Core {
   /**
    * Register a route handler for all HTTP methods.
    */
-  all<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
-    route: string,
-    handler: HTTPHandler<_RequestT>,
-    opts?: RouteOptions,
-  ): this;
-
-  get<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
-    route: string,
-    handler: HTTPHandler<_RequestT>,
-    opts?: RouteOptions,
-  ): this;
-  post<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
-    route: string,
-    handler: HTTPHandler<_RequestT>,
-    opts?: RouteOptions,
-  ): this;
-  put<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
-    route: string,
-    handler: HTTPHandler<_RequestT>,
-    opts?: RouteOptions,
-  ): this;
-  delete<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
-    route: string,
-    handler: HTTPHandler<_RequestT>,
-    opts?: RouteOptions,
-  ): this;
-  patch<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
-    route: string,
-    handler: HTTPHandler<_RequestT>,
-    opts?: RouteOptions,
-  ): this;
-  head<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
-    route: string,
-    handler: HTTPHandler<_RequestT>,
-    opts?: RouteOptions,
-  ): this;
-  options<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
-    route: string,
-    handler: HTTPHandler<_RequestT>,
-    opts?: RouteOptions,
-  ): this;
-  connect<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
-    route: string,
-    handler: HTTPHandler<_RequestT>,
-    opts?: RouteOptions,
-  ): this;
-  trace<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
-    route: string,
-    handler: HTTPHandler<_RequestT>,
-    opts?: RouteOptions,
-  ): this;
-  query<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
-    route: string,
-    handler: HTTPHandler<_RequestT>,
-    opts?: RouteOptions,
-  ): this;
+  all: RouteRegistrar<this>;
+  get: RouteRegistrar<this>;
+  post: RouteRegistrar<this>;
+  put: RouteRegistrar<this>;
+  delete: RouteRegistrar<this>;
+  patch: RouteRegistrar<this>;
+  head: RouteRegistrar<this>;
+  options: RouteRegistrar<this>;
+  connect: RouteRegistrar<this>;
+  trace: RouteRegistrar<this>;
+  query: RouteRegistrar<this>;
 }

--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -5,7 +5,10 @@ import type { MaybePromise } from "./_utils.ts";
 import type { H3RouteMeta } from "./h3.ts";
 import type { H3Core } from "../h3.ts";
 
-export type HTTPHandler = EventHandler<any, any> | FetchableObject | H3Core;
+export type HTTPHandler<_RequestT extends EventHandlerRequest = EventHandlerRequest> =
+  | EventHandler<_RequestT>
+  | FetchableObject
+  | H3Core;
 
 //  --- event handler ---
 

--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -5,7 +5,7 @@ import type { MaybePromise } from "./_utils.ts";
 import type { H3RouteMeta } from "./h3.ts";
 import type { H3Core } from "../h3.ts";
 
-export type HTTPHandler<_RequestT extends EventHandlerRequest = EventHandlerRequest> =
+export type HTTPHandler<_RequestT extends EventHandlerRequest = any> =
   | EventHandler<_RequestT>
   | FetchableObject
   | H3Core;

--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -10,6 +10,18 @@ export type HTTPHandler<_RequestT extends EventHandlerRequest = any> =
   | FetchableObject
   | H3Core;
 
+/**
+ * `HTTPHandler` defaults its request type to `any` so that a bare `HTTPHandler`
+ * annotation still accepts handlers with a narrower request type. When a handler
+ * util infers that `any` back, this collapses it to the default request shape so
+ * `any` never reaches a public return type.
+ */
+export type ResolvedRequest<_RequestT> = 0 extends 1 & _RequestT
+  ? EventHandlerRequest
+  : _RequestT extends EventHandlerRequest
+    ? _RequestT
+    : EventHandlerRequest;
+
 //  --- event handler ---
 
 export interface EventHandler<

--- a/src/types/handler.ts
+++ b/src/types/handler.ts
@@ -10,17 +10,10 @@ export type HTTPHandler<_RequestT extends EventHandlerRequest = any> =
   | FetchableObject
   | H3Core;
 
-/**
- * `HTTPHandler` defaults its request type to `any` so that a bare `HTTPHandler`
- * annotation still accepts handlers with a narrower request type. When a handler
- * util infers that `any` back, this collapses it to the default request shape so
- * `any` never reaches a public return type.
- */
-export type ResolvedRequest<_RequestT> = 0 extends 1 & _RequestT
+/** Collapses the `any` request type of a bare {@link HTTPHandler} to the default request shape. */
+export type ResolvedRequest<_RequestT extends EventHandlerRequest> = 0 extends 1 & _RequestT
   ? EventHandlerRequest
-  : _RequestT extends EventHandlerRequest
-    ? _RequestT
-    : EventHandlerRequest;
+  : _RequestT;
 
 //  --- event handler ---
 

--- a/src/utils/base.ts
+++ b/src/utils/base.ts
@@ -1,4 +1,4 @@
-import type { EventHandler, HTTPHandler } from "../types/handler.ts";
+import type { EventHandler, EventHandlerRequest, HTTPHandler } from "../types/handler.ts";
 import { toEventHandler } from "../handler.ts";
 import { withoutBase, withoutTrailingSlash } from "./internal/path.ts";
 
@@ -14,7 +14,10 @@ import { withoutBase, withoutTrailingSlash } from "./internal/path.ts";
  * @param base The base path to prefix.
  * @param handler The event handler to use with the adapted path.
  */
-export function withBase(base: string, input: HTTPHandler): EventHandler {
+export function withBase<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
+  base: string,
+  input: HTTPHandler<_RequestT>,
+): EventHandler {
   base = withoutTrailingSlash(base);
 
   const handler = toEventHandler(input);

--- a/src/utils/base.ts
+++ b/src/utils/base.ts
@@ -1,4 +1,9 @@
-import type { EventHandler, EventHandlerRequest, HTTPHandler } from "../types/handler.ts";
+import type {
+  EventHandler,
+  EventHandlerRequest,
+  HTTPHandler,
+  ResolvedRequest,
+} from "../types/handler.ts";
 import { toEventHandler } from "../handler.ts";
 import { withoutBase, withoutTrailingSlash } from "./internal/path.ts";
 
@@ -17,7 +22,7 @@ import { withoutBase, withoutTrailingSlash } from "./internal/path.ts";
 export function withBase<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
   base: string,
   input: HTTPHandler<_RequestT>,
-): EventHandler<_RequestT> {
+): EventHandler<ResolvedRequest<_RequestT>> {
   base = withoutTrailingSlash(base);
 
   const handler = toEventHandler(input);

--- a/src/utils/base.ts
+++ b/src/utils/base.ts
@@ -17,7 +17,7 @@ import { withoutBase, withoutTrailingSlash } from "./internal/path.ts";
 export function withBase<_RequestT extends EventHandlerRequest = EventHandlerRequest>(
   base: string,
   input: HTTPHandler<_RequestT>,
-): EventHandler {
+): EventHandler<_RequestT> {
   base = withoutTrailingSlash(base);
 
   const handler = toEventHandler(input);

--- a/test/unit/types.test-d.ts
+++ b/test/unit/types.test-d.ts
@@ -1,4 +1,9 @@
-import type { H3Event, RouteRules, WebSocketResponse } from "../../src/index.ts";
+import type {
+  EventHandlerRequest,
+  H3Event,
+  RouteRules,
+  WebSocketResponse,
+} from "../../src/index.ts";
 import { H3 } from "../../src/index.ts";
 import { describe, it, expectTypeOf } from "vitest";
 import {
@@ -149,6 +154,15 @@ describe("types", () => {
 
       // @ts-expect-error not an event handler
       new H3().get("/bad", (n: number) => n);
+    });
+  });
+
+  describe("routes", () => {
+    it("types the event of an inline route handler", () => {
+      new H3().get("/", (event) => {
+        expectTypeOf(event).toEqualTypeOf<H3Event<EventHandlerRequest>>();
+        return "ok";
+      });
     });
   });
 

--- a/test/unit/types.test-d.ts
+++ b/test/unit/types.test-d.ts
@@ -1,7 +1,8 @@
 import type {
+  EventHandler,
   EventHandlerRequest,
-  H3Event,
   HTTPHandler,
+  H3Event,
   RouteRules,
   WebSocketResponse,
 } from "../../src/index.ts";
@@ -162,16 +163,22 @@ describe("types", () => {
   });
 
   describe("routes", () => {
-    it("types the event of an inline route handler", () => {
+    it("types the event of an inline method handler", () => {
       new H3().get("/", (event) => {
         expectTypeOf(event).toEqualTypeOf<H3Event<EventHandlerRequest>>();
         return "ok";
       });
+    });
 
+    it("types the event of an inline `on` handler", () => {
       new H3().on("GET", "/", (event) => {
         expectTypeOf(event).toEqualTypeOf<H3Event<EventHandlerRequest>>();
         return "ok";
       });
+    });
+
+    it("accepts a handler with a concrete request type in an untyped slot", () => {
+      expectTypeOf<EventHandler<{ body: { id: string } }>>().toExtend<HTTPHandler>();
     });
   });
 

--- a/test/unit/types.test-d.ts
+++ b/test/unit/types.test-d.ts
@@ -14,6 +14,9 @@ import {
   getValidatedQuery,
   defineValidatedHandler,
   defineWebSocketHandler,
+  defineLazyEventHandler,
+  toEventHandler,
+  withBase,
 } from "../../src/index.ts";
 import {
   appendHeaders,
@@ -24,6 +27,8 @@ import {
 import { z } from "zod";
 
 describe("types", () => {
+  type ReqOf<H> = H extends (event: H3Event<infer R>) => any ? R : never;
+
   describe("eventHandler", () => {
     it("return type (inferred)", () => {
       const handler = defineHandler(() => {
@@ -103,8 +108,6 @@ describe("types", () => {
   });
 
   describe("defineValidatedHandler", () => {
-    type ReqOf<H> = H extends (event: H3Event<infer R>) => any ? R : never;
-
     it("returned handler exposes validated body, query and headers", () => {
       const handler = defineValidatedHandler({
         validate: {
@@ -163,6 +166,33 @@ describe("types", () => {
         expectTypeOf(event).toEqualTypeOf<H3Event<EventHandlerRequest>>();
         return "ok";
       });
+
+      new H3().on("GET", "/", (event) => {
+        expectTypeOf(event).toEqualTypeOf<H3Event<EventHandlerRequest>>();
+        return "ok";
+      });
+    });
+  });
+
+  describe("handler passthrough", () => {
+    const handler = defineValidatedHandler({
+      validate: { body: z.object({ title: z.string() }) },
+      handler: () => "ok",
+    });
+
+    it("keeps the request type through toEventHandler", () => {
+      const normalized = toEventHandler(handler)!;
+      expectTypeOf<ReqOf<typeof normalized>["body"]>().toEqualTypeOf<{ title: string }>();
+    });
+
+    it("keeps the request type through withBase", () => {
+      const based = withBase("/api", handler);
+      expectTypeOf<ReqOf<typeof based>["body"]>().toEqualTypeOf<{ title: string }>();
+    });
+
+    it("keeps the request type through defineLazyEventHandler", () => {
+      const lazy = defineLazyEventHandler(() => handler);
+      expectTypeOf<ReqOf<typeof lazy>["body"]>().toEqualTypeOf<{ title: string }>();
     });
   });
 

--- a/test/unit/types.test-d.ts
+++ b/test/unit/types.test-d.ts
@@ -1,6 +1,7 @@
 import type {
   EventHandlerRequest,
   H3Event,
+  HTTPHandler,
   RouteRules,
   WebSocketResponse,
 } from "../../src/index.ts";
@@ -193,6 +194,28 @@ describe("types", () => {
     it("keeps the request type through defineLazyEventHandler", () => {
       const lazy = defineLazyEventHandler(() => handler);
       expectTypeOf<ReqOf<typeof lazy>["body"]>().toEqualTypeOf<{ title: string }>();
+    });
+
+    it("does not leak any for a plain HTTPHandler", () => {
+      const plain = handler as HTTPHandler;
+
+      const normalized = toEventHandler(plain)!;
+      expectTypeOf<ReqOf<typeof normalized>>().not.toBeAny();
+      expectTypeOf<ReqOf<typeof normalized>>().toEqualTypeOf<EventHandlerRequest>();
+
+      const based = withBase("/api", plain);
+      expectTypeOf<ReqOf<typeof based>>().not.toBeAny();
+      expectTypeOf<ReqOf<typeof based>>().toEqualTypeOf<EventHandlerRequest>();
+
+      const lazy = defineLazyEventHandler(() => plain);
+      expectTypeOf<ReqOf<typeof lazy>>().not.toBeAny();
+      expectTypeOf<ReqOf<typeof lazy>>().toEqualTypeOf<EventHandlerRequest>();
+    });
+
+    it("uses the default request type for an H3 instance", () => {
+      const normalized = toEventHandler(new H3())!;
+      expectTypeOf<ReqOf<typeof normalized>>().not.toBeAny();
+      expectTypeOf<ReqOf<typeof normalized>>().toEqualTypeOf<EventHandlerRequest>();
     });
   });
 


### PR DESCRIPTION
Resolves #1545

`HTTPHandler` was widened to `EventHandler<any, any>` in #1538 so that handlers carrying a concrete request type (`defineValidatedHandler`, `defineHandler<{ body: ... }>`) could still be registered on an app. The call signature of `EventHandler` is contravariant in its request type, so the default `EventHandler<EventHandlerRequest>` rejects them.

The side effect is that `any` leaks into the contextual type of every inline route handler:

```ts
const app = new H3();
app.get("/", (event) => proxyRequest(event, "/test")); // event: H3Event<any>
```

With `@typescript-eslint/no-unsafe-argument` enabled that reports "Unsafe argument of type `H3Event<any>` assigned to a parameter of type `H3Event<EventHandlerRequest>`".

This makes `HTTPHandler` generic over the request type, and the route methods (`on`, `all`, `get`, `post`, ...) generic along with it, so the request type comes from the handler instead of being pinned to `any`. An inline handler gives nothing to infer from, so the parameter falls back to its default and `event` is typed `H3Event<EventHandlerRequest>`. A pre-typed handler still infers its own request type and registers exactly as before.

`withBase`, `toEventHandler`, `toMiddleware` and `defineLazyEventHandler` take the same generic, otherwise they would stop accepting the narrowly typed handlers that `EventHandler<any, any>` used to let through. The alias itself keeps `any` as its own default so that a bare `HTTPHandler` annotation in consumer code stays as permissive as it is today; every route method declares `EventHandlerRequest` as its default, and that is what drives the inference above.

`tracing.ts` needs an explicit `Parameters<H3["on"]>` on its wrapper, because a generic `on` no longer gives the assignment a contextual signature to take the rest args from.

The added type test in `test/unit/types.test-d.ts` fails on main, where `event` resolves to `H3Event<any>`, and passes with the change. The "handlers with a concrete request type can be registered on an app" test from #1538 still passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved request type inference and preservation across event handlers, lazy handlers, route registration, and base-path handlers.
  * Enhanced support for validated request body types when handlers are passed through or wrapped.
  * Improved inline route handler event typing across supported HTTP methods.
  * Added safer fallback typing for handlers without a specific request type.
  * Added a public route registration type for improved TypeScript support.

* **Tests**
  * Added coverage verifying request types remain available through handler utilities, route definitions, and handler wrappers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->